### PR TITLE
feat(frontend): routing system, wallet module, transaction hook, product listing page

### DIFF
--- a/agro-production/client/src/app/campaign/[id]/page.tsx
+++ b/agro-production/client/src/app/campaign/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function CampaignAliasPage({ params }: Props) {
+  const { id } = await params;
+  redirect(`/campaigns/${id}`);
+}

--- a/agro-production/client/src/app/dashboard/page.tsx
+++ b/agro-production/client/src/app/dashboard/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { useWallet } from "@/context/WalletContext";
+import WalletConnect from "@/components/WalletConnect";
+
+function shortAddr(addr: string) {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export default function DashboardPage() {
+  const { address, connected } = useWallet();
+
+  if (!connected || !address) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[50vh] gap-6 text-center">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground mb-2">My Dashboard</h1>
+          <p className="text-muted">Connect your wallet to view your activity.</p>
+        </div>
+        <WalletConnect />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-foreground">My Dashboard</h1>
+        <WalletConnect />
+      </div>
+
+      <div className="bg-surface border border-border rounded-xl p-5">
+        <p className="text-sm text-muted mb-1">Connected address</p>
+        <p className="font-mono text-sm text-foreground break-all">{address}</p>
+        <p className="font-mono text-xs text-muted mt-1">({shortAddr(address)})</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Link
+          href="/orders"
+          className="bg-surface border border-border rounded-xl p-5 hover:border-primary-400 transition-colors block"
+        >
+          <h2 className="font-semibold text-foreground mb-1">My Orders</h2>
+          <p className="text-sm text-muted">View your purchase history and order status.</p>
+        </Link>
+        <Link
+          href="/campaigns"
+          className="bg-surface border border-border rounded-xl p-5 hover:border-primary-400 transition-colors block"
+        >
+          <h2 className="font-semibold text-foreground mb-1">Browse Campaigns</h2>
+          <p className="text-sm text-muted">Discover and fund active agricultural campaigns.</p>
+        </Link>
+        <Link
+          href="/marketplace"
+          className="bg-surface border border-border rounded-xl p-5 hover:border-primary-400 transition-colors block"
+        >
+          <h2 className="font-semibold text-foreground mb-1">Marketplace</h2>
+          <p className="text-sm text-muted">Browse available produce and farm products.</p>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/agro-production/client/src/app/home/page.tsx
+++ b/agro-production/client/src/app/home/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center gap-8">
+      <div>
+        <h1 className="text-4xl font-bold text-foreground mb-3">
+          🌾 Agro Production
+        </h1>
+        <p className="text-muted text-lg max-w-xl">
+          Fund agricultural campaigns, buy produce directly from farmers, and earn
+          on-chain returns — all powered by Stellar smart contracts.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-4 justify-center">
+        <Link
+          href="/marketplace"
+          className="bg-primary-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors"
+        >
+          Browse Marketplace
+        </Link>
+        <Link
+          href="/campaigns"
+          className="border border-border text-foreground px-6 py-2.5 rounded-lg font-medium hover:bg-surface transition-colors"
+        >
+          View Campaigns
+        </Link>
+        <Link
+          href="/dashboard"
+          className="border border-border text-foreground px-6 py-2.5 rounded-lg font-medium hover:bg-surface transition-colors"
+        >
+          My Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/agro-production/client/src/app/marketplace/page.tsx
+++ b/agro-production/client/src/app/marketplace/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { fetchProducts, formatPrice } from "@/services/productService";
+import type { Product, ProductCategory } from "@/types";
+
+const CATEGORIES: { label: string; value: ProductCategory | "" }[] = [
+  { label: "All Categories", value: "" },
+  { label: "Grains", value: "GRAINS" },
+  { label: "Vegetables", value: "VEGETABLES" },
+  { label: "Fruits", value: "FRUITS" },
+  { label: "Livestock", value: "LIVESTOCK" },
+  { label: "Dairy", value: "DAIRY" },
+  { label: "Other", value: "OTHER" },
+];
+
+function ProductCard({ product }: { product: Product }) {
+  return (
+    <Link
+      href={`/product/${product.id}`}
+      className="bg-surface border border-border rounded-xl overflow-hidden hover:border-primary-400 hover:shadow-md transition-all block"
+    >
+      <div className="h-36 bg-neutral-100 flex items-center justify-center text-4xl">
+        {product.imageUrl ? (
+          <img
+            src={product.imageUrl}
+            alt={product.name}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <span>🌱</span>
+        )}
+      </div>
+      <div className="p-4 space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="font-semibold text-foreground leading-tight">{product.name}</h3>
+          <span className="text-xs bg-primary-50 text-primary-700 px-2 py-0.5 rounded-full whitespace-nowrap">
+            {product.category}
+          </span>
+        </div>
+        <p className="text-sm text-muted line-clamp-2">{product.description}</p>
+        <div className="flex items-center justify-between text-sm pt-1">
+          <span className="font-medium text-foreground">
+            {formatPrice(product.pricePerUnit)} XLM/{product.unit}
+          </span>
+          <span className="text-muted text-xs">{product.location}</span>
+        </div>
+        <p className="text-xs text-muted">
+          {product.quantity} {product.unit}(s) available
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+export default function MarketplacePage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [category, setCategory] = useState<ProductCategory | "">("");
+  const [location, setLocation] = useState("");
+  const [minPrice, setMinPrice] = useState("");
+  const [maxPrice, setMaxPrice] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchProducts({
+        category: category || undefined,
+        location: location || undefined,
+        minPrice: minPrice || undefined,
+        maxPrice: maxPrice || undefined,
+      });
+      setProducts(res.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load products");
+      setProducts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [category, location, minPrice, maxPrice]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Marketplace</h1>
+        <p className="text-muted text-sm mt-1">
+          Buy fresh produce directly from verified farmers.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-surface border border-border rounded-xl p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-muted mb-1">Category</label>
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value as ProductCategory | "")}
+            className="w-full text-sm border border-border rounded-lg px-2.5 py-1.5 bg-background text-foreground"
+          >
+            {CATEGORIES.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted mb-1">Location</label>
+          <input
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="e.g. Lagos, Kano"
+            className="w-full text-sm border border-border rounded-lg px-2.5 py-1.5 bg-background text-foreground placeholder:text-muted"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted mb-1">Min price (XLM)</label>
+          <input
+            type="number"
+            value={minPrice}
+            onChange={(e) => setMinPrice(e.target.value)}
+            min="0"
+            placeholder="0"
+            className="w-full text-sm border border-border rounded-lg px-2.5 py-1.5 bg-background text-foreground placeholder:text-muted"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted mb-1">Max price (XLM)</label>
+          <input
+            type="number"
+            value={maxPrice}
+            onChange={(e) => setMaxPrice(e.target.value)}
+            min="0"
+            placeholder="Any"
+            className="w-full text-sm border border-border rounded-lg px-2.5 py-1.5 bg-background text-foreground placeholder:text-muted"
+          />
+        </div>
+      </div>
+
+      {/* Results */}
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="bg-surface border border-border rounded-xl overflow-hidden animate-pulse">
+              <div className="h-36 bg-neutral-200" />
+              <div className="p-4 space-y-2">
+                <div className="h-4 bg-neutral-200 rounded w-3/4" />
+                <div className="h-3 bg-neutral-200 rounded w-full" />
+                <div className="h-3 bg-neutral-200 rounded w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <div className="text-center py-16">
+          <p className="text-red-600 text-sm mb-3">{error}</p>
+          <button
+            onClick={() => void load()}
+            className="text-sm text-primary-600 hover:underline"
+          >
+            Try again
+          </button>
+        </div>
+      ) : products.length === 0 ? (
+        <div className="text-center py-16 text-muted">
+          <p className="text-lg mb-1">No products found</p>
+          <p className="text-sm">Try adjusting your filters.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {products.map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/agro-production/client/src/app/page.tsx
+++ b/agro-production/client/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function Home() {
-  redirect("/campaigns");
+  redirect("/home");
 }

--- a/agro-production/client/src/app/product/[id]/page.tsx
+++ b/agro-production/client/src/app/product/[id]/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { fetchProduct, formatPrice } from "@/services/productService";
+import { useTransaction } from "@/hooks/useTransaction";
+import { buildCreateOrder } from "@/lib/contractService";
+import { useWallet } from "@/context/WalletContext";
+import WalletConnect from "@/components/WalletConnect";
+import type { Product } from "@/types";
+
+export default function ProductDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [product, setProduct] = useState<Product | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
+  const { address, connected } = useWallet();
+  const tx = useTransaction();
+
+  useEffect(() => {
+    if (!id) return;
+    fetchProduct(id)
+      .then(setProduct)
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : "Failed to load product")
+      )
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4 animate-pulse">
+        <div className="h-8 w-48 bg-neutral-200 rounded" />
+        <div className="h-64 bg-neutral-200 rounded-xl" />
+        <div className="h-24 bg-neutral-200 rounded-xl" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="border border-red-200 bg-red-50 rounded-xl p-6 text-red-700 text-sm">
+        {error}
+      </div>
+    );
+  }
+
+  if (!product) return null;
+
+  const unitPrice = BigInt(product.pricePerUnit || "0");
+  const totalPrice = unitPrice * BigInt(quantity);
+
+  async function handleOrder() {
+    if (!address || !product) return;
+    const campaignId = product.campaignId ?? "0";
+    await tx.execute(() => buildCreateOrder(address!, campaignId, totalPrice));
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2 text-sm text-muted">
+        <Link href="/marketplace" className="hover:text-foreground">
+          Marketplace
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">{product.name}</span>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="h-64 md:h-auto bg-neutral-100 rounded-xl flex items-center justify-center text-6xl">
+          {product.imageUrl ? (
+            <img
+              src={product.imageUrl}
+              alt={product.name}
+              className="w-full h-full object-cover rounded-xl"
+            />
+          ) : (
+            <span>🌱</span>
+          )}
+        </div>
+
+        <div className="space-y-5">
+          <div>
+            <span className="text-xs bg-primary-50 text-primary-700 px-2 py-0.5 rounded-full">
+              {product.category}
+            </span>
+            <h1 className="text-2xl font-bold text-foreground mt-2">{product.name}</h1>
+            <p className="text-sm text-muted mt-1">{product.description}</p>
+          </div>
+
+          <div className="space-y-1">
+            <p className="text-2xl font-semibold text-foreground">
+              {formatPrice(product.pricePerUnit)} XLM
+              <span className="text-sm font-normal text-muted"> / {product.unit}</span>
+            </p>
+            <p className="text-sm text-muted">
+              {product.quantity} {product.unit}(s) available · {product.location}
+            </p>
+            <p className="text-xs font-mono text-muted">
+              Farmer: {product.farmerAddress.slice(0, 6)}…{product.farmerAddress.slice(-4)}
+            </p>
+          </div>
+
+          {connected && address ? (
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">
+                  Quantity ({product.unit})
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={product.quantity}
+                  value={quantity}
+                  onChange={(e) =>
+                    setQuantity(Math.max(1, Math.min(product.quantity, Number(e.target.value))))
+                  }
+                  className="w-24 border border-border rounded-lg px-3 py-1.5 text-sm bg-background text-foreground"
+                />
+              </div>
+              <p className="text-sm text-muted">
+                Total:{" "}
+                <span className="font-semibold text-foreground">
+                  {formatPrice(String(totalPrice))} XLM
+                </span>
+              </p>
+
+              {tx.isSuccess && (
+                <div className="bg-green-50 border border-green-200 rounded-lg p-3 text-sm text-green-800">
+                  Order placed!{" "}
+                  {tx.txHash && (
+                    <span className="font-mono text-xs">
+                      Tx: {tx.txHash.slice(0, 12)}…
+                    </span>
+                  )}
+                </div>
+              )}
+              {tx.isError && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+                  {tx.error}
+                </div>
+              )}
+
+              <button
+                onClick={() => void handleOrder()}
+                disabled={tx.isPending || tx.isSuccess}
+                className="w-full bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors text-sm"
+              >
+                {tx.isPending ? "Processing…" : tx.isSuccess ? "Order Placed" : "Place Order"}
+              </button>
+              {tx.isError && (
+                <button
+                  onClick={tx.reset}
+                  className="w-full text-sm text-muted hover:text-foreground"
+                >
+                  Try again
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-sm text-muted">Connect your wallet to place an order.</p>
+              <WalletConnect />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/agro-production/client/src/components/NavBar.tsx
+++ b/agro-production/client/src/components/NavBar.tsx
@@ -1,45 +1,21 @@
 "use client";
 
 import Link from "next/link";
-import { useWallet } from "@/context/WalletContext";
-
-function shortAddr(addr: string) {
-  return `${addr.slice(0, 4)}…${addr.slice(-4)}`;
-}
+import WalletConnect from "@/components/WalletConnect";
 
 export default function NavBar() {
-  const { address, connected, loading, connect, disconnect } = useWallet();
-
   return (
     <nav className="border-b border-border bg-surface sticky top-0 z-10">
       <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between gap-4">
-        <Link href="/campaigns" className="font-bold text-lg text-primary-600 hover:text-primary-700">
+        <Link href="/home" className="font-bold text-lg text-primary-600 hover:text-primary-700">
           🌾 AgroProduction
         </Link>
         <div className="flex items-center gap-4 text-sm">
+          <Link href="/marketplace" className="text-muted hover:text-foreground">Marketplace</Link>
           <Link href="/campaigns" className="text-muted hover:text-foreground">Campaigns</Link>
           <Link href="/orders" className="text-muted hover:text-foreground">Orders</Link>
-          {connected && address ? (
-            <div className="flex items-center gap-2">
-              <span className="font-mono text-xs bg-primary-50 text-primary-700 px-2 py-1 rounded">
-                {shortAddr(address)}
-              </span>
-              <button
-                onClick={disconnect}
-                className="text-muted hover:text-foreground"
-              >
-                Disconnect
-              </button>
-            </div>
-          ) : (
-            <button
-              onClick={connect}
-              disabled={loading}
-              className="bg-primary-600 text-white px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
-            >
-              {loading ? "Connecting…" : "Connect Wallet"}
-            </button>
-          )}
+          <Link href="/dashboard" className="text-muted hover:text-foreground">Dashboard</Link>
+          <WalletConnect />
         </div>
       </div>
     </nav>

--- a/agro-production/client/src/components/WalletConnect.tsx
+++ b/agro-production/client/src/components/WalletConnect.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useWallet } from "@/context/WalletContext";
+
+function shortAddr(addr: string) {
+  return `${addr.slice(0, 4)}…${addr.slice(-4)}`;
+}
+
+interface WalletConnectProps {
+  className?: string;
+}
+
+export default function WalletConnect({ className = "" }: WalletConnectProps) {
+  const { address, connected, loading, error, connect, disconnect } = useWallet();
+
+  if (connected && address) {
+    return (
+      <div className={`flex items-center gap-2 ${className}`}>
+        <span
+          className="font-mono text-xs bg-primary-50 text-primary-700 border border-primary-200 px-2.5 py-1.5 rounded-lg"
+          title={address}
+        >
+          {shortAddr(address)}
+        </span>
+        <button
+          onClick={disconnect}
+          className="text-sm text-muted hover:text-foreground border border-border px-2.5 py-1.5 rounded-lg transition-colors"
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col items-start gap-1 ${className}`}>
+      <button
+        onClick={connect}
+        disabled={loading}
+        className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+      >
+        {loading ? "Connecting…" : "Connect Wallet"}
+      </button>
+      {error && (
+        <p className="text-xs text-red-600 max-w-xs">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/agro-production/client/src/hooks/useTransaction.ts
+++ b/agro-production/client/src/hooks/useTransaction.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { signAndSubmitTransaction } from "@/lib/signTransaction";
+
+export type TxStatus = "idle" | "building" | "signing" | "submitting" | "success" | "error";
+
+export interface TxState {
+  status: TxStatus;
+  txHash?: string;
+  error?: string;
+}
+
+export interface UseTransactionReturn extends TxState {
+  execute: (buildXdr: () => Promise<string>) => Promise<void>;
+  reset: () => void;
+  isIdle: boolean;
+  isPending: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+}
+
+const INITIAL_STATE: TxState = { status: "idle" };
+
+/**
+ * Hook that orchestrates the build → sign → submit flow for Soroban
+ * transactions. The caller provides a `buildXdr` function that returns
+ * the unsigned transaction XDR; this hook handles wallet signing,
+ * submission, and status tracking.
+ *
+ * Usage:
+ *   const tx = useTransaction();
+ *   await tx.execute(() => buildCreateOrder(buyer, campaignId, amount));
+ */
+export function useTransaction(): UseTransactionReturn {
+  const [state, setState] = useState<TxState>(INITIAL_STATE);
+
+  const execute = useCallback(async (buildXdr: () => Promise<string>) => {
+    setState({ status: "building" });
+    try {
+      const xdr = await buildXdr();
+
+      setState({ status: "signing" });
+      setState({ status: "submitting" });
+
+      const result = await signAndSubmitTransaction(xdr);
+
+      if (result.success) {
+        setState({ status: "success", txHash: result.txHash });
+      } else {
+        setState({ status: "error", error: result.error ?? "Transaction failed" });
+      }
+    } catch (err) {
+      setState({
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, []);
+
+  const reset = useCallback(() => setState(INITIAL_STATE), []);
+
+  return {
+    ...state,
+    execute,
+    reset,
+    isIdle: state.status === "idle",
+    isPending:
+      state.status === "building" ||
+      state.status === "signing" ||
+      state.status === "submitting",
+    isSuccess: state.status === "success",
+    isError: state.status === "error",
+  };
+}

--- a/agro-production/client/src/services/productService.ts
+++ b/agro-production/client/src/services/productService.ts
@@ -1,0 +1,40 @@
+import type { Product, ProductListResponse, ProductCategory } from "@/types";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api/v1";
+
+export interface ProductFilters {
+  category?: ProductCategory;
+  location?: string;
+  minPrice?: string;
+  maxPrice?: string;
+  page?: number;
+  limit?: number;
+}
+
+export async function fetchProducts(
+  filters: ProductFilters = {},
+): Promise<ProductListResponse> {
+  const query = new URLSearchParams();
+  if (filters.category) query.set("category", filters.category);
+  if (filters.location) query.set("location", filters.location);
+  if (filters.minPrice) query.set("minPrice", filters.minPrice);
+  if (filters.maxPrice) query.set("maxPrice", filters.maxPrice);
+  if (filters.page) query.set("page", String(filters.page));
+  if (filters.limit) query.set("limit", String(filters.limit));
+
+  const res = await fetch(`${API_BASE}/products?${query}`);
+  if (!res.ok) throw new Error(`Failed to fetch products: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchProduct(id: string): Promise<Product> {
+  const res = await fetch(`${API_BASE}/products/${id}`);
+  if (!res.ok) throw new Error(`Product not found: ${res.status}`);
+  return res.json();
+}
+
+export function formatPrice(raw: string): string {
+  const n = BigInt(raw || "0");
+  const xlm = Number(n) / 1e7;
+  return xlm.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}

--- a/agro-production/client/src/types/index.ts
+++ b/agro-production/client/src/types/index.ts
@@ -69,3 +69,36 @@ export interface CampaignListResponse {
     limit: number;
   };
 }
+
+export type ProductCategory =
+  | "GRAINS"
+  | "VEGETABLES"
+  | "FRUITS"
+  | "LIVESTOCK"
+  | "DAIRY"
+  | "OTHER";
+
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  category: ProductCategory;
+  pricePerUnit: string;
+  unit: string;
+  quantity: number;
+  location: string;
+  farmerAddress: string;
+  campaignId?: string;
+  imageUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductListResponse {
+  data: Product[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+  };
+}


### PR DESCRIPTION
## Summary

- Add `/home` landing page, `/dashboard` wallet-gated activity hub, `/campaign/:id` alias that redirects to the canonical `/campaigns/:id` URL, and update root `/` to redirect to `/home`; all routes accessible via updated NavBar that links Marketplace, Campaigns, Orders, and Dashboard
- Extract wallet connect/disconnect UI into a standalone `WalletConnect` component that renders the shortened address when connected and shows connection errors inline; update `NavBar` to use it
- Add `useTransaction` hook in `src/hooks/useTransaction.ts` that orchestrates the build → wallet-sign → submit pipeline using the existing `signAndSubmitTransaction` utility; exposes `isPending`, `isSuccess`, `isError`, `txHash`, `error`, and `reset()`
- Add `Product` and `ProductListResponse` types, `productService` with category/location/price filters, `/marketplace` grid page with filter controls and loading skeleton, and `/product/:id` detail page with quantity selector and order placement via `useTransaction`

## Test plan

- [ ] `/home` renders landing page with links to Marketplace, Campaigns, Dashboard
- [ ] `/` redirects to `/home`
- [ ] `/marketplace` renders filter controls and product grid (or empty state / error when API is unavailable)
- [ ] `/marketplace` category, location, and price filters narrow results
- [ ] `/product/:id` shows product detail and quantity selector
- [ ] `/product/:id` prompts wallet connect when no wallet is connected
- [ ] `/product/:id` places order via `useTransaction` and shows success/error feedback
- [ ] `/dashboard` redirects to connect screen when wallet is disconnected; shows address when connected
- [ ] `/campaign/:id` redirects to `/campaigns/:id`
- [ ] NavBar shows all nav links and WalletConnect button/address correctly
- [ ] Connecting and disconnecting wallet updates state across all pages

Closes #187
Closes #188
Closes #189
Closes #190