### PR TITLE
feat(backend): event listener resilience, env validation, route error handling, and expanded tests

### DIFF
--- a/agro-production/server/src/app.ts
+++ b/agro-production/server/src/app.ts
@@ -1,4 +1,4 @@
-import express, { type Request, type Response, type NextFunction } from 'express';
+import express, { type Request, type Response } from 'express';
 import cors from 'cors';
 import logger from './config/logger.js';
 import { config } from './config/index.js';
@@ -8,6 +8,7 @@ import campaignImageRoutes, {
 } from './routes/campaignImageRoutes.js';
 import campaignRoutes from './routes/campaigns.js';
 import orderRoutes from './routes/orders.js';
+import { globalErrorHandler } from './middleware/errors.js';
 
 const app = express();
 
@@ -38,9 +39,6 @@ app.use((_req: Request, res: Response) => {
 
 app.use(campaignImageErrorHandler);
 
-app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
-  logger.error('Unhandled request error', err);
-  res.status(500).json({ error: 'Internal server error' });
-});
+app.use(globalErrorHandler);
 
 export default app;

--- a/agro-production/server/src/config/index.ts
+++ b/agro-production/server/src/config/index.ts
@@ -1,32 +1,94 @@
 import 'dotenv/config';
 
+// ---------------------------------------------------------------------------
+// Required environment variables
+// These must be set in production; startup fails if any are missing.
+// ---------------------------------------------------------------------------
+const REQUIRED_IN_PRODUCTION = [
+  'DATABASE_URL',
+  'RPC_URL',
+  'PRODUCTION_CONTRACT_ID',
+  'ESCROW_CONTRACT_ID',
+] as const;
+
+function getEnv(key: string): string | undefined {
+  return process.env[key];
+}
+
+function requireEnv(key: string): string {
+  const value = getEnv(key);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}
+
+const isProduction = (process.env['NODE_ENV'] ?? 'development') === 'production';
+
+if (isProduction) {
+  const missing = REQUIRED_IN_PRODUCTION.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    // Fail hard so misconfigured deployments never silently run with bad state.
+    throw new Error(
+      `[config] Startup aborted — missing required environment variables in production:\n  ${missing.join('\n  ')}\n` +
+      `Set these in your deployment environment before starting the server.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config object
+//
+// Required variables:   must be present in production (enforced above).
+// Optional variables:   have safe defaults for local development.
+//
+// All required env vars must be documented here.
+// ---------------------------------------------------------------------------
 export const config = {
-  port: parseInt(process.env['PORT'] ?? '5001', 10),
-  nodeEnv: process.env['NODE_ENV'] ?? 'development',
-  logLevel: process.env['LOG_LEVEL'] ?? 'debug',
+  // Server
+  port: parseInt(getEnv('PORT') ?? '5001', 10),
+  nodeEnv: getEnv('NODE_ENV') ?? 'development',
+  logLevel: getEnv('LOG_LEVEL') ?? 'debug',
 
-  databaseUrl: process.env['DATABASE_URL'] ?? '',
+  // Database — required in production
+  // DATABASE_URL: PostgreSQL connection string e.g. postgresql://user:pass@host:5432/db
+  databaseUrl: isProduction ? requireEnv('DATABASE_URL') : (getEnv('DATABASE_URL') ?? ''),
 
-  rpcUrl: process.env['RPC_URL'] ?? 'https://soroban-testnet.stellar.org',
-  // Used by the upstream production watcher (single contract)
-  contractId: process.env['PRODUCTION_CONTRACT_ID'] ?? '',
-  // Used by our multi-contract Soroban event listener
-  escrowContractId: process.env['ESCROW_CONTRACT_ID'] ?? '',
+  // Stellar / Soroban RPC — required in production
+  // RPC_URL: Soroban RPC endpoint e.g. https://soroban-testnet.stellar.org
+  rpcUrl: isProduction
+    ? requireEnv('RPC_URL')
+    : (getEnv('RPC_URL') ?? 'https://soroban-testnet.stellar.org'),
+
+  // PRODUCTION_CONTRACT_ID: Stellar contract ID for the production escrow contract
+  contractId: isProduction
+    ? requireEnv('PRODUCTION_CONTRACT_ID')
+    : (getEnv('PRODUCTION_CONTRACT_ID') ?? ''),
+
+  // ESCROW_CONTRACT_ID: Stellar contract ID for the multi-contract escrow listener
+  escrowContractId: isProduction
+    ? requireEnv('ESCROW_CONTRACT_ID')
+    : (getEnv('ESCROW_CONTRACT_ID') ?? ''),
+
+  // PRODUCTION_ESCROW_CONTRACT_ID: falls back to PRODUCTION_CONTRACT_ID if not set
   productionEscrowContractId:
-    process.env['PRODUCTION_ESCROW_CONTRACT_ID'] ??
-    process.env['PRODUCTION_CONTRACT_ID'] ??
+    getEnv('PRODUCTION_ESCROW_CONTRACT_ID') ??
+    getEnv('PRODUCTION_CONTRACT_ID') ??
     '',
 
-  rateLimitWindowMs: parseInt(process.env['RATE_LIMIT_WINDOW_MS'] ?? '60000', 10),
-  rateLimitMaxRequests: parseInt(process.env['RATE_LIMIT_MAX_REQUESTS'] ?? '100', 10),
+  // Rate limiting
+  rateLimitWindowMs: parseInt(getEnv('RATE_LIMIT_WINDOW_MS') ?? '60000', 10),
+  rateLimitMaxRequests: parseInt(getEnv('RATE_LIMIT_MAX_REQUESTS') ?? '100', 10),
 
-  // Supabase — campaign image upload (Issue #155)
-  supabaseUrl: process.env['SUPABASE_URL'] ?? '',
-  supabaseAnonKey: process.env['SUPABASE_ANON_KEY'] ?? '',
-  supabaseServiceRoleKey: process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '',
-  campaignImagesBucket:
-    process.env['SUPABASE_CAMPAIGN_IMAGES_BUCKET'] ?? 'campaign-images',
+  // Supabase — campaign image upload
+  // SUPABASE_URL: Supabase project URL
+  // SUPABASE_ANON_KEY: Supabase anonymous/public key
+  // SUPABASE_SERVICE_ROLE_KEY: Supabase service role key (server-side only)
+  supabaseUrl: getEnv('SUPABASE_URL') ?? '',
+  supabaseAnonKey: getEnv('SUPABASE_ANON_KEY') ?? '',
+  supabaseServiceRoleKey: getEnv('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  campaignImagesBucket: getEnv('SUPABASE_CAMPAIGN_IMAGES_BUCKET') ?? 'campaign-images',
   campaignImagePlaceholderUrl:
-    process.env['CAMPAIGN_IMAGE_PLACEHOLDER_URL'] ??
+    getEnv('CAMPAIGN_IMAGE_PLACEHOLDER_URL') ??
     'https://placehold.co/800x800/png?text=No+Image',
 };

--- a/agro-production/server/src/events/parser.test.ts
+++ b/agro-production/server/src/events/parser.test.ts
@@ -160,5 +160,76 @@ describe("ProductionEventParser", () => {
       const event = ProductionEventParser.parse(raw);
       expect(event.timestamp).toBeInstanceOf(Date);
     });
+
+    it("stores rawId from the event id field", () => {
+      const raw = makeRaw("campaign", "settled", [1n, 0n], "777-2", 777);
+      const event = ProductionEventParser.parse(raw);
+      expect(event.rawId).toBe("777-2");
+    });
+
+    it("defaults eventIndex to 0 when id has no hyphen", () => {
+      const raw = makeRaw("campaign", "settled", [1n, 0n], "noindex", 100);
+      const event = ProductionEventParser.parse(raw);
+      expect(event.eventIndex).toBe(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("coerces numeric ScVal data to string", () => {
+      const raw = makeRaw("campaign", "created", [999n, "GFARMER", "GTOKEN", 5000n, 8888n]);
+      const event = ProductionEventParser.parse(raw);
+      if (event.action === "campaign.created") {
+        expect(typeof event.campaignId).toBe("string");
+        expect(event.campaignId).toBe("999");
+        expect(event.targetAmount).toBe("5000");
+      }
+    });
+
+    it("handles empty data array for generic events without throwing", () => {
+      const raw = makeRaw("campaign", "produce", [5n]);
+      expect(() => ProductionEventParser.parse(raw)).not.toThrow();
+    });
+
+    it("tryParse returns null for events with malformed value XDR", () => {
+      const raw: RawSorobanEvent = {
+        id: "1-0",
+        type: "contract",
+        ledger: 1,
+        ledgerClosedAt: new Date().toISOString(),
+        contractId: "C",
+        topic: [encodeSymbol("campaign"), encodeSymbol("created")],
+        value: "not-valid-base64-xdr!!!",
+      };
+      // parse throws, tryParse should swallow and return null
+      expect(ProductionEventParser.tryParse(raw)).toBeNull();
+    });
+
+    it("throws for order namespace with unknown verb", () => {
+      const raw = makeRaw("order", "cancelled", []);
+      expect(() => ProductionEventParser.parse(raw)).toThrow(/unknown action/);
+    });
+
+    it("tryParse returns null instead of throwing for order unknown verb", () => {
+      const raw = makeRaw("order", "cancelled", []);
+      expect(ProductionEventParser.tryParse(raw)).toBeNull();
+    });
+
+    it("parses order.created with zero-amount correctly", () => {
+      const raw = makeRaw("order", "created", [1n, "GBUYER", 2n, 0n]);
+      const event = ProductionEventParser.parse(raw);
+      if (event.action === "order.created") {
+        expect(event.amount).toBe("0");
+      }
+    });
+
+    it("parses campaign.invested with large i128 values without precision loss", () => {
+      const large = BigInt("170141183460469231731687303715884105727"); // i128 max
+      const raw = makeRaw("campaign", "invested", [1n, "GINVESTOR", large, large]);
+      const event = ProductionEventParser.parse(raw);
+      if (event.action === "campaign.invested") {
+        expect(event.amount).toBe(large.toString());
+        expect(event.totalRaised).toBe(large.toString());
+      }
+    });
   });
 });

--- a/agro-production/server/src/events/persister.test.ts
+++ b/agro-production/server/src/events/persister.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventPersister } from "./persister.js";
+import type {
+  CampaignCreatedEvent,
+  CampaignInvestedEvent,
+  CampaignSettledEvent,
+  GenericCampaignEvent,
+  OrderConfirmedEvent,
+  OrderCreatedEvent,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Mock Prisma and logger so tests stay unit-level and don't need a real DB.
+// ---------------------------------------------------------------------------
+vi.mock("../db/client.js", () => {
+  const tx = {
+    user: { upsert: vi.fn().mockResolvedValue({}) },
+    campaign: {
+      upsert: vi.fn().mockResolvedValue({ id: "camp-uuid" }),
+      findUnique: vi.fn().mockResolvedValue({
+        id: "camp-uuid",
+        onChainId: "1",
+        targetAmount: "10000",
+        totalRaised: "5000",
+        totalRevenue: "0",
+        status: "FUNDING",
+      }),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    investment: { upsert: vi.fn().mockResolvedValue({}) },
+    order: {
+      upsert: vi.fn().mockResolvedValue({}),
+      findUnique: vi.fn().mockResolvedValue({
+        id: "order-uuid",
+        onChainId: "10",
+        campaignId: "camp-uuid",
+        amount: "500",
+      }),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    transaction: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+    },
+  };
+
+  return {
+    prisma: {
+      transaction: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({}),
+      },
+      campaign: {
+        findUnique: vi.fn().mockResolvedValue({ id: "camp-uuid" }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      $transaction: vi.fn().mockImplementation((fn: (tx: typeof tx) => Promise<unknown>) =>
+        fn(tx),
+      ),
+    },
+  };
+});
+
+vi.mock("../config/logger.js", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../services/wsServer.js", () => ({ broadcast: vi.fn() }));
+
+// ---------------------------------------------------------------------------
+// Shared fixture builders
+// ---------------------------------------------------------------------------
+const baseEvent = {
+  ledger: 200,
+  eventIndex: 0,
+  timestamp: new Date("2024-06-01T00:00:00Z"),
+  rawId: "200-0",
+};
+
+function makeCampaignCreated(overrides?: Partial<CampaignCreatedEvent>): CampaignCreatedEvent {
+  return {
+    ...baseEvent,
+    action: "campaign.created",
+    campaignId: "1",
+    farmer: "GFARMER000000000000000000000000000000000000000000000000",
+    token: "GTOKEN000000000000000000000000000000000000000000000000AA",
+    targetAmount: "10000",
+    deadline: String(Math.floor(Date.now() / 1000) + 86400),
+    ...overrides,
+  };
+}
+
+function makeCampaignInvested(overrides?: Partial<CampaignInvestedEvent>): CampaignInvestedEvent {
+  return {
+    ...baseEvent,
+    action: "campaign.invested",
+    campaignId: "1",
+    investor: "GINVESTOR0000000000000000000000000000000000000000000000",
+    amount: "5000",
+    totalRaised: "5000",
+    ...overrides,
+  };
+}
+
+function makeCampaignSettled(overrides?: Partial<CampaignSettledEvent>): CampaignSettledEvent {
+  return {
+    ...baseEvent,
+    action: "campaign.settled",
+    campaignId: "1",
+    totalRevenue: "2000",
+    ...overrides,
+  };
+}
+
+function makeOrderCreated(overrides?: Partial<OrderCreatedEvent>): OrderCreatedEvent {
+  return {
+    ...baseEvent,
+    action: "order.created",
+    orderId: "10",
+    buyer: "GBUYER000000000000000000000000000000000000000000000000AA",
+    campaignId: "1",
+    amount: "500",
+    ...overrides,
+  };
+}
+
+function makeOrderConfirmed(overrides?: Partial<OrderConfirmedEvent>): OrderConfirmedEvent {
+  return {
+    ...baseEvent,
+    action: "order.confirmed",
+    orderId: "10",
+    buyer: "GBUYER000000000000000000000000000000000000000000000000AA",
+    campaignId: "1",
+    ...overrides,
+  };
+}
+
+function makeGenericCampaign(
+  action: GenericCampaignEvent["action"],
+  overrides?: Partial<GenericCampaignEvent>,
+): GenericCampaignEvent {
+  return {
+    ...baseEvent,
+    action,
+    campaignId: "1",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("EventPersister", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("idempotency / deduplication", () => {
+    it("skips an event that already has a transaction record", async () => {
+      const { prisma } = await import("../db/client.js");
+      vi.mocked(prisma.transaction.findUnique).mockResolvedValueOnce({
+        id: "tx-1",
+      } as never);
+
+      await EventPersister.persist(makeCampaignCreated());
+
+      // $transaction should never be called when the event is a duplicate.
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("processes an event that has not been seen before", async () => {
+      const { prisma } = await import("../db/client.js");
+      vi.mocked(prisma.transaction.findUnique).mockResolvedValueOnce(null);
+
+      await EventPersister.persist(makeCampaignCreated());
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    });
+
+    it("is safe to call persist twice for the same ledger+eventIndex", async () => {
+      const { prisma } = await import("../db/client.js");
+      // First call: not seen.
+      vi.mocked(prisma.transaction.findUnique).mockResolvedValueOnce(null);
+      // Second call: already persisted.
+      vi.mocked(prisma.transaction.findUnique).mockResolvedValueOnce({
+        id: "tx-1",
+      } as never);
+
+      const event = makeCampaignCreated();
+      await EventPersister.persist(event);
+      await EventPersister.persist(event);
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("campaign.created", () => {
+    it("persists a campaign.created event", async () => {
+      const { prisma } = await import("../db/client.js");
+
+      await EventPersister.persist(makeCampaignCreated());
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    });
+
+    it("handles unix-timestamp deadline", async () => {
+      await expect(
+        EventPersister.persist(
+          makeCampaignCreated({ deadline: "1700000000" }),
+        ),
+      ).resolves.not.toThrow();
+    });
+
+    it("handles ISO string deadline", async () => {
+      await expect(
+        EventPersister.persist(
+          makeCampaignCreated({ deadline: "2030-01-01T00:00:00.000Z" }),
+        ),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("campaign.invested", () => {
+    it("persists a campaign.invested event", async () => {
+      const { prisma } = await import("../db/client.js");
+
+      await EventPersister.persist(makeCampaignInvested());
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    });
+
+    it("warns and skips when campaign is unknown", async () => {
+      const logger = (await import("../config/logger.js")).default;
+      const { prisma } = await import("../db/client.js");
+
+      // Simulate the inner tx.campaign.findUnique returning null.
+      vi.mocked(prisma.$transaction).mockImplementationOnce(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          await fn({
+            user: { upsert: vi.fn().mockResolvedValue({}) },
+            campaign: { findUnique: vi.fn().mockResolvedValue(null) },
+            transaction: { create: vi.fn().mockResolvedValue({}) },
+          });
+        },
+      );
+
+      await EventPersister.persist(makeCampaignInvested({ campaignId: "unknown" }));
+
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        "EventPersister: investment for unknown campaign",
+        expect.objectContaining({ campaignId: "unknown" }),
+      );
+    });
+  });
+
+  describe("campaign.settled", () => {
+    it("persists a campaign.settled event", async () => {
+      const { prisma } = await import("../db/client.js");
+
+      await EventPersister.persist(makeCampaignSettled());
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("order.created", () => {
+    it("persists an order.created event", async () => {
+      const { prisma } = await import("../db/client.js");
+
+      await EventPersister.persist(makeOrderCreated());
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("order.confirmed", () => {
+    it("persists an order.confirmed event", async () => {
+      const { prisma } = await import("../db/client.js");
+
+      await EventPersister.persist(makeOrderConfirmed());
+
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("generic campaign lifecycle events", () => {
+    const lifecycleActions: GenericCampaignEvent["action"][] = [
+      "campaign.produce",
+      "campaign.harvest",
+      "campaign.failed",
+      "campaign.disputed",
+      "campaign.claimed",
+      "campaign.refunded",
+      "campaign.tranche",
+    ];
+
+    for (const action of lifecycleActions) {
+      it(`persists ${action}`, async () => {
+        const { prisma } = await import("../db/client.js");
+
+        await EventPersister.persist(makeGenericCampaign(action));
+
+        expect(prisma.$transaction).toHaveBeenCalledOnce();
+      });
+    }
+  });
+
+  describe("unknown action (fallback)", () => {
+    it("records the raw transaction without touching domain models", async () => {
+      const { prisma } = await import("../db/client.js");
+
+      // Use an action that falls through to the default branch.
+      const event = {
+        ...baseEvent,
+        action: "campaign.unknown" as never,
+        campaignId: "1",
+      };
+
+      await EventPersister.persist(event);
+
+      // Falls through to recordTransaction — uses prisma.transaction.create directly.
+      expect(prisma.transaction.create).toHaveBeenCalledOnce();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error resilience", () => {
+    it("propagates DB errors so the caller can handle them", async () => {
+      const { prisma } = await import("../db/client.js");
+      vi.mocked(prisma.$transaction).mockRejectedValueOnce(new Error("DB connection lost"));
+
+      await expect(EventPersister.persist(makeCampaignCreated())).rejects.toThrow(
+        "DB connection lost",
+      );
+    });
+  });
+});

--- a/agro-production/server/src/events/watcher.test.ts
+++ b/agro-production/server/src/events/watcher.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be hoisted before any imports that pull these modules.
+// ---------------------------------------------------------------------------
+vi.mock("../db/client.js", () => ({
+  prisma: {
+    transaction: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+vi.mock("../config/logger.js", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../config/index.js", () => ({
+  config: {
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    contractId: "CTEST000000000000000000000000000000000000000000000000AA",
+  },
+}));
+
+vi.mock("./parser.js", () => ({
+  ProductionEventParser: { tryParse: vi.fn().mockReturnValue(null) },
+}));
+
+vi.mock("./persister.js", () => ({
+  EventPersister: { persist: vi.fn().mockResolvedValue(undefined) },
+}));
+
+// rpc.Server mock
+const mockGetEvents = vi.fn().mockResolvedValue({ events: [] });
+const mockGetLatestLedger = vi.fn().mockResolvedValue({ sequence: 500 });
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  rpc: {
+    Server: vi.fn().mockImplementation(() => ({
+      getEvents: mockGetEvents,
+      getLatestLedger: mockGetLatestLedger,
+    })),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// After all mocks are declared we can import the module under test.
+// ---------------------------------------------------------------------------
+import { startProductionWatcher } from "./watcher.js";
+import { prisma } from "../db/client.js";
+import { ProductionEventParser } from "./parser.js";
+import { EventPersister } from "./persister.js";
+import logger from "../config/logger.js";
+
+describe("startProductionWatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("checkpoint loading", () => {
+    it("resumes from the last persisted ledger when a transaction record exists", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce({
+        ledger: 300,
+      } as never);
+
+      await startProductionWatcher();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        "Production watcher: resuming from persisted checkpoint",
+        expect.objectContaining({ ledger: 300 }),
+      );
+    });
+
+    it("falls back to the current ledger tip when no checkpoint exists", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce(null);
+      mockGetLatestLedger.mockResolvedValueOnce({ sequence: 500 });
+
+      await startProductionWatcher();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        "Production watcher: no checkpoint found, starting from current ledger",
+        expect.objectContaining({ ledger: 500 }),
+      );
+    });
+  });
+
+  describe("gap reconciliation", () => {
+    it("fast-forwards checkpoint when gap exceeds MAX_LEDGER_GAP", async () => {
+      // Checkpoint is at ledger 100; current tip is at 1200 → gap of 1100 > 1000.
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce({
+        ledger: 100,
+      } as never);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 1200 });
+
+      await startProductionWatcher();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Production watcher: large ledger gap detected, fast-forwarding checkpoint",
+        expect.objectContaining({ gap: 1100 }),
+      );
+    });
+
+    it("does not fast-forward when the gap is within MAX_LEDGER_GAP", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce({
+        ledger: 490,
+      } as never);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 500 });
+
+      await startProductionWatcher();
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        "Production watcher: large ledger gap detected, fast-forwarding checkpoint",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("poll loop", () => {
+    it("calls getEvents with the correct startLedger on the first tick", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce({
+        ledger: 300,
+      } as never);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 301 });
+      mockGetEvents.mockResolvedValue({ events: [] });
+
+      await startProductionWatcher();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(mockGetEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ startLedger: 300 }),
+      );
+    });
+
+    it("advances the checkpoint after processing events", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce({
+        ledger: 300,
+      } as never);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 301 });
+
+      const fakeEvent = {
+        ledger: 302,
+        id: "302-0",
+        type: "contract",
+        ledgerClosedAt: new Date().toISOString(),
+        contractId: "CTEST",
+        topic: [],
+        value: "",
+      };
+      mockGetEvents.mockResolvedValueOnce({ events: [fakeEvent] });
+      vi.mocked(ProductionEventParser.tryParse).mockReturnValueOnce(null);
+
+      await startProductionWatcher();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      // Second tick should use the advanced checkpoint (302 + 1 = 303).
+      mockGetEvents.mockResolvedValueOnce({ events: [] });
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      const calls = mockGetEvents.mock.calls;
+      expect(calls[1][0]).toMatchObject({ startLedger: 303 });
+    });
+
+    it("logs and continues when getEvents throws", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce(null);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 500 });
+      mockGetEvents.mockRejectedValueOnce(new Error("RPC timeout"));
+
+      await startProductionWatcher();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "Production watcher poll error",
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+    });
+
+    it("skips events that fail to parse (tryParse returns null)", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce(null);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 500 });
+
+      const badEvent = {
+        ledger: 501,
+        id: "501-0",
+        type: "contract",
+        ledgerClosedAt: new Date().toISOString(),
+        contractId: "CTEST",
+        topic: [],
+        value: "",
+      };
+      mockGetEvents.mockResolvedValueOnce({ events: [badEvent] });
+      vi.mocked(ProductionEventParser.tryParse).mockReturnValueOnce(null);
+
+      await startProductionWatcher();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(EventPersister.persist).not.toHaveBeenCalled();
+    });
+
+    it("persists events that parse successfully", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce(null);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 500 });
+
+      const rawEvent = {
+        ledger: 501,
+        id: "501-0",
+        type: "contract",
+        ledgerClosedAt: new Date().toISOString(),
+        contractId: "CTEST",
+        topic: [],
+        value: "",
+      };
+      const parsedEvent = {
+        action: "campaign.created" as const,
+        ledger: 501,
+        eventIndex: 0,
+        timestamp: new Date(),
+        rawId: "501-0",
+        campaignId: "1",
+        farmer: "GFARMER",
+        token: "GTOKEN",
+        targetAmount: "10000",
+        deadline: "9999999",
+      };
+
+      mockGetEvents.mockResolvedValueOnce({ events: [rawEvent] });
+      vi.mocked(ProductionEventParser.tryParse).mockReturnValueOnce(parsedEvent);
+
+      await startProductionWatcher();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(EventPersister.persist).toHaveBeenCalledWith(parsedEvent);
+    });
+
+    it("logs persist errors without crashing the poll loop", async () => {
+      vi.mocked(prisma.transaction.findFirst).mockResolvedValueOnce(null);
+      mockGetLatestLedger.mockResolvedValue({ sequence: 500 });
+
+      const rawEvent = {
+        ledger: 501,
+        id: "501-0",
+        type: "contract",
+        ledgerClosedAt: new Date().toISOString(),
+        contractId: "CTEST",
+        topic: [],
+        value: "",
+      };
+      const parsedEvent = {
+        action: "campaign.settled" as const,
+        ledger: 501,
+        eventIndex: 0,
+        timestamp: new Date(),
+        rawId: "501-0",
+        campaignId: "1",
+        totalRevenue: "500",
+      };
+
+      mockGetEvents.mockResolvedValueOnce({ events: [rawEvent] });
+      vi.mocked(ProductionEventParser.tryParse).mockReturnValueOnce(parsedEvent);
+      vi.mocked(EventPersister.persist).mockRejectedValueOnce(new Error("write failed"));
+
+      await startProductionWatcher();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "EventPersister error",
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+    });
+  });
+});

--- a/agro-production/server/src/events/watcher.ts
+++ b/agro-production/server/src/events/watcher.ts
@@ -7,17 +7,60 @@ import { EventPersister } from "./persister.js";
 import type { RawSorobanEvent } from "./types.js";
 
 const POLL_INTERVAL_MS = 5_000;
+const MAX_LEDGER_GAP = 1_000;
 // base64 encoding of "campaign" and "order" short symbols
 const CAMPAIGN_TOPIC = "AAAADwAAAAhjYW1wYWlnbg==";
 const ORDER_TOPIC = "AAAADwAAAAVvcmRlcg==";
+
+/**
+ * Loads the last persisted ledger checkpoint from the database.
+ * Falls back to the current on-chain tip when no checkpoint exists.
+ */
+async function loadCheckpoint(server: rpc.Server): Promise<number> {
+  const lastTx = await prisma.transaction.findFirst({ orderBy: { ledger: "desc" } });
+  if (lastTx) {
+    logger.info("Production watcher: resuming from persisted checkpoint", {
+      ledger: lastTx.ledger,
+    });
+    return lastTx.ledger;
+  }
+  const latest = await server.getLatestLedger();
+  logger.info("Production watcher: no checkpoint found, starting from current ledger", {
+    ledger: latest.sequence,
+  });
+  return latest.sequence;
+}
+
+/**
+ * Detects gaps between the local checkpoint and the current on-chain tip and
+ * fast-forwards the checkpoint when the gap exceeds MAX_LEDGER_GAP to prevent
+ * unbounded re-processing on long outages.
+ */
+async function reconcileGap(server: rpc.Server, lastLedger: number): Promise<number> {
+  try {
+    const latest = await server.getLatestLedger();
+    const gap = latest.sequence - lastLedger;
+    if (gap > MAX_LEDGER_GAP) {
+      logger.warn("Production watcher: large ledger gap detected, fast-forwarding checkpoint", {
+        lastLedger,
+        currentLedger: latest.sequence,
+        gap,
+        maxGap: MAX_LEDGER_GAP,
+      });
+      return latest.sequence - MAX_LEDGER_GAP;
+    }
+  } catch (err) {
+    logger.warn("Production watcher: could not fetch latest ledger for gap check", { error: err });
+  }
+  return lastLedger;
+}
 
 export async function startProductionWatcher(): Promise<void> {
   const server = new rpc.Server(config.rpcUrl);
   logger.info("Production contract watcher started", { contractId: config.contractId });
 
-  // Resume from the last persisted ledger to avoid re-processing on restart.
-  const lastTx = await prisma.transaction.findFirst({ orderBy: { ledger: "desc" } });
-  let lastLedger = lastTx?.ledger ?? (await server.getLatestLedger()).sequence;
+  let lastLedger = await loadCheckpoint(server);
+  lastLedger = await reconcileGap(server, lastLedger);
 
   setInterval(async () => {
     try {
@@ -37,6 +80,8 @@ export async function startProductionWatcher(): Promise<void> {
         ],
       });
 
+      let highWaterMark = lastLedger;
+
       for (const rawEvent of response.events) {
         const event = ProductionEventParser.tryParse(rawEvent as unknown as RawSorobanEvent);
         if (event) {
@@ -44,9 +89,15 @@ export async function startProductionWatcher(): Promise<void> {
             logger.error("EventPersister error", { error: err }),
           );
         }
-        if (rawEvent.ledger > lastLedger) {
-          lastLedger = rawEvent.ledger + 1;
+        if (rawEvent.ledger > highWaterMark) {
+          highWaterMark = rawEvent.ledger;
         }
+      }
+
+      // Advance checkpoint only after all events in the batch are processed.
+      if (highWaterMark > lastLedger) {
+        lastLedger = highWaterMark + 1;
+        logger.debug("Production watcher: checkpoint advanced", { ledger: lastLedger });
       }
     } catch (err) {
       logger.error("Production watcher poll error", { error: err });

--- a/agro-production/server/src/middleware/errors.ts
+++ b/agro-production/server/src/middleware/errors.ts
@@ -1,0 +1,49 @@
+import type { Request, Response, NextFunction } from "express";
+import logger from "../config/logger.js";
+
+/**
+ * RFC 7807 Problem Detail shape.
+ * https://datatracker.ietf.org/doc/html/rfc7807
+ */
+export interface ProblemDetail {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+  [key: string]: unknown;
+}
+
+export function problemDetail(
+  res: Response,
+  req: Request,
+  status: number,
+  title: string,
+  detail?: string,
+  extra?: Record<string, unknown>,
+): void {
+  const body: ProblemDetail = {
+    type: `https://agrocylo.io/errors/${slugify(title)}`,
+    title,
+    status,
+    instance: req.path,
+    ...(detail ? { detail } : {}),
+    ...extra,
+  };
+  res.status(status).type("application/problem+json").json(body);
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, "-");
+}
+
+// Global unhandled-error middleware (must have 4 params for Express to treat it as error handler).
+export function globalErrorHandler(
+  err: unknown,
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  logger.error("Unhandled request error", { error: err, path: req.path });
+  problemDetail(res, req, 500, "Internal Server Error");
+}

