### PR TITLE
Main

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,3 +3,11 @@ NODE_ENV=development
 
 # PostgreSQL connection string
 DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/agrocylo_db"
+
+# Supabase project connection
+SUPABASE_URL="https://YOUR_PROJECT_REF.supabase.co"
+SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY"
+SUPABASE_SERVICE_ROLE_KEY="YOUR_SUPABASE_SERVICE_ROLE_KEY"
+
+# Auth/JWT config used for RLS wallet policies
+SUPABASE_JWT_SECRET="YOUR_SUPABASE_JWT_SECRET"

--- a/server/supabase/README.md
+++ b/server/supabase/README.md
@@ -1,0 +1,36 @@
+## Supabase setup (dev + prod)
+
+This backend expects two Supabase projects:
+
+- `agrocylo-dev` for local and staging integration
+- `agrocylo-prod` for production traffic
+
+### 1) Create projects
+
+Create both projects in the Supabase dashboard and save:
+
+- Project URL
+- anon key
+- service role key
+- JWT secret
+
+Add those values to environment files based on `server/.env.example`.
+
+### 2) Apply schema
+
+Run the SQL in `supabase/migrations/20260324123000_init_profiles_locations_orders.sql` in each project SQL editor.
+
+### 3) Seed dev project
+
+Run `supabase/seed.sql` only in the dev project.
+
+### 4) Validate performance + policy behavior
+
+Use this proximity query pattern (PostGIS + GiST indexed):
+
+```sql
+select *
+from public.farmers_within_radius(7.40, 3.90, 50000);
+```
+
+Use `explain analyze` to confirm index usage and expected latency targets under load.

