### PR TITLE
[Frontend] Improve wallet connection and reconnection handling

### DIFF
--- a/agro-production/client/src/__tests__/wallet.test.tsx
+++ b/agro-production/client/src/__tests__/wallet.test.tsx
@@ -1,7 +1,16 @@
 import React from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { WalletProvider, useWallet } from "../context/WalletContext";
+import { saveWalletSession } from "../lib/walletSession";
+
+vi.mock("../lib/walletFreighter", () => ({
+  getFreighterPublicKey: vi.fn(),
+}));
+
+import { getFreighterPublicKey } from "../lib/walletFreighter";
+
+const mockGetPublicKey = vi.mocked(getFreighterPublicKey);
 
 function TestConsumer() {
   const ctx = useWallet();
@@ -10,35 +19,89 @@ function TestConsumer() {
       <span data-testid="addr">{ctx.address ?? "-"}</span>
       <button onClick={() => ctx.connect()}>connect</button>
       <span data-testid="connected">{String(ctx.connected)}</span>
+      <span data-testid="reconnecting">{String(ctx.reconnecting)}</span>
     </div>
   );
 }
 
 describe("WalletProvider", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-    // clear localStorage
+    vi.clearAllMocks();
     globalThis.localStorage?.clear?.();
+    delete (globalThis as { freighterApi?: unknown }).freighterApi;
   });
 
-  it("connects using window.freighterApi", async () => {
-    (globalThis as any).freighterApi = {
-      getPublicKey: async () => "GTESTADDRESS",
-    };
+  it("connects using Freighter public key lookup", async () => {
+    mockGetPublicKey.mockResolvedValue("GTESTADDRESS");
+
     render(
       <WalletProvider>
         <TestConsumer />
       </WalletProvider>,
     );
 
+    await waitFor(() => {
+      expect(screen.getByTestId("reconnecting").textContent).toBe("false");
+    });
+
     const btn = screen.getByText("connect");
     await act(async () => {
       btn.click();
-      // allow effects
-      await new Promise((r) => setTimeout(r, 0));
     });
 
-    expect(screen.getByTestId("connected").textContent).toBe("true");
+    await waitFor(() => {
+      expect(screen.getByTestId("connected").textContent).toBe("true");
+    });
     expect(screen.getByTestId("addr").textContent).toBe("GTESTADDRESS");
+  });
+
+  it("restores a valid saved session on startup", async () => {
+    saveWalletSession({ address: "GSAVEDADDRESS", connectedAt: Date.now() });
+    mockGetPublicKey.mockResolvedValue("GSAVEDADDRESS");
+
+    render(
+      <WalletProvider>
+        <TestConsumer />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connected").textContent).toBe("true");
+    });
+    expect(screen.getByTestId("addr").textContent).toBe("GSAVEDADDRESS");
+  });
+
+  it("adopts the active wallet when it differs from the saved session", async () => {
+    saveWalletSession({ address: "GOLDADDRESS", connectedAt: Date.now() });
+    mockGetPublicKey.mockResolvedValue("GNEWADDRESS");
+
+    render(
+      <WalletProvider>
+        <TestConsumer />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("addr").textContent).toBe("GNEWADDRESS");
+    });
+    expect(screen.getByTestId("connected").textContent).toBe("true");
+    expect(globalThis.localStorage.getItem("ap_walletSession")).toContain("GNEWADDRESS");
+  });
+
+  it("clears stale session when Freighter is unavailable", async () => {
+    saveWalletSession({ address: "GSTALEADDRESS", connectedAt: Date.now() });
+    mockGetPublicKey.mockResolvedValue(null);
+
+    render(
+      <WalletProvider>
+        <TestConsumer />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reconnecting").textContent).toBe("false");
+    });
+    expect(screen.getByTestId("connected").textContent).toBe("false");
+    expect(globalThis.localStorage.getItem("ap_walletSession")).toBeNull();
   });
 });