--- a/agro-production/server/src/middleware/validate.ts
+++ b/agro-production/server/src/middleware/validate.ts
@@ -3,13 +3,13 @@ import { z, ZodError } from "zod";
 
 /**
  * Factory that returns an Express middleware validating req.body against a
- * Zod schema. Returns 400 with structured errors on failure.
+ * Zod schema. Returns RFC 7807 Problem Detail on failure.
  */
 export function validateBody<T extends z.ZodTypeAny>(schema: T) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const result = schema.safeParse(req.body);
     if (!result.success) {
-      res.status(400).json(formatZodError(result.error));
+      res.status(400).type("application/problem+json").json(formatZodError(result.error, req.path));
       return;
     }
     req.body = result.data;
@@ -24,7 +24,7 @@ export function validateQuery<T extends z.ZodTypeAny>(schema: T) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const result = schema.safeParse(req.query);
     if (!result.success) {
-      res.status(400).json(formatZodError(result.error));
+      res.status(400).type("application/problem+json").json(formatZodError(result.error, req.path));
       return;
     }
     req.query = result.data as typeof req.query;
@@ -39,7 +39,7 @@ export function validateParams<T extends z.ZodTypeAny>(schema: T) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const result = schema.safeParse(req.params);
     if (!result.success) {
-      res.status(400).json(formatZodError(result.error));
+      res.status(400).type("application/problem+json").json(formatZodError(result.error, req.path));
       return;
     }
     req.params = result.data as typeof req.params;