--- a/server/supabase/migrations/20260324123000_init_profiles_locations_orders.sql
+++ b/server/supabase/migrations/20260324123000_init_profiles_locations_orders.sql
@@ -1,0 +1,258 @@
+-- Agrocylo Supabase baseline schema for profile/location/order metadata.
+-- This migration is safe to run in Supabase Postgres.
+
+create extension if not exists pgcrypto;
+create extension if not exists postgis;
+
+-- Shared helper to keep wallet matching case-insensitive.
+create or replace function public.normalize_wallet()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.wallet_address is not null then
+    new.wallet_address := lower(new.wallet_address);
+  end if;
+
+  if tg_table_name = 'orders_metadata' then
+    if new.buyer_wallet is not null then
+      new.buyer_wallet := lower(new.buyer_wallet);
+    end if;
+    if new.farmer_wallet is not null then
+      new.farmer_wallet := lower(new.farmer_wallet);
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+-- Reads wallet identity from JWT custom claim set by your auth layer.
+create or replace function public.current_wallet_address()
+returns text
+language sql
+stable
+as $$
+  select lower(
+    coalesce(
+      nullif(auth.jwt() ->> 'wallet_address', ''),
+      nullif(auth.jwt() ->> 'walletAddress', '')
+    )
+  );
+$$;
+
+create table if not exists public.profiles (
+  id uuid primary key default gen_random_uuid(),
+  wallet_address text not null,
+  role text not null check (role in ('farmer', 'buyer')),
+  display_name text not null,
+  bio text,
+  avatar_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint profiles_wallet_address_unique unique (wallet_address)
+);
+
+create table if not exists public.locations (
+  id uuid primary key default gen_random_uuid(),
+  wallet_address text not null references public.profiles(wallet_address) on delete cascade,
+  latitude double precision not null,
+  longitude double precision not null,
+  geohash text generated always as (
+    st_geohash(st_setsrid(st_makepoint(longitude, latitude), 4326), 8)
+  ) stored,
+  city text,
+  country text,
+  is_public boolean not null default true,
+  updated_at timestamptz not null default now(),
+  location_geog geography(point, 4326) generated always as (
+    st_setsrid(st_makepoint(longitude, latitude), 4326)::geography
+  ) stored,
+  constraint locations_wallet_address_unique unique (wallet_address),
+  constraint locations_latitude_range check (latitude between -90 and 90),
+  constraint locations_longitude_range check (longitude between -180 and 180)
+);
+
+create table if not exists public.orders_metadata (
+  id uuid primary key default gen_random_uuid(),
+  on_chain_order_id bigint not null unique,
+  buyer_wallet text not null,
+  farmer_wallet text not null,
+  description text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger trg_profiles_normalize_wallet
+before insert or update on public.profiles
+for each row execute function public.normalize_wallet();
+
+create trigger trg_locations_normalize_wallet
+before insert or update on public.locations
+for each row execute function public.normalize_wallet();
+
+create trigger trg_orders_metadata_normalize_wallet
+before insert or update on public.orders_metadata
+for each row execute function public.normalize_wallet();
+
+create trigger trg_profiles_updated_at
+before update on public.profiles
+for each row execute function public.set_updated_at();
+
+create trigger trg_locations_updated_at
+before update on public.locations
+for each row execute function public.set_updated_at();
+
+create trigger trg_orders_metadata_updated_at
+before update on public.orders_metadata
+for each row execute function public.set_updated_at();
+
+create index if not exists idx_profiles_role on public.profiles (role);
+create index if not exists idx_profiles_wallet_lower on public.profiles ((lower(wallet_address)));
+create index if not exists idx_locations_wallet on public.locations (wallet_address);
+create index if not exists idx_locations_geohash on public.locations (geohash);
+create index if not exists idx_locations_geog_gist on public.locations using gist (location_geog);
+create index if not exists idx_orders_on_chain_order_id on public.orders_metadata (on_chain_order_id);
+create index if not exists idx_orders_buyer_wallet on public.orders_metadata (buyer_wallet);
+create index if not exists idx_orders_farmer_wallet on public.orders_metadata (farmer_wallet);
+
+alter table public.profiles enable row level security;
+alter table public.locations enable row level security;
+alter table public.orders_metadata enable row level security;
+
+-- Profiles: users can read all profiles, but can only mutate their own profile.
+create policy "Profiles are readable by authenticated users"
+on public.profiles
+for select
+to authenticated
+using (true);
+
+create policy "Users can insert own profile"
+on public.profiles
+for insert
+to authenticated
+with check (wallet_address = public.current_wallet_address());
+
+create policy "Users can update own profile"
+on public.profiles
+for update
+to authenticated
+using (wallet_address = public.current_wallet_address())
+with check (wallet_address = public.current_wallet_address());
+
+-- Locations: authenticated users can read only public farmer locations.
+create policy "Authenticated users read public farmer locations"
+on public.locations
+for select
+to authenticated
+using (
+  is_public = true
+  and exists (
+    select 1
+    from public.profiles p
+    where p.wallet_address = locations.wallet_address
+      and p.role = 'farmer'
+  )
+);
+
+create policy "Users can read own location regardless of visibility"
+on public.locations
+for select
+to authenticated
+using (wallet_address = public.current_wallet_address());
+
+create policy "Users can insert own location"
+on public.locations
+for insert
+to authenticated
+with check (wallet_address = public.current_wallet_address());
+
+create policy "Users can update own location"
+on public.locations
+for update
+to authenticated
+using (wallet_address = public.current_wallet_address())
+with check (wallet_address = public.current_wallet_address());
+
+-- Orders metadata: only counterparties can read or mutate metadata.
+create policy "Buyer or farmer can read order metadata"
+on public.orders_metadata
+for select
+to authenticated
+using (
+  buyer_wallet = public.current_wallet_address()
+  or farmer_wallet = public.current_wallet_address()
+);
+
+create policy "Buyer or farmer can insert order metadata"
+on public.orders_metadata
+for insert
+to authenticated
+with check (
+  buyer_wallet = public.current_wallet_address()
+  or farmer_wallet = public.current_wallet_address()
+);
+
+create policy "Buyer or farmer can update order metadata"
+on public.orders_metadata
+for update
+to authenticated
+using (
+  buyer_wallet = public.current_wallet_address()
+  or farmer_wallet = public.current_wallet_address()
+)
+with check (
+  buyer_wallet = public.current_wallet_address()
+  or farmer_wallet = public.current_wallet_address()
+);
+
+-- Utility function for proximity search using PostGIS.
+create or replace function public.farmers_within_radius(
+  in_latitude double precision,
+  in_longitude double precision,
+  in_radius_meters integer
+)
+returns table (
+  wallet_address text,
+  display_name text,
+  city text,
+  country text,
+  latitude double precision,
+  longitude double precision,
+  distance_meters double precision
+)
+language sql
+stable
+as $$
+  select
+    p.wallet_address,
+    p.display_name,
+    l.city,
+    l.country,
+    l.latitude,
+    l.longitude,
+    st_distance(
+      l.location_geog,
+      st_setsrid(st_makepoint(in_longitude, in_latitude), 4326)::geography
+    ) as distance_meters
+  from public.locations l
+  join public.profiles p on p.wallet_address = l.wallet_address
+  where p.role = 'farmer'
+    and l.is_public = true
+    and st_dwithin(
+      l.location_geog,
+      st_setsrid(st_makepoint(in_longitude, in_latitude), 4326)::geography,
+      in_radius_meters
+    )
+  order by distance_meters asc;
+$$;

--- a/server/supabase/seed.sql
+++ b/server/supabase/seed.sql
@@ -1,0 +1,37 @@
+-- Local/dev seed data for Agrocylo Supabase tables.
+-- Uses deterministic wallet addresses for quick manual testing.
+
+insert into public.profiles (wallet_address, role, display_name, bio, avatar_url)
+values
+  ('0x1111111111111111111111111111111111111111', 'farmer', 'Amina Fields', 'Cassava and maize farmer in Ibadan.', 'https://example.com/avatars/amina.png'),
+  ('0x2222222222222222222222222222222222222222', 'farmer', 'Kofi Harvest', 'Rice grower focused on sustainable irrigation.', 'https://example.com/avatars/kofi.png'),
+  ('0x3333333333333333333333333333333333333333', 'buyer', 'Lagos Foods Ltd', 'Bulk buyer for staple produce.', 'https://example.com/avatars/lagos-foods.png'),
+  ('0x4444444444444444444444444444444444444444', 'buyer', 'Accra Grain Hub', 'Regional produce distributor.', 'https://example.com/avatars/accra-hub.png')
+on conflict (wallet_address) do update
+set
+  role = excluded.role,
+  display_name = excluded.display_name,
+  bio = excluded.bio,
+  avatar_url = excluded.avatar_url;
+
+insert into public.locations (wallet_address, latitude, longitude, city, country, is_public)
+values
+  ('0x1111111111111111111111111111111111111111', 7.3775, 3.9470, 'Ibadan', 'Nigeria', true),
+  ('0x2222222222222222222222222222222222222222', 5.6037, -0.1870, 'Accra', 'Ghana', true)
+on conflict (wallet_address) do update
+set
+  latitude = excluded.latitude,
+  longitude = excluded.longitude,
+  city = excluded.city,
+  country = excluded.country,
+  is_public = excluded.is_public;
+
+insert into public.orders_metadata (on_chain_order_id, buyer_wallet, farmer_wallet, description)
+values
+  (1001, '0x3333333333333333333333333333333333333333', '0x1111111111111111111111111111111111111111', '5 metric tons of cassava roots'),
+  (1002, '0x4444444444444444444444444444444444444444', '0x2222222222222222222222222222222222222222', '2 metric tons of polished rice')
+on conflict (on_chain_order_id) do update
+set
+  buyer_wallet = excluded.buyer_wallet,
+  farmer_wallet = excluded.farmer_wallet,
+  description = excluded.description;


### PR DESCRIPTION
Closes #51

---

What I added
New Supabase migration:
server/supabase/migrations/20260324123000_init_profiles_locations_orders.sql
New seed script:
server/supabase/seed.sql
Supabase setup doc:
server/supabase/README.md
Updated env template:
server/.env.example
Included in the migration
Tables: profiles, locations, orders_metadata with requested columns/types.
Constraints:
role check on profiles.role (farmer / buyer)
unique wallet identity in profiles (enforces wallet can only be one role)
FK locations.wallet_address -> profiles.wallet_address ON DELETE CASCADE
lat/lng range checks
on_chain_order_id unique
Indexes:
geospatial GiST index via generated location_geog geography(point,4326)
geohash index
wallet and order lookup indexes
RLS:
users can insert/update only their own profiles/locations
authenticated users can read public farmer locations
orders_metadata readable/mutable only by matching buyer/farmer wallets
Auto-updated timestamps:
updated_at trigger function applied to all three tables
Proximity query support:
farmers_within_radius(lat, lng, radius_meters) PostGIS function for fast radius lookups