### PR TITLE
feat: WebSocket reliability, multi-wallet adapters, mobile fix, server docs

### DIFF
--- a/agro-production/client/src/hooks/useWebSocket.ts
+++ b/agro-production/client/src/hooks/useWebSocket.ts
@@ -8,6 +8,10 @@ const WS_URL =
     ? `ws://${window.location.hostname}:3001/ws`
     : "ws://localhost:3001/ws");
 
+const BACKOFF_BASE_MS = 1_000;
+const BACKOFF_MAX_MS = 30_000;
+const MAX_QUEUE_SIZE = 100;
+
 export type WsMessage = {
   event: string;
   payload: unknown;
@@ -19,37 +23,74 @@ type Handler = (msg: WsMessage) => void;
 export function useWebSocket(onMessage: Handler) {
   const socketRef = useRef<WebSocket | null>(null);
   const handlerRef = useRef<Handler>(onMessage);
+  const attemptRef = useRef(0);
+  const messageQueueRef = useRef<string[]>([]);
+  const unmountedRef = useRef(false);
+
   handlerRef.current = onMessage;
 
+  const flushQueue = useCallback((ws: WebSocket) => {
+    const queued = messageQueueRef.current.splice(0);
+    for (const msg of queued) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(msg);
+      }
+    }
+  }, []);
+
   const connect = useCallback(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined" || unmountedRef.current) return;
 
     const ws = new WebSocket(WS_URL);
     socketRef.current = ws;
+
+    ws.onopen = () => {
+      attemptRef.current = 0;
+      flushQueue(ws);
+    };
 
     ws.onmessage = (e) => {
       try {
         const msg: WsMessage = JSON.parse(e.data as string);
         handlerRef.current(msg);
       } catch {
-        // ignore malformed messages
+        console.warn("[useWebSocket] Malformed message received:", e.data);
       }
     };
 
     ws.onclose = () => {
-      // Reconnect after 3s
-      setTimeout(connect, 3000);
+      if (unmountedRef.current) return;
+      const attempt = attemptRef.current;
+      const delay = Math.min(BACKOFF_BASE_MS * 2 ** attempt, BACKOFF_MAX_MS);
+      attemptRef.current = attempt + 1;
+      setTimeout(connect, delay);
     };
 
     ws.onerror = () => {
       ws.close();
     };
+  }, [flushQueue]);
+
+  /** Queue a raw JSON string to be sent once the socket is open. */
+  const send = useCallback((data: string) => {
+    const ws = socketRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(data);
+    } else {
+      if (messageQueueRef.current.length < MAX_QUEUE_SIZE) {
+        messageQueueRef.current.push(data);
+      }
+    }
   }, []);
 
   useEffect(() => {
+    unmountedRef.current = false;
     connect();
     return () => {
+      unmountedRef.current = true;
       socketRef.current?.close();
     };
   }, [connect]);
+
+  return { send };
 }

--- a/agro-production/server/README.md
+++ b/agro-production/server/README.md
@@ -1,150 +1,265 @@
-## Redis (BullMQ)
+# Agrocylo Production Server
 
-This folder contains production-oriented assets for the backend queue system.
+Production backend for the Agrocylo platform. It exposes a REST API, indexes on-chain Stellar/Soroban contract events in real-time, and broadcasts updates to connected clients via WebSocket.
 
