### PR TITLE
Fix event deduplication and rate-limit observability (#297, #304)

### DIFF
--- a/agro-production/server/README.md
+++ b/agro-production/server/README.md
@@ -57,6 +57,7 @@ cp .env.example .env
 | `PRODUCTION_CONTRACT_ID` | — | No | Alias used by the legacy single-contract watcher (falls back to `PRODUCTION_ESCROW_CONTRACT_ID`) |
 | `RATE_LIMIT_WINDOW_MS` | `60000` | No | Rate-limit rolling window in milliseconds |
 | `RATE_LIMIT_MAX_REQUESTS` | `100` | No | Max requests per IP per window |
+| `RATE_LIMIT_WRITE_MAX_REQUESTS` | `10` | No | Max write requests per IP per window |
 | `SUPABASE_URL` | — | For images | Supabase project URL (campaign image uploads) |
 | `SUPABASE_ANON_KEY` | — | For images | Supabase anon/public key |
 | `SUPABASE_SERVICE_ROLE_KEY` | — | For images | Supabase service-role key (bypasses RLS for uploads) |
@@ -180,6 +181,7 @@ Import this URL into Swagger UI, Postman, or any OpenAPI client. Validation fail
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/metrics` | JSON snapshot of platform activity |
+| `GET` | `/metrics/rate-limits` | In-memory rate-limit hit counters (`default_hits`, `write_hits`, `total_hits`) |
 
 **Metrics response fields:**
 
@@ -196,6 +198,12 @@ Import this URL into Swagger UI, Postman, or any OpenAPI client. Validation fail
 |---|---|
 | `x-wallet-address` | POST /demand, POST /supply, POST /campaigns, POST /orders |
 | `Content-Type: application/json` | All JSON POST requests |
+
+**Rate limiting behavior:**
+
+- Default limiter applies to all routes using `RATE_LIMIT_WINDOW_MS` + `RATE_LIMIT_MAX_REQUESTS`.
+- Write limiter applies to mutating endpoints using `RATE_LIMIT_WINDOW_MS` + `RATE_LIMIT_WRITE_MAX_REQUESTS`.
+- Each rejection increments in-memory counters exposed at `/metrics/rate-limits`.
 
 ---
 

--- a/agro-production/server/README.md
+++ b/agro-production/server/README.md
@@ -245,6 +245,15 @@ Stellar / Soroban network
 4. The WebSocket server broadcasts the event to all connected frontend clients.
 5. On restart the watcher reads the highest `ledger` from the `transactions` table and resumes from there — no events are re-processed.
 
+### Event idempotency guarantees
+
+- `campaign.created` - uses `campaign.upsert` and unique `transactions(ledger,eventIndex)` checks before writes.
+- `campaign.invested` - uses replay-safe `investment.upsert` and duplicate transaction checks in preflight + transaction scope.
+- `campaign.settled` - deterministic campaign revenue/status writes guarded by duplicate checks before mutation.
+- `order.created` - `order.upsert` by on-chain order ID prevents duplicate order creation.
+- `order.confirmed` - duplicate events are dropped before order status and campaign revenue updates.
+- `campaign.produce|harvest|failed|disputed` - deterministic status writes are replay-safe and guarded by duplicate checks.
+
 ---
 
 ## WebSocket

--- a/agro-production/server/src/app.ts
+++ b/agro-production/server/src/app.ts
@@ -12,6 +12,7 @@ import orderRoutes from './routes/orders.js';
 import { globalErrorHandler } from './middleware/errors.js';
 import { HealthResponseSchema } from './schemas/health.js';
 import { serveOpenApiDocument } from './openapi/document.js';
+import { getRateLimitMetrics } from './middleware/rateLimitMetrics.js';
 
 const app = express();
 
@@ -37,6 +38,10 @@ app.get('/health', (_req: Request, res: Response) => {
 });
 
 app.get('/api/docs/openapi.json', serveOpenApiDocument);
+
+app.get('/metrics/rate-limits', (_req: Request, res: Response) => {
+  res.status(200).json(getRateLimitMetrics());
+});
 
 app.use((_req: Request, res: Response) => {
   res.status(404).json({ error: 'Not found' });

--- a/agro-production/server/src/config/index.ts
+++ b/agro-production/server/src/config/index.ts
@@ -79,6 +79,7 @@ export const config = {
   // Rate limiting
   rateLimitWindowMs: parseInt(getEnv('RATE_LIMIT_WINDOW_MS') ?? '60000', 10),
   rateLimitMaxRequests: parseInt(getEnv('RATE_LIMIT_MAX_REQUESTS') ?? '100', 10),
+  rateLimitWriteMaxRequests: parseInt(getEnv('RATE_LIMIT_WRITE_MAX_REQUESTS') ?? '10', 10),
 
   // Supabase — campaign image upload
   // SUPABASE_URL: Supabase project URL

--- a/agro-production/server/src/events/persister.test.ts
+++ b/agro-production/server/src/events/persister.test.ts
@@ -197,6 +197,34 @@ describe("EventPersister", () => {
 
       expect(prisma.$transaction).toHaveBeenCalledOnce();
     });
+
+    it("skips writes when duplicate is discovered inside transaction scope", async () => {
+      const { prisma } = await import("../db/client.js");
+      const logger = (await import("../config/logger.js")).default;
+      // Preflight sees no duplicate.
+      vi.mocked(prisma.transaction.findUnique).mockResolvedValueOnce(null);
+      vi.mocked(prisma.$transaction).mockImplementationOnce(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          await fn({
+            user: { upsert: vi.fn().mockResolvedValue({}) },
+            campaign: { findUnique: vi.fn().mockResolvedValue({ id: "camp-uuid" }) },
+            order: { upsert: vi.fn().mockResolvedValue({}) },
+            transaction: {
+              findUnique: vi.fn().mockResolvedValue({ id: "tx-inside" }),
+              create: vi.fn().mockResolvedValue({}),
+            },
+          });
+        },
+      );
+
+      await EventPersister.persist(makeOrderCreated());
+
+      expect(vi.mocked(logger.debug)).toHaveBeenCalledWith(
+        "EventPersister: skipping duplicate",
+        expect.objectContaining({ stage: "persist.tx" }),
+      );
+      expect(prisma.transaction.create).not.toHaveBeenCalled();
+    });
   });
 
   describe("campaign.created", () => {

--- a/agro-production/server/src/events/persister.test.ts
+++ b/agro-production/server/src/events/persister.test.ts
@@ -158,6 +158,7 @@ describe("EventPersister", () => {
   describe("idempotency / deduplication", () => {
     it("skips an event that already has a transaction record", async () => {
       const { prisma } = await import("../db/client.js");
+      const logger = (await import("../config/logger.js")).default;
       vi.mocked(prisma.transaction.findUnique).mockResolvedValueOnce({
         id: "tx-1",
       } as never);
@@ -166,6 +167,10 @@ describe("EventPersister", () => {
 
       // $transaction should never be called when the event is a duplicate.
       expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(vi.mocked(logger.debug)).toHaveBeenCalledWith(
+        "EventPersister: skipping duplicate",
+        expect.objectContaining({ stage: "persist.preflight" }),
+      );
     });
 
     it("processes an event that has not been seen before", async () => {

--- a/agro-production/server/src/events/persister.ts
+++ b/agro-production/server/src/events/persister.ts
@@ -73,6 +73,7 @@ async function handleCampaignCreated(event: CampaignCreatedEvent) {
     : new Date(event.deadline);
 
   await prisma.$transaction(async (tx) => {
+    if (await skipDuplicateInTransaction(tx, event)) return;
     await upsertUser(tx, event.farmer, "FARMER");
 
     const campaign = await tx.campaign.upsert({
@@ -113,6 +114,15 @@ async function hasPersistedEvent(
   return Boolean(existing);
 }
 
+async function skipDuplicateInTransaction(tx: TransactionClient, event: ParsedEvent) {
+  const alreadyProcessed = await hasPersistedEvent(tx, event.ledger, event.eventIndex);
+  if (alreadyProcessed) {
+    logDuplicateSkip(event, "persist.tx");
+    return true;
+  }
+  return false;
+}
+
 function logDuplicateSkip(event: ParsedEvent, stage: string) {
   logger.debug("EventPersister: skipping duplicate", {
     action: event.action,
@@ -124,6 +134,7 @@ function logDuplicateSkip(event: ParsedEvent, stage: string) {
 
 async function handleCampaignInvested(event: CampaignInvestedEvent) {
   await prisma.$transaction(async (tx) => {
+    if (await skipDuplicateInTransaction(tx, event)) return;
     await upsertUser(tx, event.investor, "INVESTOR");
 
     const campaign = await tx.campaign.findUnique({
@@ -182,6 +193,7 @@ async function handleCampaignInvested(event: CampaignInvestedEvent) {
 
 async function handleCampaignSettled(event: CampaignSettledEvent) {
   await prisma.$transaction(async (tx) => {
+    if (await skipDuplicateInTransaction(tx, event)) return;
     const campaign = await tx.campaign.findUnique({
       where: { onChainId: event.campaignId },
     });
@@ -220,6 +232,7 @@ async function handleCampaignSettled(event: CampaignSettledEvent) {
 
 async function handleOrderCreated(event: OrderCreatedEvent) {
   await prisma.$transaction(async (tx) => {
+    if (await skipDuplicateInTransaction(tx, event)) return;
     await upsertUser(tx, event.buyer, "BUYER");
 
     const campaign = await tx.campaign.findUnique({
@@ -259,6 +272,7 @@ async function handleOrderCreated(event: OrderCreatedEvent) {
 
 async function handleOrderConfirmed(event: OrderConfirmedEvent) {
   await prisma.$transaction(async (tx) => {
+    if (await skipDuplicateInTransaction(tx, event)) return;
     const order = await tx.order.findUnique({
       where: { onChainId: event.orderId },
     });
@@ -313,6 +327,7 @@ async function updateCampaignStatus(
   status: CampaignStatus,
 ) {
   await prisma.$transaction(async (tx) => {
+    if (await skipDuplicateInTransaction(tx, event)) return;
     const campaign = await tx.campaign.findUnique({
       where: { onChainId: event.campaignId },
     });

--- a/agro-production/server/src/events/persister.ts
+++ b/agro-production/server/src/events/persister.ts
@@ -18,16 +18,9 @@ import type {
  */
 export class EventPersister {
   static async persist(event: ParsedEvent): Promise<void> {
-    // Guard against duplicate events at the DB level via the unique index on
-    // transactions(ledger, eventIndex).
-    const alreadyProcessed = await prisma.transaction.findUnique({
-      where: { ledger_eventIndex: { ledger: event.ledger, eventIndex: event.eventIndex } },
-    });
+    const alreadyProcessed = await hasPersistedEvent(prisma, event.ledger, event.eventIndex);
     if (alreadyProcessed) {
-      logger.debug("EventPersister: skipping duplicate", {
-        ledger: event.ledger,
-        eventIndex: event.eventIndex,
-      });
+      logDuplicateSkip(event, "persist.preflight");
       return;
     }
 
@@ -104,6 +97,28 @@ async function handleCampaignCreated(event: CampaignCreatedEvent) {
         eventIndex: event.eventIndex,
       },
     });
+  });
+}
+
+type TransactionClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
+
+async function hasPersistedEvent(
+  client: Pick<typeof prisma, "transaction"> | Pick<TransactionClient, "transaction">,
+  ledger: number,
+  eventIndex: number,
+) {
+  const existing = await client.transaction.findUnique({
+    where: { ledger_eventIndex: { ledger, eventIndex } },
+  });
+  return Boolean(existing);
+}
+
+function logDuplicateSkip(event: ParsedEvent, stage: string) {
+  logger.debug("EventPersister: skipping duplicate", {
+    action: event.action,
+    ledger: event.ledger,
+    eventIndex: event.eventIndex,
+    stage,
   });
 }
 

--- a/agro-production/server/src/events/persister.ts
+++ b/agro-production/server/src/events/persister.ts
@@ -67,6 +67,7 @@ export class EventPersister {
 // ---------------------------------------------------------------------------
 
 async function handleCampaignCreated(event: CampaignCreatedEvent) {
+  // Idempotency: campaign upsert + transaction uniqueness guarantee safe replay.
   const deadlineTs = parseInt(event.deadline, 10);
   const deadline = Number.isFinite(deadlineTs)
     ? new Date(deadlineTs * 1000)
@@ -133,6 +134,7 @@ function logDuplicateSkip(event: ParsedEvent, stage: string) {
 }
 
 async function handleCampaignInvested(event: CampaignInvestedEvent) {
+  // Idempotency: investment upsert key includes campaign/investor/ledger.
   await prisma.$transaction(async (tx) => {
     if (await skipDuplicateInTransaction(tx, event)) return;
     await upsertUser(tx, event.investor, "INVESTOR");
@@ -192,6 +194,7 @@ async function handleCampaignInvested(event: CampaignInvestedEvent) {
 }
 
 async function handleCampaignSettled(event: CampaignSettledEvent) {
+  // Idempotency: status/revenue overwrite plus transaction uniqueness prevents duplication.
   await prisma.$transaction(async (tx) => {
     if (await skipDuplicateInTransaction(tx, event)) return;
     const campaign = await tx.campaign.findUnique({
@@ -231,6 +234,7 @@ async function handleCampaignSettled(event: CampaignSettledEvent) {
 }
 
 async function handleOrderCreated(event: OrderCreatedEvent) {
+  // Idempotency: order upsert by onChainId makes duplicate create events safe.
   await prisma.$transaction(async (tx) => {
     if (await skipDuplicateInTransaction(tx, event)) return;
     await upsertUser(tx, event.buyer, "BUYER");
@@ -271,6 +275,7 @@ async function handleOrderCreated(event: OrderCreatedEvent) {
 }
 
 async function handleOrderConfirmed(event: OrderConfirmedEvent) {
+  // Idempotency: duplicate confirms are dropped before order/revenue mutation.
   await prisma.$transaction(async (tx) => {
     if (await skipDuplicateInTransaction(tx, event)) return;
     const order = await tx.order.findUnique({
@@ -326,6 +331,7 @@ async function updateCampaignStatus(
   event: GenericCampaignEvent,
   status: CampaignStatus,
 ) {
+  // Idempotency: status transitions are deterministic for replayed lifecycle events.
   await prisma.$transaction(async (tx) => {
     if (await skipDuplicateInTransaction(tx, event)) return;
     const campaign = await tx.campaign.findUnique({

--- a/agro-production/server/src/middleware/rateLimit.ts
+++ b/agro-production/server/src/middleware/rateLimit.ts
@@ -1,5 +1,6 @@
 import rateLimit from "express-rate-limit";
 import { config } from "../config/index.js";
+import { incrementRateLimitHit } from "./rateLimitMetrics.js";
 
 /** Default limiter applied to all routes. */
 export const defaultLimiter = rateLimit({
@@ -7,6 +8,10 @@ export const defaultLimiter = rateLimit({
   max: config.rateLimitMaxRequests,
   standardHeaders: true,
   legacyHeaders: false,
+  handler: (req, res, _next, options) => {
+    incrementRateLimitHit("default");
+    res.status(options.statusCode).send(options.message);
+  },
   message: {
     error: "Too many requests",
     retryAfter: `${config.rateLimitWindowMs / 1000}s`,
@@ -16,9 +21,13 @@ export const defaultLimiter = rateLimit({
 /** Stricter limiter for mutating endpoints (invest, create order, etc.). */
 export const writeLimiter = rateLimit({
   windowMs: config.rateLimitWindowMs,
-  max: Math.max(1, Math.floor(config.rateLimitMaxRequests / 10)),
+  max: Math.max(1, config.rateLimitWriteMaxRequests),
   standardHeaders: true,
   legacyHeaders: false,
+  handler: (req, res, _next, options) => {
+    incrementRateLimitHit("write");
+    res.status(options.statusCode).send(options.message);
+  },
   message: {
     error: "Too many write requests",
     retryAfter: `${config.rateLimitWindowMs / 1000}s`,

--- a/agro-production/server/src/middleware/rateLimitMetrics.ts
+++ b/agro-production/server/src/middleware/rateLimitMetrics.ts
@@ -1,0 +1,18 @@
+type RateLimitBucket = "default" | "write";
+
+const counters: Record<RateLimitBucket, number> = {
+  default: 0,
+  write: 0,
+};
+
+export function incrementRateLimitHit(bucket: RateLimitBucket) {
+  counters[bucket] += 1;
+}
+
+export function getRateLimitMetrics() {
+  return {
+    default_hits: counters.default,
+    write_hits: counters.write,
+    total_hits: counters.default + counters.write,
+  };
+}


### PR DESCRIPTION
## Summary
- Hardened event persistence deduplication with explicit preflight and transaction-scope duplicate checks, plus idempotency guarantees documented per handler.
- Added replay-oriented coverage for duplicate skip paths and transaction-scope deduplication behavior.
- Made write limits configurable, instrumented limiter hit counters, and exposed `/metrics/rate-limits` for operational monitoring.

## Verification
- `git log --format='%h | %an <%ae> | %cn <%ce>' -n 10` shows all authored/committed changes on this branch are `gotethry <gotethry@gmail.com>`.
- Lint diagnostics checked for changed files; no linter errors reported.
- Tests not run (intentionally skipped per request).

Closes #297
Closes #304

Made with [Cursor](https://cursor.com)