--- a/agro-production/client/src/components/WalletConnect.tsx
+++ b/agro-production/client/src/components/WalletConnect.tsx
@@ -12,7 +12,8 @@ interface WalletConnectProps {
 }
 
 export default function WalletConnect({ className = "" }: WalletConnectProps) {
-  const { address, connected, loading, error, connect, disconnect } = useWallet();
+  const { address, connected, loading, reconnecting, error, connect, disconnect } = useWallet();
+  const busy = loading || reconnecting;
 
   function handleConnect() {
     connect().then(() => {
@@ -50,11 +51,11 @@ export default function WalletConnect({ className = "" }: WalletConnectProps) {
     <div className={`flex flex-col items-start gap-1 ${className}`}>
       <button
         onClick={handleConnect}
-        disabled={loading}
-        aria-label={loading ? "Connecting wallet" : "Connect wallet"}
+        disabled={busy}
+        aria-label={busy ? "Connecting wallet" : "Connect wallet"}
         className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
       >
-        {loading ? "Connecting…" : "Connect Wallet"}
+        {reconnecting ? "Reconnecting…" : loading ? "Connecting…" : "Connect Wallet"}
       </button>
       {error && (
         <p className="text-xs text-red-600 max-w-xs" role="alert">{error}</p>

--- a/agro-production/client/src/context/WalletContext.tsx
+++ b/agro-production/client/src/context/WalletContext.tsx
@@ -1,12 +1,18 @@
 "use client";
 
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
-import FreighterApi from "@stellar/freighter-api";
+import { getFreighterPublicKey } from "@/lib/walletFreighter";
+import {
+  clearWalletSession,
+  loadWalletSession,
+  saveWalletSession,
+} from "@/lib/walletSession";
 
 interface WalletContextType {
   address: string | null;
   connected: boolean;
   loading: boolean;
+  reconnecting: boolean;
   error: string | null;
   connect: () => Promise<void>;
   disconnect: () => void;
@@ -16,6 +22,7 @@ const defaultCtx: WalletContextType = {
   address: null,
   connected: false,
   loading: false,
+  reconnecting: false,
   error: null,
   connect: async () => {},
   disconnect: () => {},
@@ -27,54 +34,83 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [address, setAddress] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const saved = typeof window !== "undefined" ? localStorage.getItem("ap_walletAddress") : null;
-    if (saved) {
-      setAddress(saved);
-      setConnected(true);
-    }
+  const applyConnection = useCallback((pub: string) => {
+    setAddress(pub);
+    setConnected(true);
+    setError(null);
+    saveWalletSession({ address: pub, connectedAt: Date.now() });
   }, []);
+
+  const clearConnection = useCallback(() => {
+    setAddress(null);
+    setConnected(false);
+    setError(null);
+    clearWalletSession();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function restoreSession() {
+      const session = loadWalletSession();
+      if (!session) return;
+
+      setReconnecting(true);
+      try {
+        const pub = await getFreighterPublicKey();
+        if (cancelled) return;
+
+        if (!pub) {
+          clearWalletSession();
+          return;
+        }
+
+        if (pub !== session.address) {
+          applyConnection(pub);
+          return;
+        }
+
+        applyConnection(pub);
+      } catch {
+        if (!cancelled) clearWalletSession();
+      } finally {
+        if (!cancelled) setReconnecting(false);
+      }
+    }
+
+    void restoreSession();
+    return () => {
+      cancelled = true;
+    };
+  }, [applyConnection]);
 
   const connect = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const w = typeof window !== "undefined" ? (window as any) : null;
-      const freighterDirect =
-        (w?.freighter as { getPublicKey?: unknown } | undefined)?.getPublicKey
-          ? (w!.freighter as { getPublicKey: () => Promise<string> })
-          : (w?.freighterApi as { getPublicKey?: unknown } | undefined)?.getPublicKey
-          ? (w!.freighterApi as { getPublicKey: () => Promise<string> })
-          : null;
-
-      const pub = freighterDirect
-        ? await freighterDirect.getPublicKey()
-        : await FreighterApi.getPublicKey();
-
+      const pub = await getFreighterPublicKey();
       if (!pub) throw new Error("Could not get public key from Freighter");
-
-      setAddress(pub);
-      setConnected(true);
-      if (typeof window !== "undefined") localStorage.setItem("ap_walletAddress", pub);
+      applyConnection(pub);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setConnected(false);
+      setAddress(null);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [applyConnection]);
 
   const disconnect = useCallback(() => {
-    setAddress(null);
-    setConnected(false);
-    setError(null);
-    if (typeof window !== "undefined") localStorage.removeItem("ap_walletAddress");
-  }, []);
+    clearConnection();
+  }, [clearConnection]);
 
   return (
-    <WalletContext.Provider value={{ address, connected, loading, error, connect, disconnect }}>
+    <WalletContext.Provider
+      value={{ address, connected, loading, reconnecting, error, connect, disconnect }}
+    >
       {children}
     </WalletContext.Provider>
   );

--- a/agro-production/client/src/lib/walletFreighter.ts
+++ b/agro-production/client/src/lib/walletFreighter.ts
@@ -1,0 +1,23 @@
+import FreighterApi from "@stellar/freighter-api";
+
+type FreighterBridge = {
+  getPublicKey: () => Promise<string>;
+};
+
+function getFreighterBridge(): FreighterBridge | null {
+  if (typeof window === "undefined") return null;
+  const w = window as Window & {
+    freighter?: FreighterBridge;
+    freighterApi?: FreighterBridge;
+  };
+
+  if (w.freighter?.getPublicKey) return w.freighter;
+  if (w.freighterApi?.getPublicKey) return w.freighterApi;
+  return null;
+}
+
+export async function getFreighterPublicKey(): Promise<string | null> {
+  const bridge = getFreighterBridge();
+  const pub = bridge ? await bridge.getPublicKey() : await FreighterApi.getPublicKey();
+  return pub || null;
+}

--- a/agro-production/client/src/lib/walletSession.ts
+++ b/agro-production/client/src/lib/walletSession.ts
@@ -1,0 +1,55 @@
+const SESSION_KEY = "ap_walletSession";
+const LEGACY_ADDRESS_KEY = "ap_walletAddress";
+
+export interface WalletSession {
+  address: string;
+  connectedAt: number;
+}
+
+function isValidSession(value: unknown): value is WalletSession {
+  if (!value || typeof value !== "object") return false;
+  const session = value as WalletSession;
+  return (
+    typeof session.address === "string" &&
+    session.address.length > 0 &&
+    typeof session.connectedAt === "number" &&
+    Number.isFinite(session.connectedAt)
+  );
+}
+
+export function loadWalletSession(): WalletSession | null {
+  if (typeof window === "undefined") return null;
+
+  const raw = localStorage.getItem(SESSION_KEY);
+  if (raw) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (isValidSession(parsed)) return parsed;
+    } catch {
+      /* fall through to legacy migration */
+    }
+    localStorage.removeItem(SESSION_KEY);
+  }
+
+  const legacyAddress = localStorage.getItem(LEGACY_ADDRESS_KEY);
+  if (!legacyAddress) return null;
+
+  const migrated: WalletSession = {
+    address: legacyAddress,
+    connectedAt: Date.now(),
+  };
+  saveWalletSession(migrated);
+  localStorage.removeItem(LEGACY_ADDRESS_KEY);
+  return migrated;
+}
+
+export function saveWalletSession(session: WalletSession): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+}
+
+export function clearWalletSession(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(SESSION_KEY);
+  localStorage.removeItem(LEGACY_ADDRESS_KEY);
+}


### PR DESCRIPTION
## Summary
- Add structured wallet session persistence in localStorage with migration from the legacy address key.
- Auto-reconnect on app startup by validating the saved session against Freighter and clearing stale state when unavailable.
- Fall back to the active wallet address when it differs from the persisted session, and show a reconnecting state in the connect UI.

## Verification
- Wallet session is written on connect and removed on disconnect.
- On reload, a saved session triggers Freighter lookup; matching addresses restore as connected.
- Mismatched or missing Freighter keys clear or update persisted session accordingly.
- `WalletConnect` disables actions and shows reconnecting while startup validation runs.

Closes #314

Made with [Cursor](https://cursor.com)