### PR TITLE
feat(backend): implement WebSocket notification (#49)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -25,3 +25,6 @@ JWT_SECRET="YOUR_JWT_SECRET_MIN_32_CHARS"
 # Stellar Soroban contract watcher
 CONTRACT_ID="YOUR_SOROBAN_CONTRACT_ID"
 RPC_URL="https://soroban-testnet.stellar.org"
+
+# WebSocket server path (clients connect to ws://host:PORT/ws)
+WS_PATH="/ws"

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -11,19 +11,17 @@ requiredEnvs.forEach((key) => {
 export const config = {
   port: process.env['PORT'] ?? 5000,
   nodeEnv: process.env['NODE_ENV'] ?? 'development',
-  redisUrl: process.env["REDIS_URL"] ?? "redis://127.0.0.1:6379",
-  runWorkers: (process.env["RUN_WORKERS"] ?? "").toLowerCase() === "true",
-  /** If set, GET /metrics requires x-metrics-api-key or Authorization: Bearer */
-  metricsApiKey: process.env["METRICS_API_KEY"]?.trim() || "",
+  redisUrl: process.env['REDIS_URL'] ?? 'redis://127.0.0.1:6379',
+  runWorkers: (process.env['RUN_WORKERS'] ?? '').toLowerCase() === 'true',
+  metricsApiKey: process.env['METRICS_API_KEY']?.trim() || '',
   supabaseUrl: process.env['SUPABASE_URL'] ?? '',
   supabaseAnonKey: process.env['SUPABASE_ANON_KEY'] ?? '',
   supabaseServiceRoleKey: process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '',
   productImagesBucket: process.env['SUPABASE_PRODUCT_IMAGES_BUCKET'] ?? 'product-images',
   productImagePlaceholderUrl: process.env['PRODUCT_IMAGE_PLACEHOLDER_URL'] ?? 'https://placehold.co/800x800/png?text=No+Image',
-  jwtSecret: process.env['JWT_SECRET'] ?? 'dev-secret',
+  jwtSecret: process.env['JWT_SECRET'] ?? 'changeme',
   contractId: process.env['CONTRACT_ID'] ?? '',
   rpcUrl: process.env['RPC_URL'] ?? 'https://soroban-testnet.stellar.org',
-  jwtSecret: process.env['JWT_SECRET'] ?? 'changeme',
-  productImagePlaceholderUrl:
-    process.env['PRODUCT_IMAGE_PLACEHOLDER_URL'] ?? 'https://placehold.co/800x800/png?text=No+Image',
+  /** WebSocket server path */
+  wsPath: process.env['WS_PATH'] ?? '/ws',
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,32 +5,34 @@ import { config } from "./config/index.js";
 import { connectDb } from "./config/database.js";
 import { startContractWatcher } from "./services/contractWatcher.js";
 import { startWorkers } from "./queues/workers.js";
-import { SocketService } from "./services/socketService.js";
+import { wsManager } from "./services/wsManager.js";
 
 async function bootstrap() {
   try {
     await connectDb();
-    startContractWatcher();
+
+    const server = http.createServer(app);
+
+    // Attach WebSocket server — must happen before server.listen
+    wsManager.init(server);
+
+    // Start Soroban event listener (blockchain → indexer → WebSocket → frontend)
+    await startContractWatcher();
 
     const runningWorkers = config.runWorkers ? startWorkers() : null;
 
-    app.listen(config.port, () => {
-    const server = http.createServer(app);
-    SocketService.initialize(server);
     server.listen(config.port, () => {
-      logger.info(
-        `[server]: Server is running at http://localhost:${config.port}`,
-      );
+      logger.info(`[server]: Server is running at http://localhost:${config.port}`);
+      logger.info(`[server]: WebSocket accepting connections at ws://localhost:${config.port}${config.wsPath}`);
     });
 
     const shutdown = async (signal: string) => {
       logger.warn(`Shutdown signal received: ${signal}`);
       if (runningWorkers) await runningWorkers.close();
-      process.exit(0);
+      server.close(() => process.exit(0));
     };
     process.on("SIGINT", () => void shutdown("SIGINT"));
     process.on("SIGTERM", () => void shutdown("SIGTERM"));
-    wsManager.init(server);
   } catch (error) {
     logger.error("Critical failure during startup:", error);
     process.exit(1);

--- a/server/src/services/notificationService.ts
+++ b/server/src/services/notificationService.ts
@@ -1,5 +1,9 @@
 import { prisma } from "../config/database.js";
 import { ApiError } from "../http/errors.js";
+import logger from "../config/logger.js";
+import { NotificationEventType } from "../enums/notificationEventType.js";
+import { buildNotificationMessage } from "../utils/notificationTemplates.js";
+import { wsManager } from "./wsManager.js";
 
 export interface NotificationRecord {
   id: string;
@@ -15,92 +19,6 @@ export interface ListNotificationsOptions {
   unreadOnly?: boolean;
   limit?: number;
 }
-
-function clampLimit(limit?: number): number {
-  if (!Number.isFinite(limit) || !limit) {
-    return 20;
-  }
-
-  return Math.min(Math.max(Math.trunc(limit), 1), 50);
-}
-
-function walletCandidates(walletAddress: string): string[] {
-  const values = new Set<string>([walletAddress]);
-  values.add(walletAddress.toLowerCase());
-  values.add(walletAddress.toUpperCase());
-  return Array.from(values);
-}
-
-export async function listNotifications(
-  walletAddress: string,
-  options: ListNotificationsOptions = {},
-): Promise<NotificationRecord[]> {
-  const unreadOnly = options.unreadOnly ?? true;
-  const limit = clampLimit(options.limit);
-  const walletMatches = walletCandidates(walletAddress);
-
-  return prisma.notification.findMany({
-    where: {
-      walletAddress: {
-        in: walletMatches,
-      },
-      ...(unreadOnly ? { isRead: false } : {}),
-    },
-    orderBy: {
-      createdAt: "asc",
-    },
-    take: limit,
-  });
-}
-
-export async function markNotificationsRead(
-  walletAddress: string,
-  ids: string[],
-): Promise<{ count: number }> {
-  if (ids.length === 0) {
-    return { count: 0 };
-  }
-
-  const notifications = await prisma.notification.findMany({
-    where: {
-      id: {
-        in: ids,
-      },
-    },
-    select: {
-      id: true,
-      walletAddress: true,
-    },
-  });
-
-  if (notifications.length !== ids.length) {
-    throw new ApiError(404, "Not Found", "One or more notifications were not found");
-  }
-
-  const walletMatches = walletCandidates(walletAddress);
-  const unauthorized = notifications.some(
-    (notification) => !walletMatches.includes(notification.walletAddress),
-  );
-
-  if (unauthorized) {
-    throw new ApiError(403, "Forbidden", "You cannot modify these notifications");
-  }
-
-  const result = await prisma.notification.updateMany({
-    where: {
-      id: {
-        in: ids,
-      },
-    },
-    data: {
-      isRead: true,
-    },
-  });
-
-  return { count: result.count };
-import logger from "../config/logger.js";
-import { NotificationEventType } from "../enums/notificationEventType.js";
-import { buildNotificationMessage } from "../utils/notificationTemplates.js";
 
 type NotificationPayload = {
   walletAddress: string;
@@ -124,57 +42,120 @@ type MappedNotification = {
   type: NotificationEventType;
 };
 
-const actionToNotifications: Record<string, (payload: EscrowEventPayload) => MappedNotification[]> = {
-  created: (payload) => [
-    ...(payload.farmerAddress
-      ? [{ walletAddress: payload.farmerAddress, type: NotificationEventType.ORDER_RECEIVED as const }]
-      : []),
-    ...(payload.farmerAddress
-      ? [{ walletAddress: payload.farmerAddress, type: NotificationEventType.NEW_INVESTMENT as const }]
-      : []),
-  ],
-  confirmed: (payload) =>
-    payload.farmerAddress
-      ? [{ walletAddress: payload.farmerAddress, type: NotificationEventType.CAMPAIGN_FUNDED }]
-      : [],
-  refunded: (payload) =>
-    payload.buyerAddress
-      ? [{ walletAddress: payload.buyerAddress, type: NotificationEventType.HARVEST_COMPLETED }]
-      : [],
+function clampLimit(limit?: number): number {
+  if (!Number.isFinite(limit) || !limit) return 20;
+  return Math.min(Math.max(Math.trunc(limit), 1), 50);
+}
+
+function walletCandidates(walletAddress: string): string[] {
+  return Array.from(new Set([walletAddress, walletAddress.toLowerCase(), walletAddress.toUpperCase()]));
+}
+
+/**
+ * Maps a contract action to the notifications that should be dispatched.
+ *   created   → ORDER_RECEIVED (farmer) + NEW_INVESTMENT (farmer)
+ *   confirmed → CAMPAIGN_FUNDED (farmer)
+ *   refunded  → HARVEST_COMPLETED (buyer)
+ */
+const actionToNotifications: Record<string, (p: EscrowEventPayload) => MappedNotification[]> = {
+  created: ({ farmerAddress }) => farmerAddress ? [
+    { walletAddress: farmerAddress, type: NotificationEventType.ORDER_RECEIVED },
+    { walletAddress: farmerAddress, type: NotificationEventType.NEW_INVESTMENT },
+  ] : [],
+  confirmed: ({ farmerAddress }) =>
+    farmerAddress ? [{ walletAddress: farmerAddress, type: NotificationEventType.CAMPAIGN_FUNDED }] : [],
+  refunded: ({ buyerAddress }) =>
+    buyerAddress ? [{ walletAddress: buyerAddress, type: NotificationEventType.HARVEST_COMPLETED }] : [],
 };
 
+export async function listNotifications(
+  walletAddress: string,
+  options: ListNotificationsOptions = {},
+): Promise<NotificationRecord[]> {
+  return prisma.notification.findMany({
+    where: {
+      walletAddress: { in: walletCandidates(walletAddress) },
+      ...(options.unreadOnly ?? true ? { isRead: false } : {}),
+    },
+    orderBy: { createdAt: "asc" },
+    take: clampLimit(options.limit),
+  });
+}
+
+export async function markNotificationsRead(
+  walletAddress: string,
+  ids: string[],
+): Promise<{ count: number }> {
+  if (ids.length === 0) return { count: 0 };
+
+  const notifications = await prisma.notification.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, walletAddress: true },
+  });
+
+  if (notifications.length !== ids.length) {
+    throw new ApiError(404, "Not Found", "One or more notifications were not found");
+  }
+
+  const walletMatches = walletCandidates(walletAddress);
+  if (notifications.some((n) => !walletMatches.includes(n.walletAddress))) {
+    throw new ApiError(403, "Forbidden", "You cannot modify these notifications");
+  }
+
+  const result = await prisma.notification.updateMany({
+    where: { id: { in: ids } },
+    data: { isRead: true },
+  });
+
+  return { count: result.count };
+}
+
 export class NotificationService {
-  static async notify(payload: NotificationPayload) {
+  /**
+   * Persist a notification to the DB and push it to the wallet owner via WebSocket.
+   */
+  static async notify(payload: NotificationPayload): Promise<void> {
     try {
-      return await prisma.notification.create({
+      const message = buildNotificationMessage(payload.type, {
+        orderId: payload.orderId,
+        amount: payload.amount,
+        token: payload.token,
+      });
+
+      const record = await prisma.notification.create({
         data: {
           walletAddress: payload.walletAddress,
-          message: buildNotificationMessage(payload.type, {
-            orderId: payload.orderId,
-            amount: payload.amount,
-            token: payload.token,
-          }),
+          message,
           orderId: payload.orderId,
           type: payload.type,
           isRead: false,
         },
       });
+
+      // Push real-time notification to the authenticated wallet owner
+      wsManager.broadcastTo(payload.walletAddress, "notification:new", {
+        id: record.id,
+        type: payload.type,
+        message,
+        orderId: payload.orderId,
+      });
     } catch (error) {
       logger.error("Failed to create notification", error);
-      return null;
     }
   }
 
-  static async notifyFromEscrowEvent(payload: EscrowEventPayload) {
+  /**
+   * Derive and dispatch all notifications for a given escrow contract event.
+   */
+  static async notifyFromEscrowEvent(payload: EscrowEventPayload): Promise<void> {
     const mapper = actionToNotifications[payload.action];
     if (!mapper) return;
 
-    const notifications = mapper(payload);
     await Promise.all(
-      notifications.map((notification) =>
+      mapper(payload).map((n) =>
         NotificationService.notify({
-          walletAddress: notification.walletAddress,
-          type: notification.type,
+          walletAddress: n.walletAddress,
+          type: n.type,
           orderId: payload.orderId,
           amount: payload.amount,
           token: payload.token,
@@ -182,23 +163,13 @@ export class NotificationService {
       ),
     );
   }
-}
 
-import { SocketService } from "./socketService.js";
-import logger from "../config/logger.js";
-
-export class NotificationService {
   /**
-   * Notify users about order-related events.
-   * @param event The event type (e.g., 'dispute_opened', 'dispute_resolved')
-   * @param data The payload for the notification
+   * Broadcast a generic order event to all connected WebSocket clients.
+   * Used by the ingestion pipeline for dispute/resolution events.
    */
-  public static async notifyOrderEvent(event: string, data: any) {
-    logger.info(`[NotificationService]: Sending notification for event: ${event}`);
-    
-    // Emit via WebSocket
-    SocketService.emit(event, data);
-
-    // Future extension: Add logic to send emails, push notifications, etc.
+  static notifyOrderEvent(event: string, data: unknown): void {
+    logger.info(`[NotificationService] Broadcasting event: ${event}`);
+    wsManager.broadcast(`order:${event}`, data);
   }
 }


### PR DESCRIPTION
- Fix bootstrap in index.ts: single http.createServer, wsManager.init before listen, remove duplicate app.listen + SocketService
- Fix config/index.ts: remove duplicate keys, add WS_PATH
- Fix notificationService.ts: remove duplicate NotificationService class, replace SocketService.emit with wsManager.broadcastTo for targeted per-wallet real-time delivery; notifyOrderEvent broadcasts to all clients
- Add WS_PATH to .env.example

Architecture: blockchain event → indexer → wsManager → frontend
  - notification:new  → sent to the specific wallet owner
  - order:*           → broadcast to all connected clients

Closes #49