### PR TITLE
fix(server): event-pipeline type safety, notification/WS semantics, static watcher imports, tests

### DIFF
--- a/agro-production/server/src/events/persister.ts
+++ b/agro-production/server/src/events/persister.ts
@@ -1,4 +1,4 @@
-import type { CampaignStatus, OrderStatus } from "@prisma/client";
+import type { CampaignStatus, OrderStatus, Prisma } from "@prisma/client";
 import { prisma } from "../db/client.js";
 import logger from "../config/logger.js";
 import { broadcast } from "../services/wsServer.js";
@@ -97,7 +97,7 @@ async function handleCampaignCreated(event: CampaignCreatedEvent) {
       data: {
         campaignId: campaign.id,
         eventType: event.action,
-        payload: event as unknown as Record<string, unknown>,
+        payload: toEventPayload(event),
         ledger: event.ledger,
         eventIndex: event.eventIndex,
       },
@@ -188,7 +188,7 @@ async function handleCampaignInvested(event: CampaignInvestedEvent) {
       data: {
         campaignId: campaign.id,
         eventType: event.action,
-        payload: event as unknown as Record<string, unknown>,
+        payload: toEventPayload(event),
         ledger: event.ledger,
         eventIndex: event.eventIndex,
       },
@@ -228,7 +228,7 @@ async function handleCampaignSettled(event: CampaignSettledEvent) {
       data: {
         campaignId: campaign.id,
         eventType: event.action,
-        payload: event as unknown as Record<string, unknown>,
+        payload: toEventPayload(event),
         ledger: event.ledger,
         eventIndex: event.eventIndex,
       },
@@ -269,7 +269,7 @@ async function handleOrderCreated(event: OrderCreatedEvent) {
       data: {
         campaignId: campaign.id,
         eventType: event.action,
-        payload: event as unknown as Record<string, unknown>,
+        payload: toEventPayload(event),
         ledger: event.ledger,
         eventIndex: event.eventIndex,
       },
@@ -322,7 +322,7 @@ async function handleOrderConfirmed(event: OrderConfirmedEvent) {
       data: {
         campaignId: order.campaignId,
         eventType: event.action,
-        payload: event as unknown as Record<string, unknown>,
+        payload: toEventPayload(event),
         ledger: event.ledger,
         eventIndex: event.eventIndex,
       },
@@ -351,7 +351,7 @@ async function updateCampaignStatus(
       data: {
         campaignId: campaign.id,
         eventType: event.action,
-        payload: event as unknown as Record<string, unknown>,
+        payload: toEventPayload(event),
         ledger: event.ledger,
         eventIndex: event.eventIndex,
       },
@@ -364,18 +364,30 @@ async function recordTransaction(event: ParsedEvent, campaignId: string | null) 
     data: {
       campaignId,
       eventType: event.action,
-      payload: event as unknown as Record<string, unknown>,
+      payload: toEventPayload(event),
       ledger: event.ledger,
       eventIndex: event.eventIndex,
     },
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function upsertUser(tx: any, walletAddress: string, role: string) {
+async function upsertUser(
+  tx: Prisma.TransactionClient,
+  walletAddress: string,
+  role: string,
+) {
   await tx.user.upsert({
     where: { walletAddress },
     create: { walletAddress, role },
     update: {},
   });
+}
+
+/**
+ * Serialize a parsed event into a Prisma-storable JSON payload. The round-trip
+ * normalizes non-JSON values (e.g. the `timestamp` Date becomes an ISO string),
+ * which is what Prisma would persist anyway.
+ */
+function toEventPayload(event: ParsedEvent): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(event)) as Prisma.InputJsonValue;
 }

--- a/server/src/services/contractWatcher.test.ts
+++ b/server/src/services/contractWatcher.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./notificationService.js", () => ({
+  NotificationService: { notifyFromEscrowEvent: vi.fn() },
+}));
+vi.mock("./wsManager.js", () => ({
+  wsManager: { broadcast: vi.fn(), broadcastTo: vi.fn() },
+}));
+vi.mock("./events/blockchainEventIngestionService.js", () => ({
+  BlockchainEventIngestionService: { ingestEvent: vi.fn() },
+}));
+vi.mock("./events/escrowEventIngestionService.js", () => ({
+  EscrowEventIngestionService: { ingestEvent: vi.fn() },
+}));
+vi.mock("../config/logger.js", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../config/index.js", () => ({
+  config: { contractId: "CONTRACT", rpcUrl: "https://rpc.example", wsPath: "/ws" },
+}));
+
+import { dispatchEvent } from "./contractWatcher.js";
+import { NotificationService } from "./notificationService.js";
+import { wsManager } from "./wsManager.js";
+
+describe("contractWatcher dispatchEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes a 'created' event to a notification and a broadcast", () => {
+    dispatchEvent("created", ["order-1", "BUYER", "FARMER", "100", "TOKEN"], 42);
+
+    expect(NotificationService.notifyFromEscrowEvent).toHaveBeenCalledWith({
+      action: "created",
+      buyerAddress: "BUYER",
+      farmerAddress: "FARMER",
+      orderId: "order-1",
+      amount: "100",
+      token: "TOKEN",
+    });
+    expect(wsManager.broadcast).toHaveBeenCalledWith("order:created", {
+      orderId: "order-1",
+      buyer: "BUYER",
+      farmer: "FARMER",
+      amount: "100",
+      token: "TOKEN",
+    });
+  });
+
+  it("broadcasts 'delivered' as a status update without a notification", () => {
+    dispatchEvent("delivered", ["order-2", "FARMER", "BUYER", "1700000000"], 43);
+
+    expect(wsManager.broadcast).toHaveBeenCalledWith("order:delivered", {
+      orderId: "order-2",
+      farmer: "FARMER",
+      buyer: "BUYER",
+    });
+    expect(NotificationService.notifyFromEscrowEvent).not.toHaveBeenCalled();
+  });
+
+  it("routes 'confirmed' to a notification and a broadcast", () => {
+    dispatchEvent("confirmed", ["order-3", "BUYER", "FARMER"]);
+
+    expect(NotificationService.notifyFromEscrowEvent).toHaveBeenCalledWith({
+      action: "confirmed",
+      buyerAddress: "BUYER",
+      farmerAddress: "FARMER",
+      orderId: "order-3",
+    });
+    expect(wsManager.broadcast).toHaveBeenCalledWith("order:confirmed", {
+      orderId: "order-3",
+      buyer: "BUYER",
+      farmer: "FARMER",
+    });
+  });
+
+  it("routes 'refunded' to a notification and a broadcast", () => {
+    dispatchEvent("refunded", ["order-4", "BUYER"]);
+
+    expect(NotificationService.notifyFromEscrowEvent).toHaveBeenCalledWith({
+      action: "refunded",
+      buyerAddress: "BUYER",
+      orderId: "order-4",
+    });
+    expect(wsManager.broadcast).toHaveBeenCalledWith("order:refunded", {
+      orderId: "order-4",
+      buyer: "BUYER",
+    });
+  });
+
+  it("ignores unknown actions without notifying or broadcasting", () => {
+    dispatchEvent("bogus", ["order-5"]);
+
+    expect(NotificationService.notifyFromEscrowEvent).not.toHaveBeenCalled();
+    expect(wsManager.broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/contractWatcher.ts
+++ b/server/src/services/contractWatcher.ts
@@ -3,6 +3,8 @@ import logger from "../config/logger.js";
 import { config } from "../config/index.js";
 import { NotificationService } from "./notificationService.js";
 import { wsManager } from "./wsManager.js";
+import { BlockchainEventIngestionService } from "./events/blockchainEventIngestionService.js";
+import { EscrowEventIngestionService } from "./events/escrowEventIngestionService.js";
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -42,11 +44,22 @@ function decodeEvent(event: any): { action: string; data: unknown[] } | null {
 function handleEvent(event: any): void {
   const decoded = decodeEvent(event);
   if (!decoded) return;
+  dispatchEvent(decoded.action, decoded.data, event.ledger);
+}
 
-  const { action, data } = decoded;
+/**
+ * Dispatches a decoded escrow event to the notification service and WebSocket
+ * broadcast. Split out from {@link handleEvent} (which handles XDR decoding) so
+ * the routing logic can be unit-tested with plain decoded data.
+ */
+export function dispatchEvent(
+  action: string,
+  data: unknown[],
+  ledger?: number,
+): void {
   const orderId = String(data[0] ?? "");
 
-  logger.info(`[ContractWatcher] Event received: ${action} | order: ${orderId} | ledger: ${event.ledger}`);
+  logger.info(`[ContractWatcher] Event received: ${action} | order: ${orderId} | ledger: ${ledger ?? "?"}`);
 
   switch (action) {
     case "created": {
@@ -152,14 +165,16 @@ export async function startContractWatcher(): Promise<void> {
       });
 
       for (const event of response.events) {
-        // Route through the structured ingestion pipeline (persistence + projection)
-        void import("./events/blockchainEventIngestionService.js")
-          .then(({ BlockchainEventIngestionService }) => BlockchainEventIngestionService.ingestEvent(event))
-          .catch((err) => logger.error("[ContractWatcher] BlockchainEventIngestionService import failed", err));
+        // Route through the structured ingestion pipeline (persistence + projection).
+        // Services are imported statically at module load, not re-imported every
+        // iteration of the polling loop.
+        void BlockchainEventIngestionService.ingestEvent(event).catch((err) =>
+          logger.error("[ContractWatcher] BlockchainEventIngestionService failed", err),
+        );
 
-        void import("./events/escrowEventIngestionService.js")
-          .then(({ EscrowEventIngestionService }) => EscrowEventIngestionService.ingestEvent(event))
-          .catch((err) => logger.error("[ContractWatcher] EscrowEventIngestionService import failed", err));
+        void EscrowEventIngestionService.ingestEvent(event).catch((err) =>
+          logger.error("[ContractWatcher] EscrowEventIngestionService failed", err),
+        );
 
         // Dispatch notifications and real-time WebSocket events
         handleEvent(event);

--- a/server/src/services/notificationService.test.ts
+++ b/server/src/services/notificationService.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../config/database.js", () => ({
+  prisma: {
+    notification: { create: vi.fn().mockResolvedValue({ id: "notif-1" }) },
+  },
+  default: {},
+}));
+vi.mock("./wsManager.js", () => ({
+  wsManager: { broadcast: vi.fn(), broadcastTo: vi.fn() },
+}));
+vi.mock("../utils/notificationTemplates.js", () => ({
+  buildNotificationMessage: vi.fn(() => "rendered message"),
+}));
+vi.mock("../config/logger.js", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { NotificationService } from "./notificationService.js";
+import { wsManager } from "./wsManager.js";
+import { prisma } from "../config/database.js";
+import { NotificationEventType } from "../enums/notificationEventType.js";
+
+const create = vi.mocked(prisma.notification.create);
+const broadcastTo = vi.mocked(wsManager.broadcastTo);
+
+describe("NotificationService.notifyFromEscrowEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    create.mockResolvedValue({ id: "notif-1" } as never);
+  });
+
+  it("notifies the buyer (ORDER_CREATED) and farmer (FUNDS_LOCKED) on 'created'", async () => {
+    await NotificationService.notifyFromEscrowEvent({
+      action: "created",
+      buyerAddress: "BUYER",
+      farmerAddress: "FARMER",
+      orderId: "order-1",
+      amount: "100",
+      token: "TOKEN",
+    });
+
+    const types = create.mock.calls.map((c) => (c[0] as { data: { type: string } }).data.type);
+    const wallets = create.mock.calls.map(
+      (c) => (c[0] as { data: { walletAddress: string } }).data.walletAddress,
+    );
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(types).toContain(NotificationEventType.ORDER_CREATED);
+    expect(types).toContain(NotificationEventType.FUNDS_LOCKED);
+    expect(wallets).toEqual(expect.arrayContaining(["BUYER", "FARMER"]));
+    // Each persisted notification is pushed to its owner over the socket.
+    expect(broadcastTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("notifies only the farmer (DELIVERY_CONFIRMED) on 'confirmed'", async () => {
+    await NotificationService.notifyFromEscrowEvent({
+      action: "confirmed",
+      buyerAddress: "BUYER",
+      farmerAddress: "FARMER",
+      orderId: "order-2",
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect((create.mock.calls[0][0] as { data: Record<string, unknown> }).data).toMatchObject({
+      walletAddress: "FARMER",
+      type: NotificationEventType.DELIVERY_CONFIRMED,
+      orderId: "order-2",
+    });
+  });
+
+  it("does nothing for an unmapped action", async () => {
+    await NotificationService.notifyFromEscrowEvent({
+      action: "delivered",
+      orderId: "order-3",
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(broadcastTo).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/notificationService.ts
+++ b/server/src/services/notificationService.ts
@@ -52,25 +52,11 @@ function walletCandidates(walletAddress: string): string[] {
 }
 
 /**
- * Maps a contract action to the notifications that should be dispatched.
- *   created   → ORDER_RECEIVED (farmer) + NEW_INVESTMENT (farmer)
- *   confirmed → CAMPAIGN_FUNDED (farmer)
- *   refunded  → HARVEST_COMPLETED (buyer)
- */
-const actionToNotifications: Record<string, (p: EscrowEventPayload) => MappedNotification[]> = {
-  created: ({ farmerAddress }) => farmerAddress ? [
-    { walletAddress: farmerAddress, type: NotificationEventType.ORDER_RECEIVED },
-    { walletAddress: farmerAddress, type: NotificationEventType.NEW_INVESTMENT },
-  ] : [],
-  confirmed: ({ farmerAddress }) =>
-    farmerAddress ? [{ walletAddress: farmerAddress, type: NotificationEventType.CAMPAIGN_FUNDED }] : [],
-  refunded: ({ buyerAddress }) =>
-    buyerAddress ? [{ walletAddress: buyerAddress, type: NotificationEventType.HARVEST_COMPLETED }] : [],
  * Maps a contract action to the list of notifications that should be sent.
- * - "created"   → OrderCreated (buyer) + FundsLocked (farmer)
+ * - "created"   → ORDER_CREATED (buyer) + FUNDS_LOCKED (farmer)
  * - "delivered" → no notification (internal state change)
- * - "confirmed" → DeliveryConfirmed (farmer)
- * - "refunded"  → RefundIssued (buyer)
+ * - "confirmed" → DELIVERY_CONFIRMED (farmer)
+ * - "refunded"  → REFUND_ISSUED (buyer)
  */
 const actionToNotifications: Record<string, (p: EscrowEventPayload) => MappedNotification[]> = {
   created: ({ buyerAddress, farmerAddress }) => [
@@ -180,10 +166,8 @@ export class NotificationService {
    * Broadcast a generic order event to all connected WebSocket clients.
    * Used by the ingestion pipeline for dispute/resolution events.
    */
-  static notifyOrderEvent(event: string, data: unknown): void {
-    logger.info(`[NotificationService] Broadcasting event: ${event}`);
   /** Generic order-event notification (used by ingestion pipeline). */
-  static async notifyOrderEvent(event: string, data: any): Promise<void> {
+  static async notifyOrderEvent(event: string, data: unknown): Promise<void> {
     logger.info(`[NotificationService] Emitting event: ${event}`);
     wsManager.broadcast(`order:${event}`, data);
   }

--- a/server/src/services/wsManager.ts
+++ b/server/src/services/wsManager.ts
@@ -62,6 +62,20 @@ class WsManager {
   }
 
   /**
+   * Send a message to a single client, guarding against send failures.
+   * A failed send drops the client so it can't wedge the broadcast loop.
+   */
+  private safeSend(ws: WebSocket, message: string): void {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    try {
+      ws.send(message);
+    } catch (err) {
+      logger.error("WebSocket send failed; dropping client", err);
+      this.clients.delete(ws);
+    }
+  }
+
+  /**
    * Broadcast an event to every connected client.
    */
   broadcast(event: string, payload: unknown): void {
@@ -72,9 +86,7 @@ class WsManager {
     });
 
     for (const { ws } of this.clients.values()) {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(message);
-      }
+      this.safeSend(ws, message);
     }
   }
 
@@ -89,11 +101,8 @@ class WsManager {
     });
 
     for (const client of this.clients.values()) {
-      if (
-        client.wallet?.toLowerCase() === wallet.toLowerCase() &&
-        client.ws.readyState === WebSocket.OPEN
-      ) {
-        client.ws.send(message);
+      if (client.wallet?.toLowerCase() === wallet.toLowerCase()) {
+        this.safeSend(client.ws, message);
       }
     }
   }


### PR DESCRIPTION
## Summary

Four backend event-pipeline issues, batched into one PR.

### #296 — TypeScript type safety in the event pipeline (`agro-production/server/src/events`)
- `upsertUser(tx: any)` → `tx: Prisma.TransactionClient` (removes the only `as any` and its eslint-disable).
- The seven `payload: event as unknown as Record<string, unknown>` casts are replaced with a single documented `toEventPayload(event): Prisma.InputJsonValue` helper (JSON round-trip, so the `timestamp` Date is stored as an ISO string — exactly what Prisma persists anyway).
- These casts were actually breaking the build: on `main`, `persister.ts` had **7** `Type 'Record<string, unknown>' is not assignable to type 'JsonNull | InputJsonValue'` errors. This change clears all 7 (agro-production `tsc` errors 27 → 20; the rest are pre-existing in unrelated files).

### #295 — Notification and WebSocket event semantics (`server/src/services`)
- `notificationService.ts` was **non-compiling on `main`** — a botched merge had duplicated `actionToNotifications` (the first object literal wasn't even closed) and `notifyOrderEvent`. Resolved to a single coherent order-lifecycle mapping (`created → ORDER_CREATED` (buyer) + `FUNDS_LOCKED` (farmer); `confirmed → DELIVERY_CONFIRMED`; `refunded → REFUND_ISSUED`) that matches `contractWatcher` and the `NotificationEventType` enum, and a single typed `notifyOrderEvent(event, data: unknown)`.
- `wsManager` gains a `safeSend` guard: a failing `ws.send` is caught, logged, and the dead client is dropped so it can't wedge the broadcast loop. (`broadcastTo` user-routing and the `{event, payload, timestamp}` envelope were already in place.)
- Net effect: `server` `tsc` errors drop from **28** to **1** (the remaining one is a pre-existing, unrelated error in `orderController.ts`).

### #293 — Dynamic imports in the event watcher (`server/src/services/contractWatcher.ts`)
- The two ingestion services were `await import(...)`-ed on **every event of every poll iteration**. They're now imported statically at module load and called directly; behavior is unchanged.

### #292 — Tests for event ingestion / watcher
- `contractWatcher` dispatch was split into a testable `dispatchEvent(action, data, ledger)` seam. New unit tests cover `created` / `delivered` / `confirmed` / `refunded` / unknown routing to the notification service and WebSocket broadcast.
- New `notificationService` tests cover the action→notification-type mapping and the unmapped-action no-op.

## Tests
- `server` (new tests): `npx vitest run src/services/contractWatcher.test.ts src/services/notificationService.test.ts` → **8 passing**.
- `server` `tsc --noEmit`: 28 → 1 error (the remaining one pre-existing, unrelated).
- `agro-production/server` `tsc --noEmit`: 27 → 20 errors (7 fixed in `persister.ts`).
- `agro-production/server` events tests unchanged by this PR (5 pre-existing failures remain — see below).

## Test plan
- [ ] `cd server && npx vitest run src/services/contractWatcher.test.ts src/services/notificationService.test.ts`
- [ ] `cd server && npx tsc --noEmit` (only the pre-existing `orderController.ts` error remains)
- [ ] `cd agro-production/server && npx tsc --noEmit` (no errors remain in `events/`)

## Out of scope (pre-existing on `main`, not addressed here)
- `server/package-lock.json` is corrupted JSON (so `npm ci` fails; `npm install` was used locally and the regenerated lockfile is intentionally **not** committed).
- `server` `orderController.ts(62,3)` syntax error.
- `agro-production/server`: missing `@nestjs/common` / `ws` type deps, `price-engine`, `sorobanEventListener`, and several test-file type errors; 5 pre-existing `persister.test.ts` failures.

Closes #296
Closes #295
Closes #293
Closes #292