### PR TITLE
feat: implement wallet transaction signing flow

### DIFF
--- a/client/src/context/WalletContext.tsx
+++ b/client/src/context/WalletContext.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import React, { createContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useEffect, useState } from "react";
 import type { WalletContextType } from "../types/wallet";
 import { getXlmBalance, getCurrentNetworkName } from "../lib/stellar";
+import { signAndSubmitTransaction } from "../lib/signTransaction";
+import type { SignAndSubmitResult } from "../lib/signTransaction";
 import FreighterApi from "@stellar/freighter-api";
 
 const initialState: WalletContextType = {
@@ -15,6 +17,7 @@ const initialState: WalletContextType = {
   connect: async () => {},
   disconnect: () => {},
   refreshBalance: async () => {},
+  signAndSubmit: async () => ({ success: false, error: "Wallet not connected" }),
 };
 
 export const WalletContext = createContext<WalletContextType>(initialState);
@@ -111,6 +114,28 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.removeItem("walletNetwork");
   };
 
+  const signAndSubmit = useCallback(
+    async (transactionXdr: string): Promise<SignAndSubmitResult> => {
+      if (!connected || !address) {
+        return { success: false, error: "Wallet not connected" };
+      }
+      setError(null);
+      try {
+        const result = await signAndSubmitTransaction(transactionXdr);
+        // Refresh balance after a successful on-chain transaction
+        if (result.success) {
+          await refreshBalance();
+        }
+        return result;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg);
+        return { success: false, error: msg };
+      }
+    },
+    [connected, address]
+  );
+
   const ctx = {
     address,
     balance,
@@ -121,6 +146,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
     connect,
     disconnect,
     refreshBalance: async () => refreshBalance(),
+    signAndSubmit,
   };
 
   return (

--- a/client/src/lib/signTransaction.ts
+++ b/client/src/lib/signTransaction.ts
@@ -1,0 +1,173 @@
+/**
+ * Wallet Transaction Signing Flow
+ *
+ * Implements the complete signing lifecycle:
+ *   1. Frontend builds transaction (XDR)
+ *   2. Wallet signs transaction (Freighter prompt)
+ *   3. Signed transaction submitted to Soroban RPC
+ *   4. Poll for confirmation and return result
+ */
+
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { rpc } from "@stellar/stellar-sdk";
+import FreighterApi from "@stellar/freighter-api";
+import { getRpcServer, getCurrentNetworkName } from "./stellar";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface SignAndSubmitResult {
+  success: boolean;
+  txHash?: string;
+  status?: string;
+  resultXdr?: string;
+  error?: string;
+}
+
+export interface SignTransactionOptions {
+  /** Network passphrase override (auto-detected from Freighter if omitted). */
+  networkPassphrase?: string;
+  /** Polling timeout in ms after submission (default 30 000). */
+  timeoutMs?: number;
+  /** Polling interval in ms (default 1 000). */
+  intervalMs?: number;
+}
+
+// ── Network passphrase helper ────────────────────────────────────────────
+
+async function resolveNetworkPassphrase(
+  override?: string
+): Promise<string> {
+  if (override) return override;
+  try {
+    const details = await FreighterApi.getNetworkDetails();
+    return details.networkPassphrase;
+  } catch {
+    return "Test SDF Network ; September 2015";
+  }
+}
+
+// ── Core API ─────────────────────────────────────────────────────────────
+
+/**
+ * Sign a transaction XDR using the Freighter wallet.
+ *
+ * Opens the Freighter signing prompt and returns the signed XDR string.
+ * Throws if the user rejects or Freighter is unavailable.
+ *
+ * @param transactionXdr - Base64-encoded unsigned transaction envelope
+ * @param opts           - Optional overrides
+ * @returns Signed transaction XDR (base64)
+ */
+export async function signTransaction(
+  transactionXdr: string,
+  opts?: Pick<SignTransactionOptions, "networkPassphrase">
+): Promise<string> {
+  const networkPassphrase = await resolveNetworkPassphrase(
+    opts?.networkPassphrase
+  );
+
+  const signedXdr = await FreighterApi.signTransaction(transactionXdr, {
+    networkPassphrase,
+  });
+
+  if (!signedXdr) {
+    throw new Error("Transaction was rejected by the wallet");
+  }
+
+  return signedXdr;
+}
+
+/**
+ * Submit a signed transaction XDR to the Soroban RPC and wait for
+ * a terminal status.
+ *
+ * @param signedXdr - Base64-encoded signed transaction envelope
+ * @param opts      - Optional overrides
+ * @returns Submission result with hash and final status
+ */
+export async function submitTransaction(
+  signedXdr: string,
+  opts?: SignTransactionOptions
+): Promise<SignAndSubmitResult> {
+  const networkPassphrase = await resolveNetworkPassphrase(
+    opts?.networkPassphrase
+  );
+  const timeoutMs = opts?.timeoutMs ?? 30_000;
+  const intervalMs = opts?.intervalMs ?? 1_000;
+
+  const server = await getRpcServer();
+  const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+
+  const sendResponse = await server.sendTransaction(tx);
+
+  if (sendResponse.status === "ERROR") {
+    return {
+      success: false,
+      error: `Submission rejected: ${sendResponse.errorResult?.toXDR("base64") ?? sendResponse.status}`,
+    };
+  }
+
+  const txHash = sendResponse.hash;
+
+  // Poll until terminal state
+  const deadline = Date.now() + timeoutMs;
+  let result = await server.getTransaction(txHash);
+
+  while (
+    result.status === rpc.Api.GetTransactionStatus.NOT_FOUND &&
+    Date.now() < deadline
+  ) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    result = await server.getTransaction(txHash);
+  }
+
+  if (result.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+    return {
+      success: true,
+      txHash,
+      status: "SUCCESS",
+      resultXdr: result.resultMetaXdr?.toXDR("base64"),
+    };
+  }
+
+  if (result.status === rpc.Api.GetTransactionStatus.FAILED) {
+    return {
+      success: false,
+      txHash,
+      status: "FAILED",
+      resultXdr: result.resultMetaXdr?.toXDR("base64"),
+      error: "Transaction failed on-chain",
+    };
+  }
+
+  return {
+    success: false,
+    txHash,
+    status: "TIMEOUT",
+    error: `Transaction not confirmed within ${timeoutMs / 1000}s`,
+  };
+}
+
+/**
+ * End-to-end helper: sign a transaction with Freighter then submit it
+ * to the Soroban RPC and wait for confirmation.
+ *
+ * This is the primary function most callers should use.
+ *
+ * @param transactionXdr - Base64-encoded unsigned transaction envelope
+ * @param opts           - Optional overrides
+ */
+export async function signAndSubmitTransaction(
+  transactionXdr: string,
+  opts?: SignTransactionOptions
+): Promise<SignAndSubmitResult> {
+  try {
+    const signedXdr = await signTransaction(transactionXdr, opts);
+    return await submitTransaction(signedXdr, opts);
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/client/src/types/wallet.ts
+++ b/client/src/types/wallet.ts
@@ -1,3 +1,5 @@
+import type { SignAndSubmitResult } from "../lib/signTransaction";
+
 export interface WalletState {
   address: string | null;
   balance: string | null; // XLM balance as human-readable string
@@ -11,4 +13,6 @@ export interface WalletContextType extends WalletState {
   connect: () => Promise<void>;
   disconnect: () => void;
   refreshBalance: () => Promise<void>;
+  /** Sign a transaction XDR with Freighter, submit it, and wait for confirmation. */
+  signAndSubmit: (transactionXdr: string) => Promise<SignAndSubmitResult>;
 }


### PR DESCRIPTION
## Summary

- Add a reusable signing layer for the complete Soroban transaction lifecycle
- Expose `signAndSubmit` through the wallet context so any component can trigger signing
- Auto-refresh wallet balance after successful on-chain transactions

## Details

### `lib/signTransaction.ts` (new)

Implements the full signing workflow described in issue #31:

| Function | Step | Purpose |
|----------|------|---------|
| `signTransaction(xdr)` | Frontend -> Wallet | Opens Freighter prompt, returns signed XDR |
| `submitTransaction(signedXdr)` | Signed -> Network | Submits to Soroban RPC, polls for confirmation |
| `signAndSubmitTransaction(xdr)` | End-to-end | Sign + submit + poll in one call |

All functions return a typed `SignAndSubmitResult` with `success`, `txHash`, `status`, `resultXdr`, and `error` fields.

### `types/wallet.ts` (updated)

Added `signAndSubmit` method to `WalletContextType` so the signing flow is available through React context.

### `context/WalletContext.tsx` (updated)

- Imports and exposes `signAndSubmit` via the wallet context
- Validates wallet connection before signing
- Auto-refreshes XLM balance after successful transactions
- Surfaces signing errors through the context's `error` state

### Usage

```tsx
const { signAndSubmit } = useWallet();

// After building a transaction XDR via contractService:
const result = await signAndSubmit(transactionXdr);
if (result.success) {
  console.log("Confirmed:", result.txHash);
}
```

## Test plan

- [ ] Connect Freighter wallet on testnet
- [ ] Call `signAndSubmit()` with a valid transaction XDR
- [ ] Verify Freighter signing prompt appears
- [ ] Confirm transaction and verify `txHash` is returned
- [ ] Reject transaction in Freighter — verify error is surfaced
- [ ] Verify balance auto-refreshes after successful submission

Closes #31