-Start Redis:
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Environment Variables](#environment-variables)
+- [Database Setup](#database-setup)
+- [Running the Server](#running-the-server)
+- [Redis / Queue Worker](#redis--queue-worker)
+- [API Reference](#api-reference)
+- [Event Architecture](#event-architecture)
+- [WebSocket](#websocket)
+- [Testing](#testing)
+
+---
+
+## Prerequisites
+
+- Node.js ≥ 20
+- PostgreSQL (local or hosted, e.g. Supabase)
+- Docker & Docker Compose (for the Redis queue)
+- A deployed Stellar/Soroban contract ID
+
+---
+
+## Installation
+
+```bash
+cd agro-production/server
+npm install
+```
+
+---
+
+## Environment Variables
+
+Copy the example file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `PORT` | `5001` | No | Port the HTTP server listens on |
+| `NODE_ENV` | `development` | No | `development` or `production` |
+| `LOG_LEVEL` | `debug` | No | Winston log level (`debug`, `info`, `warn`, `error`) |
+| `DATABASE_URL` | — | **Yes** | PostgreSQL connection string (`postgresql://user:pass@host/db`) |
+| `RPC_URL` | `https://soroban-testnet.stellar.org` | No | Stellar Soroban RPC endpoint |
+| `ESCROW_CONTRACT_ID` | — | **Yes** | Contract ID for the primary EscrowContract |
+| `PRODUCTION_ESCROW_CONTRACT_ID` | — | **Yes** | Contract ID for the ProductionEscrowContract |
+| `PRODUCTION_CONTRACT_ID` | — | No | Alias used by the legacy single-contract watcher (falls back to `PRODUCTION_ESCROW_CONTRACT_ID`) |
+| `RATE_LIMIT_WINDOW_MS` | `60000` | No | Rate-limit rolling window in milliseconds |
+| `RATE_LIMIT_MAX_REQUESTS` | `100` | No | Max requests per IP per window |
+| `SUPABASE_URL` | — | For images | Supabase project URL (campaign image uploads) |
+| `SUPABASE_ANON_KEY` | — | For images | Supabase anon/public key |
+| `SUPABASE_SERVICE_ROLE_KEY` | — | For images | Supabase service-role key (bypasses RLS for uploads) |
+| `SUPABASE_CAMPAIGN_IMAGES_BUCKET` | `campaign-images` | No | Supabase storage bucket name |
+| `CAMPAIGN_IMAGE_PLACEHOLDER_URL` | `https://placehold.co/800x800/png?text=No+Image` | No | Fallback URL when no image is stored |
+| `METRICS_API_KEY` | — | No | If set, `/metrics` requires this value as `x-metrics-api-key` or `Authorization: Bearer <key>` |
+
+---
+
+## Database Setup
+
+The server uses Prisma with PostgreSQL.
+
+```bash
+# Apply all pending migrations
+npx prisma migrate deploy
+
+# (Development only) Create and apply a new migration
+npx prisma migrate dev --name <migration-name>
+
+# Open Prisma Studio (visual DB browser)
+npx prisma db studio
+```
+
+The schema lives in `prisma/schema.prisma`. Models: `User`, `Campaign`, `Investment`, `Order`, `Transaction`.
+
+---
+
+## Running the Server
+
+```bash
+# Development (hot-reload via tsx watch)
+npm run dev
+
+# Build TypeScript
+npm run build
+
+# Production (requires npm run build first)
+npm start
+```
+
+On startup the server will:
+
+1. Connect to PostgreSQL via Prisma.
+2. Start the **multi-contract Soroban event listener** (`src/services/sorobanEventListener.ts`) — watches both `ESCROW_CONTRACT_ID` and `PRODUCTION_ESCROW_CONTRACT_ID`.
+3. Start the **single-contract production watcher** (`src/events/watcher.ts`) if `PRODUCTION_CONTRACT_ID` is set — resumes from the last persisted ledger to avoid re-processing events after a restart.
+4. Attach the **WebSocket server** on the same HTTP port.
+5. Serve the HTTP API.
+
+---
+
+## Redis / Queue Worker
+
+A Redis-backed queue (BullMQ) handles async jobs. Start Redis first:
 
 ```bash
 docker compose -f docker-compose.redis.yml up -d
 ```
 
-Then run the backend worker process from the root `server/` package:
+Then run the worker from the root `server/` package:
 
 ```bash
 cd server
 npm run worker:dev
 ```
 
-## Buyer demand & farmer supply APIs
+---
 
-Implemented in the root `server/` app (run migrations from `server/`).
+## API Reference
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| `POST` | `/demand` | Buyer expresses demand (stored with `buyer_wallet` from `x-wallet-address`) |
-| `POST` | `/supply` | Farmer declares supply (stored with `farmer_wallet` from `x-wallet-address`) |
+All REST endpoints are served on `http://localhost:<PORT>`.
 
-Headers: `x-wallet-address` (required), `Content-Type: application/json`.
+### Health
 
-Apply DB migration:
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/health` | Returns `{ status: "UP", service, env, timestamp }` |
 
-```bash
-cd server
-npx prisma migrate deploy
+### Campaigns
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/campaigns` | List all campaigns |
+| `GET` | `/api/v1/campaigns/:id` | Get a single campaign by ID |
+| `POST` | `/api/v1/campaigns` | Create a campaign (requires `x-wallet-address` header) |
+
+### Orders
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/orders` | List orders |
+| `POST` | `/api/v1/orders` | Create an order (requires `x-wallet-address` header) |
+
+### Campaign Images
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/campaign-images/upload` | Upload a campaign image (multipart/form-data, field: `image`) |
+| `DELETE` | `/campaign-images/:campaignId` | Delete a campaign's image |
+
+### Buyer Demand & Farmer Supply
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/demand` | Buyer expresses demand (wallet from `x-wallet-address`) |
+| `POST` | `/supply` | Farmer declares supply (wallet from `x-wallet-address`) |
+
+### Metrics
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/metrics` | JSON snapshot of platform activity |
+
+**Metrics response fields:**
+
+- `orders_per_day` — count of orders with `createdAt` on the current UTC calendar day
+- `campaigns_created` — count of product/campaign rows created that same UTC day
+- `total_volume` — sum of `orders.amount` for all time (parses as finite number)
+- `active_users` — distinct buyer/seller wallet addresses on any order in the last 30 days
+
+**Auth:** If `METRICS_API_KEY` is set, send `x-metrics-api-key: <key>` or `Authorization: Bearer <key>`.
+
+**Common headers:**
+
+| Header | When required |
+|---|---|
+| `x-wallet-address` | POST /demand, POST /supply, POST /campaigns, POST /orders |
+| `Content-Type: application/json` | All JSON POST requests |
+
+---
+
+## Event Architecture
+
+```
+Stellar / Soroban network
+        │
+        │  RPC polling (every 5 s)
+        ▼
+┌────────────────────────────────────────────────┐
+│           Soroban Event Listener               │
+│  sorobanEventListener.ts                       │
+│  Watches: ESCROW_CONTRACT_ID                   │
+│           PRODUCTION_ESCROW_CONTRACT_ID        │
+└──────────────────┬─────────────────────────────┘
+                   │
+                   │  also
+                   ▼
+┌────────────────────────────────────────────────┐
+│         Production Contract Watcher            │
+│  events/watcher.ts                             │
+│  Watches: PRODUCTION_CONTRACT_ID               │
+│  Resumes from last persisted ledger (Prisma)   │
+│  Filters: campaign.* and order.* topics        │
+└──────────────────┬─────────────────────────────┘
+                   │
+        ┌──────────┼──────────┐
+        ▼          ▼          ▼
+   Parser      Persister   WebSocket
+(events/     (events/     broadcast
+ parser.ts)  persister.ts) (services/
+                           wsServer.ts)
+        │          │
+        └────┬─────┘
+             ▼
+       PostgreSQL (Prisma)
+       campaigns / orders /
+       transactions tables
 ```
 
-## Platform metrics
+**Event flow:**
 
-Implemented in the root `server/` app.
+1. The watcher polls the Soroban RPC for new ledger events matching the contract IDs.
+2. `ProductionEventParser` parses raw Soroban events into typed domain events (`campaign.created`, `order.placed`, etc.).
+3. `EventPersister` writes the parsed event to PostgreSQL via Prisma.
+4. The WebSocket server broadcasts the event to all connected frontend clients.
+5. On restart the watcher reads the highest `ledger` from the `transactions` table and resumes from there — no events are re-processed.
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| `GET` | `/metrics` | JSON snapshot: `orders_per_day`, `campaigns_created`, `total_volume`, `active_users` |
+---
 
-Optional auth: set `METRICS_API_KEY` in the server environment, then send the same value as `x-metrics-api-key` or `Authorization: Bearer <METRICS_API_KEY>`.
+## WebSocket
 
-**Field definitions**
+Clients connect to `ws://localhost:<PORT>/ws`. The server pushes JSON messages with the shape:
 
-- **orders_per_day** — Count of `orders` rows with `createdAt` on the current **UTC calendar day**.
-- **campaigns_created** — Count of **product listings** (`products` rows) created that same UTC day (used as farmer/market “campaigns” until a dedicated campaigns feature exists).
-- **total_volume** — Sum of `orders.amount` where the value parses as a finite number (all time).
-- **active_users** — Distinct buyer or seller wallet addresses appearing on any order in the **last 30 days**.
-
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
-
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
-
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
-
-## Description
-
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
-## Project setup
-
-```bash
-$ npm install
+```ts
+{
+  event: string;      // e.g. "campaign.created", "order.placed"
+  payload: unknown;   // event-specific data
+  timestamp: string;  // ISO 8601
+}
 ```
 
-## Compile and run the project
+The frontend `useWebSocket` hook (in `agro-production/client/`) handles reconnection with exponential backoff and queues outbound messages while disconnected.
+
+---
+
+## Testing
 
 ```bash
-# development
-$ npm run start
+# Run all unit tests (vitest)
+npm test
 
-# watch mode
-$ npm run start:dev
-
-# production mode
-$ npm run start:prod
+# Run a single test file
+npx vitest run src/events/parser.test.ts
 ```
 
-## Run tests
-
-```bash
-# unit tests
-$ npm run test
-
-# e2e tests
-$ npm run test:e2e
-
-# test coverage
-$ npm run test:cov
-```
-
-## Deployment
-
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
-
-```bash
-$ npm install -g @nestjs/mau
-$ mau deploy
-```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+Test files live alongside their source files (`*.test.ts`). Integration tests in `src/test/api.test.ts` require a running database — set `DATABASE_URL` before running them.

--- a/client/src/components/modals/wallet-modal.tsx
+++ b/client/src/components/modals/wallet-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { Wallet, X, AlertTriangle } from "lucide-react";
+import { Wallet, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,

--- a/client/src/components/modals/wallet-modal.tsx
+++ b/client/src/components/modals/wallet-modal.tsx
@@ -1,36 +1,123 @@
 "use client";
 
-import { Wallet } from "lucide-react";
+import { useState } from "react";
+import Image from "next/image";
+import { Wallet, X, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { useWallet } from "@/hooks/useWallet";
+import { WALLET_ADAPTERS } from "@/lib/walletAdapters";
 
-/**
- * "Connect Wallet" button that triggers the Freighter extension prompt.
- * Renders a compact icon button on mobile and the full label on desktop.
- */
+function isMobileBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /android|iphone|ipad|ipod|mobile/i.test(navigator.userAgent);
+}
+
 export default function WalletModal() {
-  const { connect, loading } = useWallet();
+  const { connect, loading, error } = useWallet();
+  const [open, setOpen] = useState(false);
+  const [connectingId, setConnectingId] = useState<string | null>(null);
+  const onMobile = isMobileBrowser();
+
+  const handleSelect = async (adapterId: string) => {
+    setConnectingId(adapterId);
+    await connect(adapterId);
+    setConnectingId(null);
+    // Dialog stays open when there is an error so the user can read it.
+    // connect-wallet-inner.tsx handles post-connection redirect on success.
+  };
 
   return (
-    <>
-      <Button
-        className="hidden sm:inline-flex"
-        onClick={() => void connect()}
-        disabled={loading}
-        isLoading={loading}
-      >
-        <Wallet className="size-4" />
-        Connect Wallet
-      </Button>
-      <Button
-        size="icon"
-        className="inline-flex sm:hidden"
-        onClick={() => void connect()}
-        disabled={loading}
-        aria-label="Connect Wallet"
-      >
-        <Wallet className="size-4" />
-      </Button>
-    </>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className="hidden sm:inline-flex" disabled={loading}>
+          <Wallet className="size-4" />
+          Connect Wallet
+        </Button>
+      </DialogTrigger>
+      <DialogTrigger asChild>
+        <Button
+          size="icon"
+          className="inline-flex sm:hidden"
+          disabled={loading}
+          aria-label="Connect Wallet"
+        >
+          <Wallet className="size-4" />
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Connect a Wallet</DialogTitle>
+        </DialogHeader>
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <ul className="flex flex-col gap-2">
+          {WALLET_ADAPTERS.map((adapter) => {
+            const unavailable = onMobile && !adapter.supportsMobile();
+            const isConnecting = connectingId === adapter.id;
+
+            return (
+              <li key={adapter.id}>
+                <button
+                  type="button"
+                  disabled={loading || unavailable}
+                  onClick={() => void handleSelect(adapter.id)}
+                  className="flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <div className="relative size-9 shrink-0 overflow-hidden rounded-md bg-muted">
+                    <Image
+                      src={adapter.icon}
+                      alt={adapter.name}
+                      fill
+                      className="object-contain p-1"
+                      onError={(e) => {
+                        (e.currentTarget as HTMLImageElement).style.display =
+                          "none";
+                      }}
+                    />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium leading-none">{adapter.name}</p>
+                    {unavailable && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        Desktop only
+                      </p>
+                    )}
+                    {adapter.supportsMobile() && onMobile && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        Mobile supported
+                      </p>
+                    )}
+                  </div>
+                  {isConnecting && (
+                    <span className="ml-auto size-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        {onMobile && (
+          <p className="text-center text-xs text-muted-foreground">
+            On mobile, only wallets marked &quot;Mobile supported&quot; work
+            directly. Others require a desktop browser.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/client/src/components/onboarding/ConnectWallet.tsx
+++ b/client/src/components/onboarding/ConnectWallet.tsx
@@ -27,7 +27,7 @@ export default function ConnectWallet({ onNext }: ConnectWalletProps) {
       <CardHeader className="text-center">
         <CardTitle className="text-2xl">Connect Your Wallet</CardTitle>
         <CardDescription>
-          Sign in with Freighter to use AgroCylo. You stay in custody — no
+          Connect your Stellar wallet to use AgroCylo. You stay in custody — no
           seed phrases handed over.
         </CardDescription>
       </CardHeader>
@@ -54,7 +54,7 @@ export default function ConnectWallet({ onNext }: ConnectWalletProps) {
             className="w-full"
           >
             <Wallet className="size-4" />
-            Connect Freighter Wallet
+            Connect Wallet
           </Button>
         )}
       </CardContent>

--- a/client/src/components/onboarding/LocationConsent.tsx
+++ b/client/src/components/onboarding/LocationConsent.tsx
@@ -94,9 +94,9 @@ export default function LocationConsent({
             country: detectedCountry,
             isPublic,
           });
-        } catch (err: any) {
+        } catch (err: unknown) {
           console.error("Reverse geocoding failed", err);
-          if (err.name === 'AbortError') {
+          if (err instanceof Error && err.name === 'AbortError') {
             setErrorMsg("Request timed out");
           } else {
             setErrorMsg("Failed to detect city/country automatically");

--- a/client/src/context/WalletContext.tsx
+++ b/client/src/context/WalletContext.tsx
@@ -2,10 +2,17 @@
 
 import React, { createContext, useCallback, useEffect, useState } from "react";
 import type { WalletContextType } from "../types/wallet";
-import { getXlmBalance, getCurrentNetworkName } from "../lib/stellar";
+import { getXlmBalance } from "../lib/stellar";
 import { signAndSubmitTransaction } from "../lib/signTransaction";
 import type { SignAndSubmitResult } from "../lib/signTransaction";
-import FreighterApi from "@stellar/freighter-api";
+import {
+  WALLET_ADAPTERS,
+  getPreferredAdapter,
+  savePreferredAdapter,
+  FreighterAdapter,
+} from "../lib/walletAdapters";
+
+const CONNECT_TIMEOUT_MS = 12_000;
 
 const initialState: WalletContextType = {
   address: null,
@@ -14,6 +21,7 @@ const initialState: WalletContextType = {
   loading: false,
   error: null,
   network: null,
+  activeWalletId: null,
   connect: async () => {},
   disconnect: () => {},
   refreshBalance: async () => {},
@@ -31,34 +39,32 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [network, setNetwork] = useState<string | null>(null);
+  const [activeWalletId, setActiveWalletId] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const cachedAddr = localStorage.getItem("walletAddress");
     const cachedNet = localStorage.getItem("walletNetwork");
+    const cachedWalletId = localStorage.getItem("activeWalletId");
     if (!cachedAddr) return;
 
-    // Show cached state immediately so the UI doesn't flash a disconnected nav.
     setAddress(cachedAddr);
     setConnected(true);
     if (cachedNet) setNetwork(cachedNet);
+    if (cachedWalletId) setActiveWalletId(cachedWalletId);
 
-    // Then reconcile with Freighter — the user may have switched wallets
-    // outside of our app, in which case the cached address is stale and would
-    // sign transactions for the wrong account.
     (async () => {
       try {
-        const freighterDirect = window.freighter ?? window.freighterApi ?? null;
-        const livePub = freighterDirect
-          ? await freighterDirect.getPublicKey()
-          : await FreighterApi.getPublicKey();
+        const adapter =
+          WALLET_ADAPTERS.find((a) => a.id === cachedWalletId) ??
+          FreighterAdapter;
+        const livePub = await adapter.getPublicKey();
 
         if (livePub && livePub !== cachedAddr) {
-          // Wallet switched — adopt the live key and refetch.
           setAddress(livePub);
           localStorage.setItem("walletAddress", livePub);
-          const liveNet = await getCurrentNetworkName();
+          const liveNet = await adapter.getNetwork();
           setNetwork(liveNet);
           localStorage.setItem("walletNetwork", liveNet);
           const b = await getXlmBalance(livePub);
@@ -69,14 +75,14 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
         const b = await getXlmBalance(cachedAddr);
         setBalance(b);
       } catch {
-        // Freighter unreachable (e.g. extension uninstalled). Treat the cached
-        // session as disconnected rather than silently signing with stale data.
         setAddress(null);
         setConnected(false);
         setNetwork(null);
         setBalance(null);
+        setActiveWalletId(null);
         localStorage.removeItem("walletAddress");
         localStorage.removeItem("walletNetwork");
+        localStorage.removeItem("activeWalletId");
       }
     })();
   }, []);
@@ -94,35 +100,57 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   };
 
-  const connect = async () => {
+  const connect = async (adapterId?: string) => {
     setLoading(true);
     setError(null);
+
+    const adapter =
+      (adapterId ? WALLET_ADAPTERS.find((a) => a.id === adapterId) : null) ??
+      getPreferredAdapter();
+
+    const isMobile =
+      typeof navigator !== "undefined" &&
+      /android|iphone|ipad|ipod|mobile/i.test(navigator.userAgent);
+
+    if (isMobile && !adapter.supportsMobile()) {
+      const deepLink = adapter.mobileDeepLink();
+      const hint = deepLink
+        ? `Open ${adapter.name} at ${deepLink} and try again.`
+        : `${adapter.name} is not supported on mobile. Please use a desktop browser with the ${adapter.name} extension installed.`;
+      setError(hint);
+      setLoading(false);
+      return;
+    }
+
     try {
-      // Prefer window.freighter / window.freighterApi if available (e.g. Playwright test mocks).
-      // The @stellar/freighter-api npm package uses browser-extension messaging which
-      // is unavailable in headless test contexts.
-      const freighterDirect =
-        typeof window !== "undefined"
-          ? window.freighter ?? window.freighterApi ?? null
-          : null;
+      const pub = await Promise.race([
+        adapter.getPublicKey(),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `Connection timed out after ${CONNECT_TIMEOUT_MS / 1000}s. ` +
+                    `Make sure ${adapter.name} is unlocked and try again.`,
+                ),
+            ),
+            CONNECT_TIMEOUT_MS,
+          ),
+        ),
+      ]);
 
-      // Get current network
-      const networkName = freighterDirect?.getNetwork
-        ? await freighterDirect.getNetwork()
-        : await getCurrentNetworkName();
-      setNetwork(networkName);
-      localStorage.setItem("walletNetwork", networkName);
+      const networkName = await adapter.getNetwork();
 
-      // Get public key
-      const pub = freighterDirect
-        ? await freighterDirect.getPublicKey()
-        : await FreighterApi.getPublicKey();
-      if (!pub) {
-        throw new Error("Could not get public key from Freighter");
-      }
       setAddress(pub);
-      localStorage.setItem("walletAddress", pub);
+      setNetwork(networkName);
       setConnected(true);
+      setActiveWalletId(adapter.id);
+
+      localStorage.setItem("walletAddress", pub);
+      localStorage.setItem("walletNetwork", networkName);
+      localStorage.setItem("activeWalletId", adapter.id);
+      savePreferredAdapter(adapter.id);
+
       await refreshBalance(pub);
     } catch (err: unknown) {
       const errorMsg = err instanceof Error ? err.message : String(err);
@@ -141,8 +169,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
     setConnected(false);
     setError(null);
     setNetwork(null);
+    setActiveWalletId(null);
     localStorage.removeItem("walletAddress");
     localStorage.removeItem("walletNetwork");
+    localStorage.removeItem("activeWalletId");
   };
 
   const signAndSubmit = useCallback(
@@ -153,7 +183,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
       setError(null);
       try {
         const result = await signAndSubmitTransaction(transactionXdr);
-        // Refresh balance after a successful on-chain transaction
         if (result.success) {
           await refreshBalance();
         }
@@ -164,23 +193,26 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({
         return { success: false, error: msg };
       }
     },
-    [connected, address]
+    [connected, address],
   );
 
-  const ctx = {
-    address,
-    balance,
-    connected,
-    loading,
-    error,
-    network,
-    connect,
-    disconnect,
-    refreshBalance: async () => refreshBalance(),
-    signAndSubmit,
-  };
-
   return (
-    <WalletContext.Provider value={ctx}>{children}</WalletContext.Provider>
+    <WalletContext.Provider
+      value={{
+        address,
+        balance,
+        connected,
+        loading,
+        error,
+        network,
+        activeWalletId,
+        connect,
+        disconnect,
+        refreshBalance: async () => refreshBalance(),
+        signAndSubmit,
+      }}
+    >
+      {children}
+    </WalletContext.Provider>
   );
 };

--- a/client/src/lib/walletAdapters.ts
+++ b/client/src/lib/walletAdapters.ts
@@ -1,0 +1,174 @@
+"use client";
+
+import FreighterApi from "@stellar/freighter-api";
+
+export interface WalletAdapter {
+  id: string;
+  name: string;
+  icon: string;
+  /** Returns true if this wallet is available in the current browser/environment. */
+  isAvailable(): boolean;
+  /** Returns true if this adapter supports mobile browsers. */
+  supportsMobile(): boolean;
+  getPublicKey(): Promise<string>;
+  getNetwork(): Promise<string>;
+  /** Returns the deep-link URL to open the wallet on mobile, or null if unsupported. */
+  mobileDeepLink(): string | null;
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+function isMobile(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /android|iphone|ipad|ipod|mobile/i.test(navigator.userAgent);
+}
+
+// ─── Freighter adapter ──────────────────────────────────────────────────────
+
+export const FreighterAdapter: WalletAdapter = {
+  id: "freighter",
+  name: "Freighter",
+  icon: "/wallets/freighter.svg",
+
+  isAvailable() {
+    if (typeof window === "undefined") return false;
+    return !!(window.freighter ?? window.freighterApi) || !isMobile();
+  },
+
+  supportsMobile() {
+    return false;
+  },
+
+  mobileDeepLink() {
+    return null;
+  },
+
+  async getPublicKey() {
+    const direct = window.freighter ?? window.freighterApi ?? null;
+    const pub = direct
+      ? await direct.getPublicKey()
+      : await FreighterApi.getPublicKey();
+    if (!pub) throw new Error("Freighter did not return a public key");
+    return pub;
+  },
+
+  async getNetwork() {
+    const direct = window.freighter ?? window.freighterApi ?? null;
+    if (direct?.getNetwork) return direct.getNetwork();
+    const { getCurrentNetworkName } = await import("./stellar");
+    return getCurrentNetworkName();
+  },
+};
+
+// ─── xBull adapter ─────────────────────────────────────────────────────────
+
+type XBullWindow = Window & {
+  xBullSDK?: {
+    connect(opts?: { canRequestPublicKey?: boolean; canRequestSign?: boolean }): Promise<void>;
+    getPublicKey(): Promise<string>;
+    isConnected(): Promise<boolean>;
+  };
+};
+
+export const XBullAdapter: WalletAdapter = {
+  id: "xbull",
+  name: "xBull",
+  icon: "/wallets/xbull.svg",
+
+  isAvailable() {
+    if (typeof window === "undefined") return false;
+    return !!(window as XBullWindow).xBullSDK;
+  },
+
+  supportsMobile() {
+    return false;
+  },
+
+  mobileDeepLink() {
+    return null;
+  },
+
+  async getPublicKey() {
+    const sdk = (window as XBullWindow).xBullSDK;
+    if (!sdk) throw new Error("xBull wallet extension is not installed");
+    await sdk.connect({ canRequestPublicKey: true });
+    const pub = await sdk.getPublicKey();
+    if (!pub) throw new Error("xBull did not return a public key");
+    return pub;
+  },
+
+  async getNetwork() {
+    // xBull does not expose a getNetwork call; fall back to the Stellar horizon network.
+    const { getCurrentNetworkName } = await import("./stellar");
+    return getCurrentNetworkName();
+  },
+};
+
+// ─── Rabet adapter ─────────────────────────────────────────────────────────
+
+type RabetWindow = Window & {
+  rabet?: {
+    connect(): Promise<{ publicKey: string }>;
+    getPublicKey(): Promise<string>;
+    getNetwork(): Promise<{ network: string }>;
+  };
+};
+
+export const RabetAdapter: WalletAdapter = {
+  id: "rabet",
+  name: "Rabet",
+  icon: "/wallets/rabet.svg",
+
+  isAvailable() {
+    if (typeof window === "undefined") return false;
+    return !!(window as RabetWindow).rabet;
+  },
+
+  supportsMobile() {
+    return true;
+  },
+
+  mobileDeepLink() {
+    return "https://rabet.io";
+  },
+
+  async getPublicKey() {
+    const rabet = (window as RabetWindow).rabet;
+    if (!rabet) throw new Error("Rabet wallet extension is not installed");
+    const result = await rabet.connect();
+    if (!result.publicKey) throw new Error("Rabet did not return a public key");
+    return result.publicKey;
+  },
+
+  async getNetwork() {
+    const rabet = (window as RabetWindow).rabet;
+    if (!rabet) throw new Error("Rabet wallet extension is not installed");
+    const result = await rabet.getNetwork();
+    return result.network;
+  },
+};
+
+// ─── Registry ──────────────────────────────────────────────────────────────
+
+export const WALLET_ADAPTERS: WalletAdapter[] = [
+  FreighterAdapter,
+  XBullAdapter,
+  RabetAdapter,
+];
+
+export const WALLET_PREFERENCE_KEY = "preferredWallet";
+
+export function getPreferredAdapter(): WalletAdapter {
+  if (typeof window !== "undefined") {
+    const saved = localStorage.getItem(WALLET_PREFERENCE_KEY);
+    if (saved) {
+      const found = WALLET_ADAPTERS.find((a) => a.id === saved);
+      if (found) return found;
+    }
+  }
+  return FreighterAdapter;
+}
+
+export function savePreferredAdapter(id: string) {
+  localStorage.setItem(WALLET_PREFERENCE_KEY, id);
+}

--- a/client/src/types/wallet.ts
+++ b/client/src/types/wallet.ts
@@ -7,12 +7,14 @@ export interface WalletState {
   loading: boolean;
   error: string | null;
   network: string | null; // Current Stellar network name
+  activeWalletId: string | null; // ID of the currently active wallet adapter
 }
 
 export interface WalletContextType extends WalletState {
-  connect: () => Promise<void>;
+  /** Connect using the specified wallet adapter ID, or the user's saved preference. */
+  connect: (adapterId?: string) => Promise<void>;
   disconnect: () => void;
   refreshBalance: () => Promise<void>;
-  /** Sign a transaction XDR with Freighter, submit it, and wait for confirmation. */
+  /** Sign a transaction XDR with the active wallet, submit it, and wait for confirmation. */
   signAndSubmit: (transactionXdr: string) => Promise<SignAndSubmitResult>;
 }


### PR DESCRIPTION
## Summary

- **Closes #315** — WebSocket exponential backoff, outbound message queue, malformed-message logging
- **Closes #310** — Full production server README rewrite
- **Closes #328** — Freighter mobile hang: 12 s timeout + mobile detection + actionable errors
- **Closes #330** — Pluggable multi-wallet adapter system (Freighter, xBull, Rabet) with selector UI

---

## Changes

### `agro-production/client/src/hooks/useWebSocket.ts` — fix #315

- Reconnection now uses **exponential backoff** (`1 s × 2ⁿ`, capped at 30 s) instead of a fixed 3 s delay.
- Added an **outbound message queue** (capped at 100 messages) that flushes automatically when the socket re-opens.
- Malformed incoming messages are now **logged** via `console.warn` with the raw data instead of being silently swallowed.
- Added a `send()` return value so callers can queue outbound messages.
- Unmount guard prevents reconnect attempts after the component is destroyed.

### `agro-production/server/README.md` — fix #310

Complete rewrite covering:
- Prerequisites, installation, and first-run steps
- Full **environment variable table** (all 14 variables with defaults, required flags, and descriptions)
- Database setup commands (Prisma migrate/studio)
- Startup modes (`npm run dev` vs `npm start`) and what each service does on boot
- Redis/BullMQ worker setup
- **Full API reference** (health, campaigns, orders, campaign images, demand/supply, metrics)
- **ASCII event-architecture diagram** showing the Soroban polling loop → parser → persister → WebSocket broadcast flow
- Testing section

### `client/src/lib/walletAdapters.ts` (new) — feat #330

Introduces a **`WalletAdapter` interface** with:
- `id`, `name`, `icon`, `isAvailable()`, `supportsMobile()`, `mobileDeepLink()`, `getPublicKey()`, `getNetwork()`

Three concrete adapters:
| Adapter | Detection | Mobile |
|---|---|---|
| **Freighter** | `window.freighter` / `@stellar/freighter-api` | ❌ desktop only |
| **xBull** | `window.xBullSDK` | ❌ desktop only |
| **Rabet** | `window.rabet` | ✅ (deep-link to rabet.io) |

Adapter preference persisted in `localStorage` under `preferredWallet`.

### `client/src/context/WalletContext.tsx` — feat #330 + fix #328

- `connect()` now accepts an optional `adapterId` — routes to the chosen adapter or falls back to the saved preference.
- **12-second timeout** on every connect attempt; on expiry shows a clear message telling the user to unlock their wallet and retry.
- **Mobile detection** before each connect: if the selected adapter does not support mobile, a descriptive error (with deep-link URL if available) is shown instead of opening a popup that would hang indefinitely.
- `activeWalletId` state exposed on the context.
- Session reconciliation on page load uses the cached adapter ID.

### `client/src/components/modals/wallet-modal.tsx` — feat #330

- Replaced the single "Connect Wallet" button with a **wallet-selector dialog** listing all registered adapters.
- Per-adapter availability badges ("Desktop only" / "Mobile supported").
- Inline spinner on the connecting adapter; all others disabled during connection.
- Error banner inside the dialog so users see timeout/mobile errors without the dialog closing.

### `client/src/components/onboarding/ConnectWallet.tsx` — feat #330

- Updated copy from "Freighter"-specific to wallet-agnostic ("Connect your Stellar wallet").

### `client/src/types/wallet.ts` — feat #330

- Added `activeWalletId: string | null` to `WalletState`.
- Updated `connect` signature to `(adapterId?: string) => Promise<void>` (fully backward-compatible).


Closes #315
Closes #310
Closes #328 
Closes #330