@@ -47,10 +47,13 @@ export function validateParams<T extends z.ZodTypeAny>(schema: T) {
   };
 }
 
-function formatZodError(error: ZodError) {
+function formatZodError(error: ZodError, instance: string) {
   return {
-    error: "Validation failed",
-    details: error.issues.map((issue) => ({
+    type: "https://agrocylo.io/errors/validation-failed",
+    title: "Validation Failed",
+    status: 400,
+    instance,
+    errors: error.issues.map((issue) => ({
       field: issue.path.join("."),
       message: issue.message,
       code: issue.code,

--- a/agro-production/server/src/routes/campaigns.ts
+++ b/agro-production/server/src/routes/campaigns.ts
@@ -7,9 +7,12 @@ import {
   CreateCampaignSchema,
   InvestSchema,
   ListCampaignsQuerySchema,
+  type CreateCampaignInput,
+  type InvestInput,
+  type ListCampaignsQuery,
 } from "../schemas/campaign.js";
-import type { CampaignStatus } from "@prisma/client";
 import { broadcast } from "../services/wsServer.js";
+import { problemDetail } from "../middleware/errors.js";
 
 const router = Router();
 
@@ -18,12 +21,7 @@ router.get(
   "/campaigns",
   validateQuery(ListCampaignsQuerySchema),
   async (req: Request, res: Response) => {
-    const { status, farmerAddress, page, limit } = req.query as unknown as {
-      status?: CampaignStatus;
-      farmerAddress?: string;
-      page: number;
-      limit: number;
-    };
+    const { status, farmerAddress, page, limit } = req.query as unknown as ListCampaignsQuery;
 
     const where = {
       ...(status ? { status } : {}),
@@ -58,7 +56,7 @@ router.get(
     });
 
     if (!campaign) {
-      res.status(404).json({ error: "Campaign not found" });
+      problemDetail(res, req, 404, "Campaign Not Found", `No campaign with id ${req.params.id}`);
       return;
     }
 
@@ -72,7 +70,8 @@ router.post(
   writeLimiter,
   validateBody(CreateCampaignSchema),
   async (req: Request, res: Response) => {
-    const { farmerAddress, tokenAddress, targetAmount, deadline } = req.body;
+    const { farmerAddress, tokenAddress, targetAmount, deadline } =
+      req.body as CreateCampaignInput;
 
     await prisma.user.upsert({
       where: { walletAddress: farmerAddress },
@@ -110,38 +109,41 @@ router.get(
 );
 
 // GET /investments?investorAddress=... — all investments for a user
-router.get(
-  "/investments",
-  async (req: Request, res: Response) => {
-    const { investorAddress } = req.query;
-    if (!investorAddress || typeof investorAddress !== "string") {
-      res.status(400).json({ error: "investorAddress query param required" });
-      return;
-    }
+router.get("/investments", async (req: Request, res: Response) => {
+  const { investorAddress } = req.query;
+  if (!investorAddress || typeof investorAddress !== "string") {
+    problemDetail(
+      res,
+      req,
+      400,
+      "Missing Query Parameter",
+      "investorAddress query param is required",
+    );
+    return;
+  }
 
-    const investments = await prisma.investment.findMany({
-      where: { investorAddress },
-      orderBy: { createdAt: "desc" },
-      include: {
-        campaign: {
-          select: {
-            id: true,
-            onChainId: true,
-            farmerAddress: true,
-            tokenAddress: true,
-            targetAmount: true,
-            totalRaised: true,
-            totalRevenue: true,
-            status: true,
-            deadline: true,
-          },
+  const investments = await prisma.investment.findMany({
+    where: { investorAddress },
+    orderBy: { createdAt: "desc" },
+    include: {
+      campaign: {
+        select: {
+          id: true,
+          onChainId: true,
+          farmerAddress: true,
+          tokenAddress: true,
+          targetAmount: true,
+          totalRaised: true,
+          totalRevenue: true,
+          status: true,
+          deadline: true,
         },
       },
-    });
+    },
+  });
 
-    res.json(investments);
-  },
-);
+  res.json(investments);
+});
 
 // POST /campaigns/:id/invest — record an investment (indexer shortcut)
 router.post(
@@ -150,15 +152,21 @@ router.post(
   validateParams(CampaignIdParamSchema),
   validateBody(InvestSchema),
   async (req: Request, res: Response) => {
-    const { investorAddress, amount } = req.body;
+    const { investorAddress, amount } = req.body as InvestInput;
 
     const campaign = await prisma.campaign.findUnique({ where: { id: req.params.id } });
     if (!campaign) {
-      res.status(404).json({ error: "Campaign not found" });
+      problemDetail(res, req, 404, "Campaign Not Found", `No campaign with id ${req.params.id}`);
       return;
     }
     if (campaign.status !== "FUNDING") {
-      res.status(409).json({ error: "Campaign is not accepting investments" });
+      problemDetail(
+        res,
+        req,
+        409,
+        "Campaign Not Accepting Investments",
+        `Campaign status is ${campaign.status}`,
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR resolves four related backend issues that improve reliability, correctness, and observability of the `agro-production/server`.

---

### #298 — Event listener resilience and ledger checkpointing

**Problem:** `watcher.ts` held the last-processed ledger only in memory, causing all events since the last restart to be missed.

**Changes:**
- `loadCheckpoint()` reads the highest `ledger` from the `transactions` table on startup and logs whether it resumed from a checkpoint or fell back to the chain tip.
- `reconcileGap()` detects when the local checkpoint has fallen more than `MAX_LEDGER_GAP` (1 000) ledgers behind the on-chain tip and fast-forwards to `tip - MAX_LEDGER_GAP` to prevent unbounded replay on long outages.
- The in-loop high-water-mark is now advanced atomically after the full batch is processed, not per-event, eliminating partial-batch checkpoint drift.

---

### #299 — API route error handling and validation

**Problem:** `campaigns.ts` used `as unknown as` casts to bypass the type system after validation middleware had already parsed and narrowed the request, and error responses were plain `{ error: string }` objects with no machine-readable structure.

**Changes:**
- New `src/middleware/errors.ts` provides a `problemDetail()` helper that emits [RFC 7807 Problem Detail](https://datatracker.ietf.org/doc/html/rfc7807) JSON with `Content-Type: application/problem+json`. A `globalErrorHandler` express middleware replaces the ad-hoc 500 handler in `app.ts`.
- `validate.ts` updated to emit RFC 7807 validation errors (keyed `errors[]` instead of `details[]`) consistent with the new helper.
- `campaigns.ts` now uses the inferred Zod types (`CreateCampaignInput`, `InvestInput`, `ListCampaignsQuery`) instead of `as unknown as` casts, and all 404/409/400 branches use `problemDetail()`.

---

### #300 — Strict environment validation

**Problem:** All env vars in `config/index.ts` silently fell back to empty strings or testnet defaults, making it possible to start a production server with a missing `DATABASE_URL` or `PRODUCTION_CONTRACT_ID`.

**Changes:**
- Introduced `requireEnv()` — throws immediately if a required variable is absent.
- On `NODE_ENV=production`, the four critical variables (`DATABASE_URL`, `RPC_URL`, `PRODUCTION_CONTRACT_ID`, `ESCROW_CONTRACT_ID`) are checked up-front; if any are missing the process exits with a descriptive message listing exactly which are unset.
- Each variable is documented inline with its expected format.
- Non-production environments retain safe defaults so local development and CI are unaffected.

---

### #301 — Expanded event watcher and persister tests

**Problem:** Test coverage was limited to happy-path parser round-trips; persistence logic, idempotency, and watcher behaviour were untested.

**New files:**
- `src/events/persister.test.ts` — unit tests for `EventPersister` covering: duplicate-event skipping, idempotent double-call safety, all event handler branches (`campaign.created`, `campaign.invested`, `campaign.settled`, `order.created`, `order.confirmed`, all lifecycle verbs), the unknown-action fallback path, unknown-campaign warning path, and DB error propagation.
- `src/events/watcher.test.ts` — unit tests for `startProductionWatcher` covering: checkpoint resume from DB, fallback to chain tip, gap fast-forward trigger, poll loop advancing the checkpoint after a batch, `getEvents` error resilience, parse-failure skip, successful persist call, and persist-error logging without loop crash.

**Expanded** `src/events/parser.test.ts` — additional edge cases: `rawId` capture, eventIndex default when id has no hyphen, numeric ScVal → string coercion, malformed value XDR returning `null` via `tryParse`, unknown order verb, zero-amount order, and large i128 value round-trip.

---

## Test plan

- [ ] `cd agro-production/server && npm test` — all vitest suites pass
- [ ] Start server with `NODE_ENV=production` and a missing `DATABASE_URL` — process should exit with a clear error message listing the missing variable
- [ ] Start server with all required env vars set — startup proceeds normally
- [ ] `GET /api/v1/campaigns/not-a-uuid` — response is `application/problem+json` 400
- [ ] `GET /api/v1/campaigns/00000000-0000-0000-0000-000000000000` (non-existent) — response is `application/problem+json` 404
- [ ] Restart the server after processing some events — watcher resumes from the persisted ledger, not the chain tip

Closes #298
Closes #299
Closes #300
Closes #301