### PR TITLE
feat: create Soroban contract interaction service

### DIFF
--- a/client/src/services/stellar/contractService.ts
+++ b/client/src/services/stellar/contractService.ts
@@ -1,0 +1,322 @@
+/**
+ * Soroban Contract Interaction Service
+ *
+ * Provides typed helpers for every escrow-contract method used by the
+ * Agrocylo frontend: creating orders, confirming delivery, requesting
+ * refunds, and querying order state.
+ *
+ * All public functions return a {@link ContractResult} that wraps either
+ * the decoded return value or a human-readable error so callers never
+ * need to catch raw RPC exceptions.
+ */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { getNetworkConfig, type NetworkConfig } from "./networkConfig";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+/** Standardised response envelope for every contract call. */
+export interface ContractResult<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+/** On-chain order representation returned by `get_order`. */
+export interface Order {
+  orderId: string;
+  buyer: string;
+  seller: string;
+  amount: bigint;
+  status: string;
+  createdAt: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+let _config: NetworkConfig | null = null;
+
+function config(): NetworkConfig {
+  if (!_config) _config = getNetworkConfig();
+  return _config;
+}
+
+function rpcServer(): StellarSdk.rpc.Server {
+  return new StellarSdk.rpc.Server(config().rpcUrl);
+}
+
+function contractInstance(): StellarSdk.Contract {
+  const { contractId } = config();
+  if (!contractId) {
+    throw new Error(
+      "Contract ID is not configured. Set NEXT_PUBLIC_CONTRACT_ID in your environment."
+    );
+  }
+  return new StellarSdk.Contract(contractId);
+}
+
+/**
+ * Build, simulate, and return a transaction ready for signing.
+ *
+ * The caller (usually the wallet-signing layer) is responsible for
+ * signing and submitting the returned transaction.
+ */
+async function buildTransaction(
+  sourcePublicKey: string,
+  method: string,
+  ...params: StellarSdk.xdr.ScVal[]
+): Promise<StellarSdk.Transaction> {
+  const server = rpcServer();
+  const { networkPassphrase } = config();
+  const contract = contractInstance();
+
+  const sourceAccount = await server.getAccount(sourcePublicKey);
+
+  const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(contract.call(method, ...params))
+    .setTimeout(30)
+    .build();
+
+  const simulated = await server.simulateTransaction(tx);
+
+  if (StellarSdk.rpc.Api.isSimulationError(simulated)) {
+    throw new Error(
+      `Simulation failed: ${(simulated as StellarSdk.rpc.Api.SimulateTransactionErrorResponse).error}`
+    );
+  }
+
+  const prepared = StellarSdk.rpc.assembleTransaction(
+    tx,
+    simulated as StellarSdk.rpc.Api.SimulateTransactionSuccessResponse
+  ).build();
+
+  return prepared;
+}
+
+/**
+ * Submit a signed transaction and wait for confirmation.
+ */
+async function submitTransaction(
+  signedXdr: string
+): Promise<StellarSdk.rpc.Api.GetTransactionResponse> {
+  const server = rpcServer();
+  const { networkPassphrase } = config();
+  const tx = StellarSdk.TransactionBuilder.fromXDR(
+    signedXdr,
+    networkPassphrase
+  );
+
+  const response = await server.sendTransaction(tx);
+
+  if (response.status === "ERROR") {
+    throw new Error(`Transaction submission failed: ${response.status}`);
+  }
+
+  // Poll until the transaction leaves PENDING state
+  let result = await server.getTransaction(response.hash);
+  const deadline = Date.now() + 30_000;
+
+  while (
+    result.status === StellarSdk.rpc.Api.GetTransactionStatus.NOT_FOUND &&
+    Date.now() < deadline
+  ) {
+    await new Promise((r) => setTimeout(r, 1_000));
+    result = await server.getTransaction(response.hash);
+  }
+
+  return result;
+}
+
+// ── Decode helpers ───────────────────────────────────────────────────────
+
+function decodeOrderStatus(val: StellarSdk.xdr.ScVal): string {
+  const vec = val.vec();
+  if (vec && vec.length > 0) {
+    return vec[0].sym().toString();
+  }
+  return "Unknown";
+}
+
+function decodeOrder(val: StellarSdk.xdr.ScVal): Order {
+  const fields = val.map();
+  if (!fields) throw new Error("Expected map value for order");
+
+  const get = (key: string): StellarSdk.xdr.ScVal => {
+    const entry = fields.find(
+      (e) => e.key().sym().toString() === key
+    );
+    if (!entry) throw new Error(`Missing field: ${key}`);
+    return entry.val();
+  };
+
+  return {
+    orderId: StellarSdk.scValToNative(get("order_id")),
+    buyer: StellarSdk.Address.fromScVal(get("buyer")).toString(),
+    seller: StellarSdk.Address.fromScVal(get("seller")).toString(),
+    amount: StellarSdk.scValToNative(get("amount")),
+    status: decodeOrderStatus(get("status")),
+    createdAt: Number(StellarSdk.scValToNative(get("created_at"))),
+  };
+}
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Build a `create_order` transaction.
+ *
+ * @param buyer   - Stellar public key of the buyer
+ * @param seller  - Stellar public key of the seller
+ * @param amount  - Payment amount in stroops
+ * @returns Transaction XDR ready for wallet signing
+ */
+export async function createOrder(
+  buyer: string,
+  seller: string,
+  amount: bigint
+): Promise<ContractResult<string>> {
+  try {
+    const tx = await buildTransaction(
+      buyer,
+      "create_order",
+      new StellarSdk.Address(buyer).toScVal(),
+      new StellarSdk.Address(seller).toScVal(),
+      StellarSdk.nativeToScVal(amount, { type: "i128" })
+    );
+    return { success: true, data: tx.toXDR() };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Build a `confirm_delivery` transaction.
+ *
+ * @param buyer   - Stellar public key of the buyer confirming delivery
+ * @param orderId - On-chain order identifier
+ * @returns Transaction XDR ready for wallet signing
+ */
+export async function confirmDelivery(
+  buyer: string,
+  orderId: string
+): Promise<ContractResult<string>> {
+  try {
+    const tx = await buildTransaction(
+      buyer,
+      "confirm_delivery",
+      new StellarSdk.Address(buyer).toScVal(),
+      StellarSdk.nativeToScVal(orderId, { type: "symbol" })
+    );
+    return { success: true, data: tx.toXDR() };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Build a `refund_order` transaction.
+ *
+ * @param caller  - Stellar public key of the caller requesting the refund
+ * @param orderId - On-chain order identifier
+ * @returns Transaction XDR ready for wallet signing
+ */
+export async function refundOrder(
+  caller: string,
+  orderId: string
+): Promise<ContractResult<string>> {
+  try {
+    const tx = await buildTransaction(
+      caller,
+      "refund_order",
+      new StellarSdk.Address(caller).toScVal(),
+      StellarSdk.nativeToScVal(orderId, { type: "symbol" })
+    );
+    return { success: true, data: tx.toXDR() };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Query order details (read-only, no signing required).
+ *
+ * @param orderId - On-chain order identifier
+ * @returns Decoded {@link Order} object
+ */
+export async function getOrder(
+  orderId: string
+): Promise<ContractResult<Order>> {
+  try {
+    const server = rpcServer();
+    const contract = contractInstance();
+    const { networkPassphrase } = config();
+
+    // Use a zero-account source since this is read-only
+    const fakeSource = StellarSdk.Keypair.random().publicKey();
+    const sourceAccount = await server.getAccount(fakeSource).catch(() => {
+      // For read-only calls we can create a mock account
+      return new StellarSdk.Account(fakeSource, "0");
+    });
+
+    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          "get_order",
+          StellarSdk.nativeToScVal(orderId, { type: "symbol" })
+        )
+      )
+      .setTimeout(30)
+      .build();
+
+    const simulated = await server.simulateTransaction(tx);
+
+    if (StellarSdk.rpc.Api.isSimulationError(simulated)) {
+      throw new Error(
+        `Query failed: ${(simulated as StellarSdk.rpc.Api.SimulateTransactionErrorResponse).error}`
+      );
+    }
+
+    const successResult =
+      simulated as StellarSdk.rpc.Api.SimulateTransactionSuccessResponse;
+    const returnVal = successResult.result?.retval;
+
+    if (!returnVal) {
+      throw new Error("No return value from get_order");
+    }
+
+    return { success: true, data: decodeOrder(returnVal) };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Submit a signed transaction XDR to the network and wait for
+ * confirmation.
+ *
+ * @param signedXdr - Base64-encoded signed transaction envelope
+ * @returns The final transaction status
+ */
+export async function submitSignedTransaction(
+  signedXdr: string
+): Promise<ContractResult<string>> {
+  try {
+    const result = await submitTransaction(signedXdr);
+
+    if (result.status === StellarSdk.rpc.Api.GetTransactionStatus.SUCCESS) {
+      return { success: true, data: "Transaction confirmed" };
+    }
+
+    return {
+      success: false,
+      error: `Transaction ended with status: ${result.status}`,
+    };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}

--- a/client/src/services/stellar/index.ts
+++ b/client/src/services/stellar/index.ts
@@ -1,0 +1,11 @@
+export {
+  createOrder,
+  confirmDelivery,
+  refundOrder,
+  getOrder,
+  submitSignedTransaction,
+  type ContractResult,
+  type Order,
+} from "./contractService";
+
+export { getNetworkConfig, type NetworkConfig } from "./networkConfig";

--- a/client/src/services/stellar/networkConfig.ts
+++ b/client/src/services/stellar/networkConfig.ts
@@ -1,0 +1,45 @@
+/**
+ * Stellar / Soroban network configuration.
+ *
+ * Reads the active network from environment variables so the same code
+ * works against a local standalone instance, the public testnet, or
+ * mainnet without any code changes.
+ *
+ * Environment variables (set in `.env.local`):
+ *   NEXT_PUBLIC_SOROBAN_RPC_URL   - Soroban RPC endpoint
+ *   NEXT_PUBLIC_NETWORK_PASSPHRASE - Stellar network passphrase
+ *   NEXT_PUBLIC_CONTRACT_ID        - Deployed escrow contract address
+ */
+
+export interface NetworkConfig {
+  rpcUrl: string;
+  networkPassphrase: string;
+  contractId: string;
+}
+
+const TESTNET_RPC_URL = "https://soroban-testnet.stellar.org";
+const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+
+/**
+ * Returns the active network configuration.
+ *
+ * Falls back to Stellar Testnet defaults when env vars are not set,
+ * which is the expected development environment for Agrocylo.
+ */
+export function getNetworkConfig(): NetworkConfig {
+  const rpcUrl =
+    process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ?? TESTNET_RPC_URL;
+
+  const networkPassphrase =
+    process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? TESTNET_PASSPHRASE;
+
+  const contractId = process.env.NEXT_PUBLIC_CONTRACT_ID ?? "";
+  if (!contractId) {
+    console.warn(
+      "[networkConfig] NEXT_PUBLIC_CONTRACT_ID is not set. " +
+        "Contract calls will fail until a deployed contract address is provided."
+    );
+  }
+
+  return { rpcUrl, networkPassphrase, contractId };
+}


### PR DESCRIPTION
## Summary

- Add reusable service layer for interacting with the Agrocylo escrow smart contract from the frontend
- Implement `contractService.ts` with typed helpers for all core escrow operations
- Add `networkConfig.ts` for environment-driven RPC and network configuration

## Details

### `services/stellar/networkConfig.ts`
- Reads `NEXT_PUBLIC_SOROBAN_RPC_URL`, `NEXT_PUBLIC_NETWORK_PASSPHRASE`, and `NEXT_PUBLIC_CONTRACT_ID` from environment
- Falls back to Stellar Testnet defaults for development
- Warns when contract ID is not configured

### `services/stellar/contractService.ts`
Typed helpers wrapping the escrow contract methods:

| Function | Purpose |
|----------|---------|
| `createOrder(buyer, seller, amount)` | Builds a `create_order` transaction for wallet signing |
| `confirmDelivery(buyer, orderId)` | Builds a `confirm_delivery` transaction |
| `refundOrder(caller, orderId)` | Builds a `refund_order` transaction |
| `getOrder(orderId)` | Read-only query — decodes on-chain order state |
| `submitSignedTransaction(signedXdr)` | Submits signed XDR and polls for confirmation |

All functions return a `ContractResult<T>` envelope with `success`, `data`, and `error` fields so callers never need to handle raw exceptions.

### `services/stellar/index.ts`
Barrel exports for clean imports: `import { createOrder, getOrder } from "@/services/stellar"`

## Test plan

- [ ] Set `NEXT_PUBLIC_CONTRACT_ID` to a deployed testnet contract address
- [ ] Call `getOrder()` with a known order ID — verify decoded response
- [ ] Call `createOrder()` — verify transaction XDR is returned
- [ ] Sign and submit via `submitSignedTransaction()` — verify confirmation

Closes #29