### PR TITLE
feat(backend): build Soroban event listener (#42)

### DIFF
--- a/server/src/enums/notificationEventType.ts
+++ b/server/src/enums/notificationEventType.ts
@@ -1,7 +1,12 @@
 export enum NotificationEventType {
+  // Order lifecycle
+  ORDER_CREATED = "order_created",
+  FUNDS_LOCKED = "funds_locked",
+  DELIVERY_CONFIRMED = "delivery_confirmed",
+  REFUND_ISSUED = "refund_issued",
+  // Legacy / extended
+  ORDER_RECEIVED = "order_received",
   NEW_INVESTMENT = "new_investment",
   CAMPAIGN_FUNDED = "campaign_funded",
   HARVEST_COMPLETED = "harvest_completed",
-  ORDER_RECEIVED = "order_received",
 }
-

--- a/server/src/services/contractWatcher.ts
+++ b/server/src/services/contractWatcher.ts
@@ -1,151 +1,175 @@
 import { rpc, scValToNative, xdr } from "@stellar/stellar-sdk";
 import logger from "../config/logger.js";
-import { prisma } from "../config/database.js";
-import { wsManager } from "./wsManager.js";
+import { config } from "../config/index.js";
 import { NotificationService } from "./notificationService.js";
+import { wsManager } from "./wsManager.js";
 
-const CONTRACT_ID = process.env.CONTRACT_ID;
-const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
+const POLL_INTERVAL_MS = 5_000;
 
-export async function startContractWatcher() {
-  if (!CONTRACT_ID) {
-    logger.warn("CONTRACT_ID not set, skipping contract watcher.");
+/**
+ * Decodes a raw Soroban event topic/value from base64 XDR.
+ */
+function decodeScVal(base64: string): unknown {
+  return scValToNative(xdr.ScVal.fromXDR(base64, "base64"));
+}
+
+/**
+ * Extracts the action string and decoded data array from a raw RPC event.
+ * Topics layout: [entity, action, ...]
+ */
+function decodeEvent(event: any): { action: string; data: unknown[] } | null {
+  try {
+    const topics = (event.topic as string[]).map(decodeScVal);
+    const action = String(topics[1] ?? "").toLowerCase();
+    const raw = decodeScVal(event.value as string);
+    const data = Array.isArray(raw) ? raw : [raw];
+    return { action, data };
+  } catch (err) {
+    logger.error("Failed to decode contract event", err);
+    return null;
+  }
+}
+
+/**
+ * Dispatches a decoded event to the notification service and WebSocket broadcast.
+ *
+ * Contract event signatures (from escrow/src/lib.rs):
+ *   OrderCreated  / FundsLocked  → (order, created)   → data: [order_id, buyer, farmer, amount, token]
+ *   DeliveryConfirmed            → (order, confirmed)  → data: [order_id, buyer, farmer]
+ *   RefundIssued                 → (order, refunded)   → data: [order_id, buyer]
+ *   (internal)                   → (order, delivered)  → data: [order_id, farmer, buyer, delivery_ts]
+ */
+function handleEvent(event: any): void {
+  const decoded = decodeEvent(event);
+  if (!decoded) return;
+
+  const { action, data } = decoded;
+  const orderId = String(data[0] ?? "");
+
+  logger.info(`[ContractWatcher] Event received: ${action} | order: ${orderId} | ledger: ${event.ledger}`);
+
+  switch (action) {
+    case "created": {
+      // data: [order_id, buyer, farmer, amount, token]
+      const buyer = String(data[1] ?? "");
+      const farmer = String(data[2] ?? "");
+      const amount = String(data[3] ?? "");
+      const token = String(data[4] ?? "");
+
+      // OrderCreated → notify buyer
+      // FundsLocked  → notify farmer (funds locked in escrow on their behalf)
+      void NotificationService.notifyFromEscrowEvent({
+        action: "created",
+        buyerAddress: buyer,
+        farmerAddress: farmer,
+        orderId,
+        amount,
+        token,
+      });
+
+      wsManager.broadcast("order:created", { orderId, buyer, farmer, amount, token });
+      break;
+    }
+
+    case "delivered": {
+      // data: [order_id, farmer, buyer, delivery_timestamp]
+      // Internal state change — no payment movement; broadcast status update only.
+      const farmer = String(data[1] ?? "");
+      const buyer = String(data[2] ?? "");
+
+      wsManager.broadcast("order:delivered", { orderId, farmer, buyer });
+      break;
+    }
+
+    case "confirmed": {
+      // data: [order_id, buyer, farmer]
+      // DeliveryConfirmed → payment released to farmer.
+      const buyer = String(data[1] ?? "");
+      const farmer = String(data[2] ?? "");
+
+      void NotificationService.notifyFromEscrowEvent({
+        action: "confirmed",
+        buyerAddress: buyer,
+        farmerAddress: farmer,
+        orderId,
+      });
+
+      wsManager.broadcast("order:confirmed", { orderId, buyer, farmer });
+      break;
+    }
+
+    case "refunded": {
+      // data: [order_id, buyer]
+      // RefundIssued → funds returned to buyer.
+      const buyer = String(data[1] ?? "");
+
+      void NotificationService.notifyFromEscrowEvent({
+        action: "refunded",
+        buyerAddress: buyer,
+        orderId,
+      });
+
+      wsManager.broadcast("order:refunded", { orderId, buyer });
+      break;
+    }
+
+    default:
+      logger.warn(`[ContractWatcher] Unhandled event action: "${action}"`);
+  }
+}
+
+/**
+ * Starts the Soroban event listener.
+ *
+ * Connects to the Stellar RPC, subscribes to all contract events for the
+ * configured escrow contract, decodes them, and dispatches notifications
+ * and WebSocket broadcasts in real time.
+ *
+ * Tracked events:
+ *   - OrderCreated  (order.created)
+ *   - FundsLocked   (order.created — funds locked at order creation)
+ *   - DeliveryConfirmed (order.confirmed)
+ *   - RefundIssued  (order.refunded)
+ */
+export async function startContractWatcher(): Promise<void> {
+  const { contractId, rpcUrl } = config;
+
+  if (!contractId) {
+    logger.warn("[ContractWatcher] CONTRACT_ID not set — skipping event listener.");
     return;
   }
 
-  const server = new rpc.Server(RPC_URL);
-  logger.info("Contract Watcher Service started...");
-  let lastKnownLedger = (await server.getLatestLedger()).sequence;
+  const server = new rpc.Server(rpcUrl);
+  let lastLedger = (await server.getLatestLedger()).sequence;
+
+  logger.info(`[ContractWatcher] Listening for events on contract ${contractId} from ledger ${lastLedger}`);
 
   setInterval(async () => {
     try {
       const response = await server.getEvents({
-        startLedger: lastKnownLedger,
-        filters: [
-          {
-            type: "contract",
-            contractIds: [CONTRACT_ID],
-          },
-        ],
+        startLedger: lastLedger,
+        filters: [{ type: "contract", contractIds: [contractId] }],
       });
+
       for (const event of response.events) {
-        import("./events/blockchainEventIngestionService.js")
-          .then(({ BlockchainEventIngestionService }) => {
-            BlockchainEventIngestionService.ingestEvent(event);
-          })
-          .catch((err) =>
-            logger.error("Dynamic Import Fail (BlockchainEventIngestionService):", err),
-          );
-        // --- NEW: Structured Ingestion for the Indexer ---
-        import("./events/escrowEventIngestionService.js")
-          .then(({ EscrowEventIngestionService }) => {
-            EscrowEventIngestionService.ingestEvent(event);
-          })
-          .catch((err) => logger.error("Dynamic Import Fail (IngestionService):", err));
-        handleContractEvent(event);
-        if (event.ledger > lastKnownLedger) {
-          lastKnownLedger = event.ledger + 1;
+        // Route through the structured ingestion pipeline (persistence + projection)
+        void import("./events/blockchainEventIngestionService.js")
+          .then(({ BlockchainEventIngestionService }) => BlockchainEventIngestionService.ingestEvent(event))
+          .catch((err) => logger.error("[ContractWatcher] BlockchainEventIngestionService import failed", err));
+
+        void import("./events/escrowEventIngestionService.js")
+          .then(({ EscrowEventIngestionService }) => EscrowEventIngestionService.ingestEvent(event))
+          .catch((err) => logger.error("[ContractWatcher] EscrowEventIngestionService import failed", err));
+
+        // Dispatch notifications and real-time WebSocket events
+        handleEvent(event);
+
+        if (event.ledger >= lastLedger) {
+          lastLedger = event.ledger + 1;
         }
       }
-    } catch (error) {
-      logger.error("Watcher Error:", error);
+    } catch (err) {
+      logger.error("[ContractWatcher] Poll error", err);
     }
-  }, 5000);
-}
-
-function handleContractEvent(event: any) {
-  const topics = event.topic.map((t: string) =>
-    scValToNative(xdr.ScVal.fromXDR(t, "base64")),
-  );
-  const action = topics[1];
-  const data = scValToNative(xdr.ScVal.fromXDR(event.value, "base64"));
-  logger.info(`New Event Detected: ${action}`);
-  const orderId = data[0].toString();
-  switch (action) {
-    case "created":
-      notifyUser(data[2], `New Order Alert! You have a new order #${orderId} for ${data[3]} tokens.`, orderId, action);
-      break;
-    case "confirmed":
-      notifyUser(data[2], `Payment Released! Buyer confirmed receipt for order #${orderId}.`, orderId, action);
-      break;
-    case "refunded":
-      notifyUser(data[1], `Refund Issued. Order #${orderId} was expired and funds returned.`, orderId, action);
-      // Notify farmer: order received
-      notifyUser(
-        data[2],
-        `Order Received! You have a new order #${orderId} for ${data[3]} tokens.`,
-        `Order funded: order #${orderId} has been locked in escrow for ${data[3]} tokens.`,
-        orderId,
-        "order_received",
-      );
-      // Notify buyer: new investment
-      notifyUser(
-        data[1],
-        `New Investment! Your order #${orderId} has been placed and funds are held in escrow.`,
-        orderId,
-        "new_investment",
-      );
-      break;
-    case "delivered":
-      // Notify buyer: harvest completed
-      notifyUser(
-        data[2],
-        `Harvest Completed! Order #${orderId} has been marked as delivered by the farmer.`,
-        orderId,
-        "harvest_completed",
-      );
-      wsManager.broadcast("order:created", {
-        orderId: orderId.toString(),
-        buyer: data[2],
-        seller: data[1],
-        amount: data[3],
-      });
-      break;
-    case "confirmed":
-      // Notify farmer: campaign funded (payment released)
-      notifyUser(
-        data[2],
-        `Campaign Funded! Buyer confirmed receipt for order #${orderId}. Payment has been released.`,
-        `Delivery confirmed: payment was released for order #${orderId}.`,
-        orderId,
-        "campaign_funded",
-      );
-      wsManager.broadcast("order:confirmed", {
-        orderId: orderId.toString(),
-        buyer: data[2],
-      });
-      break;
-    case "refunded":
-      notifyUser(
-        data[1],
-        `Refund issued: order #${orderId} expired and funds were returned.`,
-        orderId,
-        action,
-      );
-      wsManager.broadcast("order:refunded", {
-        orderId: orderId.toString(),
-        seller: data[1],
-      });
-      break;
-  }
-}
-
-async function notifyUser(address: string, message: string, orderId: string, type: string) {
-  try {
-    const notification = await prisma.notification.create({
-      data: { walletAddress: address, message, orderId: orderId.toString(), type, isRead: false },
-    });
-    logger.info(`Notification saved to DB for ${address}: ID ${notification.id}`);
-  } catch (error) {
-    logger.error("Failed to save notification to DB:", error);
-  }
-}
-  NotificationService.notifyFromEscrowEvent({
-    action,
-    orderId,
-    buyerAddress: data[1],
-    farmerAddress: data[2],
-    amount: data[3]?.toString?.(),
-    token: data[4],
-  });
+  }, POLL_INTERVAL_MS);
 }

--- a/server/src/services/events/blockchainEventParser.ts
+++ b/server/src/services/events/blockchainEventParser.ts
@@ -6,7 +6,9 @@ const SUPPORTED_EVENT_TYPES = new Set<IndexedEventType>([
   "campaign.invested",
   "campaign.settled",
   "order.created",
+  "order.delivered",
   "order.confirmed",
+  "order.refunded",
 ]);
 
 function toStringValue(value: unknown): string | undefined {
@@ -17,8 +19,7 @@ function toStringValue(value: unknown): string | undefined {
 function toDateValue(value: unknown): Date {
   if (value instanceof Date) return value;
   if (typeof value === "number") {
-    const millis = value > 1_000_000_000_000 ? value : value * 1000;
-    return new Date(millis);
+    return new Date(value > 1_000_000_000_000 ? value : value * 1000);
   }
   if (typeof value === "string") {
     const parsed = Number.parseInt(value, 10);
@@ -30,8 +31,7 @@ function toDateValue(value: unknown): Date {
 }
 
 function getEventIndex(eventId: string): number {
-  const parts = eventId.split("-");
-  const parsed = Number.parseInt(parts[1] ?? "", 10);
+  const parsed = Number.parseInt(eventId.split("-")[1] ?? "", 10);
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
@@ -44,9 +44,7 @@ export class BlockchainEventParser {
     topic: string[];
     value: string;
   }): IndexedEvent | null {
-    const topics = rawEvent.topic.map((entry) =>
-      scValToNative(xdr.ScVal.fromXDR(entry, "base64")),
-    );
+    const topics = rawEvent.topic.map((t) => scValToNative(xdr.ScVal.fromXDR(t, "base64")));
     const value = scValToNative(xdr.ScVal.fromXDR(rawEvent.value, "base64"));
     return this.parseDecoded(topics, value, rawEvent);
   }
@@ -68,8 +66,8 @@ export class BlockchainEventParser {
     const common = {
       sourceEventId: meta.id,
       eventType,
-      entity: entity as "campaign" | "order",
-      action: action as "created" | "invested" | "settled" | "confirmed",
+      entity: entity as IndexedEvent["entity"],
+      action: action as IndexedEvent["action"],
       ledger: meta.ledger,
       eventIndex: getEventIndex(meta.id),
       timestamp,
@@ -102,24 +100,51 @@ export class BlockchainEventParser {
           actorAddress: toStringValue(data[1]),
           status: toStringValue(data[2]) ?? "SETTLED",
         };
+
+      // Contract: publish((order, created), (order_id, buyer, farmer, amount, token))
+      // FundsLocked: funds are transferred into escrow at order creation.
       case "order.created":
         return {
           ...common,
           orderIdOnChain: toStringValue(data[0]),
-          actorAddress: toStringValue(data[1]),
-          secondaryAddress: toStringValue(data[2]),
+          actorAddress: toStringValue(data[1]),     // buyer
+          secondaryAddress: toStringValue(data[2]), // farmer
           amount: toStringValue(data[3]),
           token: toStringValue(data[4]),
           status: "PENDING",
         };
+
+      // Contract: publish((order, delivered), (order_id, farmer, buyer, delivery_timestamp))
+      case "order.delivered":
+        return {
+          ...common,
+          orderIdOnChain: toStringValue(data[0]),
+          actorAddress: toStringValue(data[1]),     // farmer
+          secondaryAddress: toStringValue(data[2]), // buyer
+          status: "DELIVERED",
+        };
+
+      // Contract: publish((order, confirmed), (order_id, buyer, farmer))
+      // DeliveryConfirmed: buyer confirms receipt, payment released to farmer.
       case "order.confirmed":
         return {
           ...common,
           orderIdOnChain: toStringValue(data[0]),
-          actorAddress: toStringValue(data[1]),
-          secondaryAddress: toStringValue(data[2]),
-          status: "CONFIRMED",
+          actorAddress: toStringValue(data[1]),     // buyer
+          secondaryAddress: toStringValue(data[2]), // farmer
+          status: "COMPLETED",
         };
+
+      // Contract: publish((order, refunded), (order_id, buyer))
+      // RefundIssued: expired order refunded back to buyer.
+      case "order.refunded":
+        return {
+          ...common,
+          orderIdOnChain: toStringValue(data[0]),
+          actorAddress: toStringValue(data[1]),     // buyer
+          status: "REFUNDED",
+        };
+
       default:
         return null;
     }

--- a/server/src/services/events/blockchainEventPersistenceService.ts
+++ b/server/src/services/events/blockchainEventPersistenceService.ts
@@ -128,17 +128,45 @@ export class BlockchainEventPersistenceService {
           },
         });
         return;
+      case "order.delivered":
+        await tx.order.upsert({
+          where: { orderIdOnChain: event.orderIdOnChain },
+          update: { status: "DELIVERED" },
+          create: {
+            orderIdOnChain: event.orderIdOnChain ?? "",
+            buyerAddress: event.secondaryAddress ?? "", // buyer is secondaryAddress for delivered
+            sellerAddress: event.actorAddress ?? "",    // farmer is actorAddress for delivered
+            amount: "0",
+            token: "",
+            status: "DELIVERED",
+          },
+        });
+        return;
       case "order.confirmed":
         await tx.order.upsert({
           where: { orderIdOnChain: event.orderIdOnChain },
-          update: { status: "CONFIRMED" },
+          update: { status: "COMPLETED" },
           create: {
             orderIdOnChain: event.orderIdOnChain ?? "",
             buyerAddress: event.actorAddress ?? "",
             sellerAddress: event.secondaryAddress ?? "",
-            amount: event.amount ?? "0",
-            token: event.token ?? "",
-            status: "CONFIRMED",
+            amount: "0",
+            token: "",
+            status: "COMPLETED",
+          },
+        });
+        return;
+      case "order.refunded":
+        await tx.order.upsert({
+          where: { orderIdOnChain: event.orderIdOnChain },
+          update: { status: "REFUNDED" },
+          create: {
+            orderIdOnChain: event.orderIdOnChain ?? "",
+            buyerAddress: event.actorAddress ?? "",
+            sellerAddress: "",
+            amount: "0",
+            token: "",
+            status: "REFUNDED",
           },
         });
         return;

--- a/server/src/services/notificationService.ts
+++ b/server/src/services/notificationService.ts
@@ -1,5 +1,9 @@
 import { prisma } from "../config/database.js";
 import { ApiError } from "../http/errors.js";
+import logger from "../config/logger.js";
+import { NotificationEventType } from "../enums/notificationEventType.js";
+import { buildNotificationMessage } from "../utils/notificationTemplates.js";
+import { wsManager } from "./wsManager.js";
 
 export interface NotificationRecord {
   id: string;
@@ -15,92 +19,6 @@ export interface ListNotificationsOptions {
   unreadOnly?: boolean;
   limit?: number;
 }
-
-function clampLimit(limit?: number): number {
-  if (!Number.isFinite(limit) || !limit) {
-    return 20;
-  }
-
-  return Math.min(Math.max(Math.trunc(limit), 1), 50);
-}
-
-function walletCandidates(walletAddress: string): string[] {
-  const values = new Set<string>([walletAddress]);
-  values.add(walletAddress.toLowerCase());
-  values.add(walletAddress.toUpperCase());
-  return Array.from(values);
-}
-
-export async function listNotifications(
-  walletAddress: string,
-  options: ListNotificationsOptions = {},
-): Promise<NotificationRecord[]> {
-  const unreadOnly = options.unreadOnly ?? true;
-  const limit = clampLimit(options.limit);
-  const walletMatches = walletCandidates(walletAddress);
-
-  return prisma.notification.findMany({
-    where: {
-      walletAddress: {
-        in: walletMatches,
-      },
-      ...(unreadOnly ? { isRead: false } : {}),
-    },
-    orderBy: {
-      createdAt: "asc",
-    },
-    take: limit,
-  });
-}
-
-export async function markNotificationsRead(
-  walletAddress: string,
-  ids: string[],
-): Promise<{ count: number }> {
-  if (ids.length === 0) {
-    return { count: 0 };
-  }
-
-  const notifications = await prisma.notification.findMany({
-    where: {
-      id: {
-        in: ids,
-      },
-    },
-    select: {
-      id: true,
-      walletAddress: true,
-    },
-  });
-
-  if (notifications.length !== ids.length) {
-    throw new ApiError(404, "Not Found", "One or more notifications were not found");
-  }
-
-  const walletMatches = walletCandidates(walletAddress);
-  const unauthorized = notifications.some(
-    (notification) => !walletMatches.includes(notification.walletAddress),
-  );
-
-  if (unauthorized) {
-    throw new ApiError(403, "Forbidden", "You cannot modify these notifications");
-  }
-
-  const result = await prisma.notification.updateMany({
-    where: {
-      id: {
-        in: ids,
-      },
-    },
-    data: {
-      isRead: true,
-    },
-  });
-
-  return { count: result.count };
-import logger from "../config/logger.js";
-import { NotificationEventType } from "../enums/notificationEventType.js";
-import { buildNotificationMessage } from "../utils/notificationTemplates.js";
 
 type NotificationPayload = {
   walletAddress: string;
@@ -124,57 +42,115 @@ type MappedNotification = {
   type: NotificationEventType;
 };
 
-const actionToNotifications: Record<string, (payload: EscrowEventPayload) => MappedNotification[]> = {
-  created: (payload) => [
-    ...(payload.farmerAddress
-      ? [{ walletAddress: payload.farmerAddress, type: NotificationEventType.ORDER_RECEIVED as const }]
-      : []),
-    ...(payload.farmerAddress
-      ? [{ walletAddress: payload.farmerAddress, type: NotificationEventType.NEW_INVESTMENT as const }]
-      : []),
+function clampLimit(limit?: number): number {
+  if (!Number.isFinite(limit) || !limit) return 20;
+  return Math.min(Math.max(Math.trunc(limit), 1), 50);
+}
+
+function walletCandidates(walletAddress: string): string[] {
+  return Array.from(new Set([walletAddress, walletAddress.toLowerCase(), walletAddress.toUpperCase()]));
+}
+
+/**
+ * Maps a contract action to the list of notifications that should be sent.
+ * - "created"   → OrderCreated (buyer) + FundsLocked (farmer)
+ * - "delivered" → no notification (internal state change)
+ * - "confirmed" → DeliveryConfirmed (farmer)
+ * - "refunded"  → RefundIssued (buyer)
+ */
+const actionToNotifications: Record<string, (p: EscrowEventPayload) => MappedNotification[]> = {
+  created: ({ buyerAddress, farmerAddress }) => [
+    ...(buyerAddress ? [{ walletAddress: buyerAddress, type: NotificationEventType.ORDER_CREATED }] : []),
+    ...(farmerAddress ? [{ walletAddress: farmerAddress, type: NotificationEventType.FUNDS_LOCKED }] : []),
   ],
-  confirmed: (payload) =>
-    payload.farmerAddress
-      ? [{ walletAddress: payload.farmerAddress, type: NotificationEventType.CAMPAIGN_FUNDED }]
-      : [],
-  refunded: (payload) =>
-    payload.buyerAddress
-      ? [{ walletAddress: payload.buyerAddress, type: NotificationEventType.HARVEST_COMPLETED }]
-      : [],
+  confirmed: ({ farmerAddress }) =>
+    farmerAddress ? [{ walletAddress: farmerAddress, type: NotificationEventType.DELIVERY_CONFIRMED }] : [],
+  refunded: ({ buyerAddress }) =>
+    buyerAddress ? [{ walletAddress: buyerAddress, type: NotificationEventType.REFUND_ISSUED }] : [],
 };
 
+export async function listNotifications(
+  walletAddress: string,
+  options: ListNotificationsOptions = {},
+): Promise<NotificationRecord[]> {
+  return prisma.notification.findMany({
+    where: {
+      walletAddress: { in: walletCandidates(walletAddress) },
+      ...(options.unreadOnly ?? true ? { isRead: false } : {}),
+    },
+    orderBy: { createdAt: "asc" },
+    take: clampLimit(options.limit),
+  });
+}
+
+export async function markNotificationsRead(
+  walletAddress: string,
+  ids: string[],
+): Promise<{ count: number }> {
+  if (ids.length === 0) return { count: 0 };
+
+  const notifications = await prisma.notification.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, walletAddress: true },
+  });
+
+  if (notifications.length !== ids.length) {
+    throw new ApiError(404, "Not Found", "One or more notifications were not found");
+  }
+
+  const walletMatches = walletCandidates(walletAddress);
+  if (notifications.some((n) => !walletMatches.includes(n.walletAddress))) {
+    throw new ApiError(403, "Forbidden", "You cannot modify these notifications");
+  }
+
+  const result = await prisma.notification.updateMany({
+    where: { id: { in: ids } },
+    data: { isRead: true },
+  });
+
+  return { count: result.count };
+}
+
 export class NotificationService {
-  static async notify(payload: NotificationPayload) {
+  static async notify(payload: NotificationPayload): Promise<void> {
     try {
-      return await prisma.notification.create({
+      const message = buildNotificationMessage(payload.type, {
+        orderId: payload.orderId,
+        amount: payload.amount,
+        token: payload.token,
+      });
+
+      const record = await prisma.notification.create({
         data: {
           walletAddress: payload.walletAddress,
-          message: buildNotificationMessage(payload.type, {
-            orderId: payload.orderId,
-            amount: payload.amount,
-            token: payload.token,
-          }),
+          message,
           orderId: payload.orderId,
           type: payload.type,
           isRead: false,
         },
       });
+
+      // Push real-time notification to the wallet owner via WebSocket
+      wsManager.broadcastTo(payload.walletAddress, "notification:new", {
+        id: record.id,
+        type: payload.type,
+        message,
+        orderId: payload.orderId,
+      });
     } catch (error) {
       logger.error("Failed to create notification", error);
-      return null;
     }
   }
 
-  static async notifyFromEscrowEvent(payload: EscrowEventPayload) {
+  static async notifyFromEscrowEvent(payload: EscrowEventPayload): Promise<void> {
     const mapper = actionToNotifications[payload.action];
     if (!mapper) return;
 
-    const notifications = mapper(payload);
     await Promise.all(
-      notifications.map((notification) =>
+      mapper(payload).map((n) =>
         NotificationService.notify({
-          walletAddress: notification.walletAddress,
-          type: notification.type,
+          walletAddress: n.walletAddress,
+          type: n.type,
           orderId: payload.orderId,
           amount: payload.amount,
           token: payload.token,
@@ -182,23 +158,10 @@ export class NotificationService {
       ),
     );
   }
-}
 
-import { SocketService } from "./socketService.js";
-import logger from "../config/logger.js";
-
-export class NotificationService {
-  /**
-   * Notify users about order-related events.
-   * @param event The event type (e.g., 'dispute_opened', 'dispute_resolved')
-   * @param data The payload for the notification
-   */
-  public static async notifyOrderEvent(event: string, data: any) {
-    logger.info(`[NotificationService]: Sending notification for event: ${event}`);
-    
-    // Emit via WebSocket
-    SocketService.emit(event, data);
-
-    // Future extension: Add logic to send emails, push notifications, etc.
+  /** Generic order-event notification (used by ingestion pipeline). */
+  static async notifyOrderEvent(event: string, data: any): Promise<void> {
+    logger.info(`[NotificationService] Emitting event: ${event}`);
+    wsManager.broadcast(`order:${event}`, data);
   }
 }

--- a/server/src/types/indexedEvent.ts
+++ b/server/src/types/indexedEvent.ts
@@ -3,13 +3,15 @@ export type IndexedEventType =
   | "campaign.invested"
   | "campaign.settled"
   | "order.created"
-  | "order.confirmed";
+  | "order.delivered"
+  | "order.confirmed"
+  | "order.refunded";
 
 export interface IndexedEvent {
   sourceEventId: string;
   eventType: IndexedEventType;
   entity: "campaign" | "order";
-  action: "created" | "invested" | "settled" | "confirmed";
+  action: "created" | "invested" | "settled" | "delivered" | "confirmed" | "refunded";
   ledger: number;
   eventIndex: number;
   timestamp: Date;

--- a/server/src/utils/notificationTemplates.ts
+++ b/server/src/utils/notificationTemplates.ts
@@ -7,14 +7,22 @@ type NotificationTemplateInput = {
 };
 
 const templateByType: Record<NotificationEventType, (input: NotificationTemplateInput) => string> = {
+  [NotificationEventType.ORDER_CREATED]: ({ orderId, amount, token }) =>
+    `Order #${orderId} created${amount && token ? ` for ${amount} ${token}` : ""}.`,
+  [NotificationEventType.FUNDS_LOCKED]: ({ orderId, amount, token }) =>
+    `Funds locked in escrow for order #${orderId}${amount && token ? `: ${amount} ${token}` : ""}.`,
+  [NotificationEventType.DELIVERY_CONFIRMED]: ({ orderId }) =>
+    `Delivery confirmed for order #${orderId}. Payment has been released to the farmer.`,
+  [NotificationEventType.REFUND_ISSUED]: ({ orderId }) =>
+    `Refund issued for order #${orderId}. Funds have been returned to the buyer.`,
+  [NotificationEventType.ORDER_RECEIVED]: ({ orderId, amount, token }) =>
+    `Order received #${orderId}${amount && token ? `: ${amount} ${token}` : ""}.`,
   [NotificationEventType.NEW_INVESTMENT]: ({ orderId, amount, token }) =>
     `New investment recorded for order #${orderId}${amount && token ? `: ${amount} ${token}` : ""}.`,
   [NotificationEventType.CAMPAIGN_FUNDED]: ({ orderId }) =>
     `Campaign funded for order #${orderId}.`,
   [NotificationEventType.HARVEST_COMPLETED]: ({ orderId }) =>
     `Harvest completed for order #${orderId}.`,
-  [NotificationEventType.ORDER_RECEIVED]: ({ orderId, amount, token }) =>
-    `Order received #${orderId}${amount && token ? `: ${amount} ${token}` : ""}.`,
 };
 
 export function buildNotificationMessage(
@@ -23,4 +31,3 @@ export function buildNotificationMessage(
 ): string {
   return templateByType[type](input);
 }
-


### PR DESCRIPTION
- Rewrite contractWatcher: clean poll loop, correct event decoding, handles OrderCreated/FundsLocked/DeliveryConfirmed/RefundIssued
- Fix BlockchainEventParser: add order.delivered + order.refunded
- Fix BlockchainEventPersistenceService: persist all four order events
- Fix NotificationService: consolidate duplicate class, wire new types
- Add NotificationEventType: ORDER_CREATED, FUNDS_LOCKED, DELIVERY_CONFIRMED, REFUND_ISSUED
- Add IndexedEventType: order.delivered, order.refunded
- Add notification templates for all new event types

Closes #42