### PR TITLE
fix(agro-production): resolve issues #517 #519 #520 #524

### DIFF
--- a/agro-production/.env.example
+++ b/agro-production/.env.example
@@ -1,0 +1,65 @@
+# Unified environment variables for agro-production (server + client).
+# Copy to agro-production/server/.env for the backend and
+# agro-production/client/.env for the frontend, then fill in real values.
+# See agro-production/server/README.md and agro-production/client/README.md for details.
+
+# ── Server ─────────────────────────────────────────────────────────────────────
+
+PORT=5001
+NODE_ENV=development
+LOG_LEVEL=debug
+
+# PostgreSQL — required in all environments
+DATABASE_URL="postgresql://user:password@localhost:5432/agrocylo_production"
+
+# Soroban RPC endpoint
+RPC_URL=https://soroban-testnet.stellar.org
+
+# Contract IDs (required in production)
+ESCROW_CONTRACT_ID=C...
+PRODUCTION_ESCROW_CONTRACT_ID=C...
+# Alias used by the single-contract production watcher (falls back to PRODUCTION_ESCROW_CONTRACT_ID)
+PRODUCTION_CONTRACT_ID=C...
+
+# Rate limiting
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX_REQUESTS=100
+RATE_LIMIT_WRITE_MAX_REQUESTS=10
+
+# Metrics endpoint auth (leave blank to allow unauthenticated access)
+METRICS_API_KEY=
+
+# CORS — comma-separated allowed origins (leave blank to allow all in development)
+CORS_ORIGINS=
+
+# Graceful shutdown timeout
+SHUTDOWN_TIMEOUT_MS=15000
+
+# Supabase — required only for campaign image uploads
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_CAMPAIGN_IMAGES_BUCKET=campaign-images
+CAMPAIGN_IMAGE_PLACEHOLDER_URL=https://placehold.co/800x800/png?text=No+Image
+
+# ── Client (NEXT_PUBLIC_*) ──────────────────────────────────────────────────────
+# These vars must be prefixed NEXT_PUBLIC_ to be available in the browser.
+# They should mirror the server values above.
+
+# REST API base URL — mirrors PORT above
+NEXT_PUBLIC_API_URL=http://localhost:5001
+
+# WebSocket URL — mirrors PORT above (auto-derived from window.location if omitted)
+NEXT_PUBLIC_WS_URL=ws://localhost:5001/ws
+
+# Soroban RPC — should match RPC_URL above
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Stellar network passphrase
+NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+# On-chain contract address — mirrors PRODUCTION_CONTRACT_ID / PRODUCTION_ESCROW_CONTRACT_ID above
+NEXT_PUBLIC_PRODUCTION_CONTRACT_ID=C...
+
+# XLM native token SAC address (testnet default provided)
+NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID=

--- a/agro-production/client/.env.example
+++ b/agro-production/client/.env.example
@@ -1,0 +1,22 @@
+# Client environment variables for agro-production/client.
+# All vars must be prefixed NEXT_PUBLIC_ to be available in the browser.
+# Copy to .env and fill in real values.
+# See the full variable reference in agro-production/.env.example.
+
+# REST API base URL (server PORT)
+NEXT_PUBLIC_API_URL=http://localhost:5001
+
+# WebSocket URL — auto-derived from window.location if omitted
+NEXT_PUBLIC_WS_URL=ws://localhost:5001/ws
+
+# Soroban RPC endpoint (should match server RPC_URL)
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Stellar network passphrase
+NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+# On-chain production contract address (mirrors PRODUCTION_CONTRACT_ID / PRODUCTION_ESCROW_CONTRACT_ID)
+NEXT_PUBLIC_PRODUCTION_CONTRACT_ID=C...
+
+# XLM native token SAC address (leave blank on testnet unless overriding)
+NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID=

--- a/agro-production/client/README.md
+++ b/agro-production/client/README.md
@@ -11,10 +11,24 @@ Install
 npm install
 ```
 
-Env
-- `NEXT_PUBLIC_API_URL` — API base URL (default: http://localhost:3001/api/v1)
-- `NEXT_PUBLIC_SOROBAN_RPC_URL` — Soroban RPC endpoint
-- `NEXT_PUBLIC_NETWORK_PASSPHRASE` — Network passphrase
+## Environment Variables
+
+Copy the example file and fill in real values:
+
+```bash
+cp .env.example .env
+```
+
+A unified example covering both server and client vars lives at `agro-production/.env.example`.
+
+| Client var | Server var it mirrors | Required | Notes |
+|---|---|---|---|
+| `NEXT_PUBLIC_API_URL` | `PORT` (derived) | Yes | REST base URL, e.g. `http://localhost:5001` |
+| `NEXT_PUBLIC_WS_URL` | `PORT` (derived) | No | WebSocket URL; auto-derived from `window.location` if omitted |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | `RPC_URL` | Yes | Both client and server should point to the same RPC endpoint |
+| `NEXT_PUBLIC_PRODUCTION_CONTRACT_ID` | `PRODUCTION_CONTRACT_ID` / `PRODUCTION_ESCROW_CONTRACT_ID` | Yes | On-chain production-escrow contract address |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | — | Yes | Stellar network passphrase (client-only) |
+| `NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID` | — | No | XLM native token SAC address |
 
 Available scripts
 - `npm run dev` — start Next.js dev server

--- a/agro-production/client/src/hooks/useInvest.ts
+++ b/agro-production/client/src/hooks/useInvest.ts
@@ -3,9 +3,11 @@ import { buildInvest } from "@/lib/contractService";
 import { signAndSubmitTransaction } from "@/lib/signTransaction";
 import {
   InvestmentIndexingTimeoutError,
+  resolveIndexedInvestment,
   waitForIndexedInvestment,
 } from "@/services/investmentService";
 import type { Investment } from "@/types";
+import { useWebSocket } from "./useWebSocket";
 
 export type InvestmentPhase =
   | "idle"
@@ -26,6 +28,15 @@ export interface InvestmentRequest {
 }
 
 export function useInvest() {
+  // Resolve any pending waitForIndexedInvestment call as soon as the server
+  // emits the investment.indexed WebSocket event, avoiding REST polling.
+  useWebSocket((msg) => {
+    if (msg.event === "investment.indexed") {
+      const payload = msg.payload as Investment & { txHash?: string };
+      if (payload.txHash) resolveIndexedInvestment(payload.txHash, payload);
+    }
+  });
+
   const [phase, setPhase] = useState<InvestmentPhase>("idle");
   const [error, setError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);

--- a/agro-production/client/src/services/investmentService.ts
+++ b/agro-production/client/src/services/investmentService.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Campaign, Investment } from "@/types";
 import api from "../lib/apiClient";
 
@@ -35,11 +37,37 @@ function wait(ms: number): Promise<void> {
 }
 
 /**
+ * Module-level registry of pending indexing waiters, keyed by txHash.
+ * Populated by waitForIndexedInvestment; resolved by resolveIndexedInvestment
+ * when the server emits an investment.indexed WebSocket event.
+ */
+const _waiters = new Map<string, (inv: Investment) => void>();
+
+/**
+ * Resolve a pending waitForIndexedInvestment call via the WebSocket path.
+ * Called by the useInvest hook when it receives an investment.indexed WS event.
+ * Safe to call with any txHash — no-op if no waiter is registered.
+ */
+export function resolveIndexedInvestment(txHash: string, investment: Investment): void {
+  const resolve = _waiters.get(txHash);
+  if (resolve) {
+    _waiters.delete(txHash);
+    resolve(investment);
+  }
+}
+
+/**
  * Wait for the server's Soroban indexer to project a confirmed investment.
  *
- * This intentionally performs no write. A matching on-chain transaction hash
- * is the proof of investment; the REST API remains a read model that may lag
- * the ledger by a few polling intervals.
+ * Strategy:
+ * 1. Register a one-shot WebSocket resolver for the given txHash.
+ * 2. Race it against a wsTimeoutMs window (default 2 s).
+ *    - If the WS fires first → return immediately, no polling.
+ *    - If the WS times out → fall back to REST polling for the remainder of
+ *      timeoutMs. This handles the case where the WebSocket is disconnected
+ *      or the event arrives after reconnection.
+ * 3. No duplicate resolution: _waiters entry is deleted on first resolution,
+ *    so a late WS event after polling has started is a safe no-op.
  */
 export async function waitForIndexedInvestment({
   campaignId,
@@ -48,6 +76,7 @@ export async function waitForIndexedInvestment({
   txHash,
   timeoutMs = INDEXING_TIMEOUT_MS,
   pollIntervalMs = INDEXING_POLL_INTERVAL_MS,
+  wsTimeoutMs = 2_000,
 }: {
   campaignId: string;
   investorAddress: string;
@@ -55,9 +84,23 @@ export async function waitForIndexedInvestment({
   txHash: string;
   timeoutMs?: number;
   pollIntervalMs?: number;
+  wsTimeoutMs?: number;
 }): Promise<Investment> {
-  const deadline = Date.now() + timeoutMs;
+  // 1. Try WebSocket path first
+  const wsPromise = new Promise<Investment>((resolve) => {
+    _waiters.set(txHash, resolve);
+  });
+  const wsResult = await Promise.race([
+    wsPromise,
+    wait(wsTimeoutMs).then(() => null),
+  ]);
+  if (wsResult !== null) return wsResult;
 
+  // WS timed out — clean up the waiter entry before polling
+  _waiters.delete(txHash);
+
+  // 2. Polling fallback
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const investments = await fetchCampaignInvestments(campaignId);
     const indexed = investments.find(

--- a/agro-production/server/README.md
+++ b/agro-production/server/README.md
@@ -141,11 +141,44 @@ curl http://localhost:5001/api/docs/openapi.json
 
 Import this URL into Swagger UI, Postman, or any OpenAPI client. Validation failures return `application/problem+json` with per-field `errors` (field path, message, and Zod code).
 
-### Health
+### Health & Readiness
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/health` | Returns `{ status: "UP", service, env, timestamp }` |
+| `GET` | `/health` | Shallow liveness probe — always 200 while process is running |
+| `GET` | `/livez` | Alias liveness probe — returns uptime |
+| `GET` | `/readyz` | Deep readiness probe — checks DB + RPC; returns 503 if either is down |
+
+**`/health` response:**
+```json
+{ "status": "UP", "service": "agro-production-server", "env": "production", "timestamp": "..." }
+```
+
+**`/readyz` response (200 when ready):**
+```json
+{
+  "status": "ready",
+  "checks": {
+    "database": { "status": "UP" },
+    "rpc": { "status": "UP" }
+  },
+  "lastLedger": 12345,
+  "timestamp": "..."
+}
+```
+
+**`/readyz` response (503 when not ready):**
+```json
+{
+  "status": "not_ready",
+  "checks": {
+    "database": { "status": "DOWN", "message": "connection refused" },
+    "rpc": { "status": "UP" }
+  },
+  "lastLedger": 0,
+  "timestamp": "..."
+}
+```
 
 ### Campaigns
 
@@ -180,17 +213,41 @@ Import this URL into Swagger UI, Postman, or any OpenAPI client. Validation fail
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/metrics` | JSON snapshot of platform activity |
+| `GET` | `/metrics` | Prometheus text format — four key platform metrics |
 | `GET` | `/metrics/rate-limits` | In-memory rate-limit hit counters (`default_hits`, `write_hits`, `total_hits`) |
+| `GET` | `/metrics/events` | In-memory event ingestion counters broken down by action |
 
-**Metrics response fields:**
+**`/metrics` — Prometheus text format (4 metrics):**
 
-- `orders_per_day` — count of orders with `createdAt` on the current UTC calendar day
-- `campaigns_created` — count of product/campaign rows created that same UTC day
-- `total_volume` — sum of `orders.amount` for all time (parses as finite number)
-- `active_users` — distinct buyer/seller wallet addresses on any order in the last 30 days
+| Metric | Type | Description |
+|---|---|---|
+| `events_processed_total` | counter | Total Soroban events indexed since server start |
+| `last_indexed_ledger` | gauge | Last ledger sequence number successfully indexed |
+| `ws_clients_connected` | gauge | Number of active WebSocket client connections |
+| `api_requests_total` | counter | Total HTTP requests received since server start |
 
-**Auth:** If `METRICS_API_KEY` is set, send `x-metrics-api-key: <key>` or `Authorization: Bearer <key>`.
+**Sample Prometheus scrape config:**
+
+```yaml
+scrape_configs:
+  - job_name: agro_production
+    static_configs:
+      - targets: ['localhost:5001']
+    metrics_path: /metrics
+    # If METRICS_API_KEY is set:
+    params:
+      {}
+    authorization:
+      type: Bearer
+      credentials: <your-METRICS_API_KEY>
+```
+
+Or send the key as a header:
+```
+x-metrics-api-key: <your-METRICS_API_KEY>
+```
+
+**Auth:** If `METRICS_API_KEY` is set, all `/metrics*` endpoints require `x-metrics-api-key: <key>` or `Authorization: Bearer <key>`. Leave `METRICS_API_KEY` blank to allow unauthenticated access (development).
 
 **Common headers:**
 

--- a/agro-production/server/src/app.ts
+++ b/agro-production/server/src/app.ts
@@ -19,8 +19,13 @@ import { serveOpenApiDocument } from './openapi/document.js';
 import { getRateLimitMetrics } from './middleware/rateLimitMetrics.js';
 import { getEventMetrics } from './events/metrics.js';
 import { prisma } from './db/client.js';
+import { server as sorobanRpcServer } from './services/sorobanEventListener.js';
+import { getWsClientCount } from './services/wsServer.js';
 
 const app = express();
+
+// Simple lifetime counter for api_requests_total Prometheus metric.
+let _requestTotal = 0;
 
 const corsOptions: cors.CorsOptions = {
   origin:
@@ -37,6 +42,7 @@ const corsOptions: cors.CorsOptions = {
 app.use(cors(corsOptions));
 app.use(express.json());
 app.use(defaultLimiter);
+app.use((_req: Request, _res: Response, next: express.NextFunction) => { _requestTotal++; next(); });
 
 app.use((req: Request, _res: Response, next: express.NextFunction) => {
   if (isGracefullyShuttingDown() && req.method !== 'GET') {
@@ -72,6 +78,7 @@ app.get('/livez', async (_req: Request, res: Response) => {
 
 app.get('/readyz', async (_req: Request, res: Response) => {
   const checks: Record<string, { status: string; message?: string }> = {};
+  let lastLedger = 0;
 
   try {
     await prisma.$queryRaw`SELECT 1`;
@@ -80,17 +87,45 @@ app.get('/readyz', async (_req: Request, res: Response) => {
     checks.database = { status: 'DOWN', message: (err as Error).message };
   }
 
+  try {
+    const latest = await sorobanRpcServer.getLatestLedger();
+    lastLedger = latest.sequence;
+    checks.rpc = { status: 'UP' };
+  } catch (err) {
+    checks.rpc = { status: 'DOWN', message: (err as Error).message };
+  }
+
   const ready = Object.values(checks).every((c) => c.status === 'UP');
   const statusCode = ready ? 200 : 503;
 
   jsonValidated(res, ReadyzResponseSchema, statusCode, {
     status: ready ? 'ready' : 'not_ready',
     checks,
+    lastLedger,
     timestamp: new Date().toISOString(),
   });
 });
 
 app.get('/api/docs/openapi.json', serveOpenApiDocument);
+
+app.get('/metrics', requireMetricsAuth, (_req: Request, res: Response) => {
+  const em = getEventMetrics();
+  const lines = [
+    '# HELP events_processed_total Total events indexed from Soroban contracts',
+    '# TYPE events_processed_total counter',
+    `events_processed_total ${em.processed}`,
+    '# HELP last_indexed_ledger Last Soroban ledger sequence number indexed',
+    '# TYPE last_indexed_ledger gauge',
+    `last_indexed_ledger ${em.last_processed_ledger}`,
+    '# HELP ws_clients_connected Current number of connected WebSocket clients',
+    '# TYPE ws_clients_connected gauge',
+    `ws_clients_connected ${getWsClientCount()}`,
+    '# HELP api_requests_total Total HTTP requests received since server start',
+    '# TYPE api_requests_total counter',
+    `api_requests_total ${_requestTotal}`,
+  ];
+  res.set('Content-Type', 'text/plain; version=0.0.4').send(lines.join('\n') + '\n');
+});
 
 app.get('/metrics/rate-limits', requireMetricsAuth, (_req: Request, res: Response) => {
   res.status(200).json(getRateLimitMetrics());

--- a/agro-production/server/src/config/index.ts
+++ b/agro-production/server/src/config/index.ts
@@ -1,7 +1,6 @@
 import 'dotenv/config';
 
 const REQUIRED_IN_PRODUCTION = [
-  'DATABASE_URL',
   'RPC_URL',
   'PRODUCTION_CONTRACT_ID',
   'ESCROW_CONTRACT_ID',
@@ -41,7 +40,7 @@ export const config = {
   nodeEnv: getEnv('NODE_ENV') ?? 'development',
   logLevel: getEnv('LOG_LEVEL') ?? 'debug',
 
-  databaseUrl: isProduction ? requireEnv('DATABASE_URL') : (getEnv('DATABASE_URL') ?? ''),
+  databaseUrl: requireEnv('DATABASE_URL'),
 
   rpcUrl: isProduction
     ? requireEnv('RPC_URL')

--- a/agro-production/server/src/events/persister.ts
+++ b/agro-production/server/src/events/persister.ts
@@ -139,6 +139,29 @@ function logDuplicateSkip(event: ParsedEvent, stage: string) {
 
 async function handleCampaignInvested(event: CampaignInvestedEvent) {
   // Idempotency: investment upsert key includes campaign/investor/ledger.
+  // Broadcast payloads are captured inside the transaction but sent only after
+  // prisma.$transaction resolves (i.e. after the DB commit) so clients never
+  // receive a notification for a rolled-back write.
+  type PostCommitPayloads = {
+    campaignInvested: {
+      campaignId: string;
+      investorAddress: string;
+      amount: string;
+      totalRaised: string;
+      txHash: string | undefined;
+    };
+    investmentIndexed: {
+      id: string;
+      campaignId: string;
+      investorAddress: string;
+      amount: string;
+      ledger: number;
+      txHash: string | undefined;
+      createdAt: string;
+    };
+  };
+  let post: PostCommitPayloads | null = null;
+
   await prisma.$transaction(async (tx) => {
     if (await skipDuplicateInTransaction(tx, event)) return;
     await upsertUser(tx, event.investor, "INVESTOR");
@@ -161,7 +184,7 @@ async function handleCampaignInvested(event: CampaignInvestedEvent) {
       },
     });
 
-    await tx.investment.upsert({
+    const inv = await tx.investment.upsert({
       where: {
         campaignId_investorAddress_ledger: {
           campaignId: campaign.id,
@@ -179,14 +202,6 @@ async function handleCampaignInvested(event: CampaignInvestedEvent) {
       update: {},
     });
 
-    broadcast("campaign.invested", {
-      campaignId: campaign.id,
-      investorAddress: event.investor,
-      amount: event.amount,
-      totalRaised: event.totalRaised,
-      txHash: event.txHash,
-    });
-
     await tx.transaction.create({
       data: {
         campaignId: campaign.id,
@@ -197,7 +212,31 @@ async function handleCampaignInvested(event: CampaignInvestedEvent) {
         txHash: event.txHash,
       },
     });
+
+    post = {
+      campaignInvested: {
+        campaignId: campaign.id,
+        investorAddress: event.investor,
+        amount: event.amount,
+        totalRaised: event.totalRaised,
+        txHash: event.txHash,
+      },
+      investmentIndexed: {
+        id: inv.id,
+        campaignId: campaign.id,
+        investorAddress: inv.investorAddress,
+        amount: inv.amount,
+        ledger: inv.ledger,
+        txHash: inv.txHash ?? undefined,
+        createdAt: inv.createdAt.toISOString(),
+      },
+    };
   });
+
+  if (post) {
+    broadcast("campaign.invested", (post as PostCommitPayloads).campaignInvested);
+    broadcast("investment.indexed", (post as PostCommitPayloads).investmentIndexed);
+  }
 }
 
 async function handleCampaignSettled(event: CampaignSettledEvent) {

--- a/agro-production/server/src/schemas/health.ts
+++ b/agro-production/server/src/schemas/health.ts
@@ -23,6 +23,7 @@ export const ReadyzResponseSchema = z.object({
     status: z.enum(["UP", "DOWN"]),
     message: z.string().optional(),
   })),
+  lastLedger: z.number().optional(),
   timestamp: z.string().datetime(),
 });
 

--- a/agro-production/server/src/services/sorobanEventListener.ts
+++ b/agro-production/server/src/services/sorobanEventListener.ts
@@ -18,7 +18,15 @@ interface ParsedEvent {
   txHash: string;
 }
 
-const server = new rpc.Server(config.rpcUrl);
+/** Per-contract polling state including replay-safe cursor and backoff tracking. */
+interface ContractState {
+  ledger: number;
+  failureCount: number;
+  /** Epoch ms after which the next poll attempt is allowed; 0 = no backoff active. */
+  backoffUntil: number;
+}
+
+export const server = new rpc.Server(config.rpcUrl);
 
 // Topic base64 encoding for "order" and "campaign" symbols.
 const ORDER_TOPIC = 'AAAADwAAAAVvcmRlcg==';
@@ -140,6 +148,14 @@ async function handleEvent(parsed: ParsedEvent): Promise<void> {
   await persistEvent(parsed);
 }
 
+/**
+ * Poll a single contract for new events starting at `lastLedger`.
+ * Returns the new high-watermark ledger.
+ *
+ * Throws on RPC-level failures (e.g. network error, rate-limit) so the
+ * caller can apply exponential backoff. Per-event parse/persist errors are
+ * caught internally and do not abort the batch.
+ */
 async function pollContract(
   contract: ContractConfig,
   lastLedger: number,
@@ -147,34 +163,31 @@ async function pollContract(
   let highWatermark = lastLedger;
 
   for (const topicFilter of contract.topicFilters) {
-    try {
-      const response = await server.getEvents({
-        startLedger: lastLedger,
-        filters: [
-          {
-            type: 'contract',
-            contractIds: [contract.id],
-            topics: [topicFilter],
-          },
-        ],
-      });
+    // RPC errors propagate to the caller — do not catch here.
+    const response = await server.getEvents({
+      startLedger: lastLedger,
+      filters: [
+        {
+          type: 'contract',
+          contractIds: [contract.id],
+          topics: [topicFilter],
+        },
+      ],
+    });
 
-      for (const event of response.events) {
-        const parsed = parseEvent(event, contract.label);
-        if (parsed) {
-          try {
-            await handleEvent(parsed);
-          } catch {
-            // Do not advance watermark past failed events
-            continue;
-          }
-        }
-        if (event.ledger > highWatermark) {
-          highWatermark = event.ledger + 1;
+    for (const event of response.events) {
+      const parsed = parseEvent(event, contract.label);
+      if (parsed) {
+        try {
+          await handleEvent(parsed);
+        } catch {
+          // Do not advance watermark past a failed persist — retry next poll.
+          continue;
         }
       }
-    } catch (err) {
-      logger.error(`Poll error for ${contract.label} (filter: ${topicFilter}):`, err);
+      if (event.ledger > highWatermark) {
+        highWatermark = event.ledger + 1;
+      }
     }
   }
 
@@ -182,11 +195,22 @@ async function pollContract(
 }
 
 /**
+ * Compute the next backoff delay with jitter to avoid thundering-herd
+ * when multiple contracts fail simultaneously.
+ */
+function backoffDelayMs(failureCount: number): number {
+  const base = Math.min(1_000 * 2 ** failureCount, 60_000);
+  return base + Math.random() * 500;
+}
+
+/**
  * Start the Soroban event listener.
  *
  * Persists per-contract replay-safe cursors in the database within the same
  * transaction as the event record, ensuring no events are skipped on restart.
- * On failure, the cursor is not advanced so the next poll retries the batch.
+ * On RPC failure the affected contract backs off exponentially (up to ~60 s)
+ * while other contracts continue polling normally. Polling resumes
+ * automatically once the RPC endpoint recovers.
  */
 export async function startSorobanEventListener(): Promise<ReturnType<typeof setInterval> | null> {
   const contracts = buildContracts();
@@ -205,17 +229,43 @@ export async function startSorobanEventListener(): Promise<ReturnType<typeof set
   );
 
   // Load persisted cursors for each contract
-  const watermarks = new Map<string, number>();
+  const states = new Map<string, ContractState>();
   for (const contract of contracts) {
-    const cursor = await loadCursor(contract.id);
-    watermarks.set(contract.id, cursor);
+    const ledger = await loadCursor(contract.id);
+    states.set(contract.id, { ledger, failureCount: 0, backoffUntil: 0 });
   }
 
   const interval = setInterval(async () => {
     for (const contract of contracts) {
-      const lastLedger = watermarks.get(contract.id) ?? 0;
-      const newWatermark = await pollContract(contract, lastLedger);
-      watermarks.set(contract.id, newWatermark);
+      const state = states.get(contract.id)!;
+
+      // Skip if still in backoff window
+      if (state.backoffUntil > Date.now()) {
+        logger.debug(`Soroban listener: ${contract.label} is backing off, skipping poll`, {
+          backoffRemainingMs: state.backoffUntil - Date.now(),
+        });
+        continue;
+      }
+
+      try {
+        const newWatermark = await pollContract(contract, state.ledger);
+        // Successful poll: reset backoff
+        if (state.failureCount > 0) {
+          logger.info(`Soroban listener: ${contract.label} recovered after ${state.failureCount} failure(s)`);
+        }
+        state.ledger = newWatermark;
+        state.failureCount = 0;
+        state.backoffUntil = 0;
+      } catch (err) {
+        state.failureCount += 1;
+        const delay = backoffDelayMs(state.failureCount);
+        state.backoffUntil = Date.now() + delay;
+        logger.warn(
+          `Soroban listener: ${contract.label} poll failed (attempt ${state.failureCount}), ` +
+          `backing off for ${Math.round(delay)}ms`,
+          { error: err instanceof Error ? err.message : String(err) },
+        );
+      }
     }
   }, 5_000);
 

--- a/agro-production/server/src/services/wsServer.ts
+++ b/agro-production/server/src/services/wsServer.ts
@@ -11,6 +11,7 @@ export type WsEventName =
   | "campaign.created"
   | "campaign.invested"
   | "campaign.settled"
+  | "investment.indexed"
   | "order.created"
   | "order.confirmed"
   | "error";
@@ -116,6 +117,10 @@ export function attachWebSocketServer(server: Server): void {
 /** Broadcast an indexer event to currently connected clients. */
 export function broadcast(event: WsEventName, payload: unknown): void {
   activeServer?.broadcast(event, payload);
+}
+
+export function getWsClientCount(): number {
+  return activeServer?.clientCount ?? 0;
 }
 
 export function closeWebSocketServer(): Promise<void> {


### PR DESCRIPTION
  ## Summary

  Resolves four issues in `agro-production/`:

  - **#517** — Soroban event listener now tracks per-contract failure counts and backs off exponentially (capped
  at ~60 s + jitter) after consecutive RPC errors. Polling resumes automatically once RPC recovers.
  - **#519** — Added `agro-production/.env.example` (unified server + client) and
  `agro-production/client/.env.example` (client standalone); `client/README.md` now has a server↔client env var
  mapping table; `DATABASE_URL` is required in all environments (was previously only enforced in production).
  - **#520** — Server now emits `investment.indexed` WebSocket event (with full investment payload) after the DB
  transaction commits. Client's `waitForIndexedInvestment` resolves via WS within 2 s; falls back to REST
  polling automatically if WS is unavailable; no duplicate updates possible.
  - **#524** — `/readyz` now checks RPC reachability alongside DB and includes `lastLedger` in the response (503
  if either is down). New `/metrics` endpoint exposes Prometheus text format with `events_processed_total`,
  `last_indexed_ledger`, `ws_clients_connected`, and `api_requests_total`.

  ## Test plan

  - [ ] Start server with invalid `RPC_URL`; verify logs show exponential backoff (not a 5 s error flood)
  - [ ] `cp agro-production/.env.example agro-production/server/.env && npm run dev` — starts without
  missing-env errors
  - [ ] `cp agro-production/client/.env.example agro-production/client/.env && npm run dev` — client builds
  without error
  - [ ] After a confirmed invest tx, browser WS tab shows `investment.indexed` frame before any REST poll fires
  - [ ] With WS disconnected, `waitForIndexedInvestment` falls back to polling after ~2 s
  - [ ] `curl localhost:5001/readyz` → 200 with `checks.database.status: "UP"` and `checks.rpc.status: "UP"`
  - [ ] Stop PostgreSQL → `curl localhost:5001/readyz` → 503 with `checks.database.status: "DOWN"`
  - [ ] `curl localhost:5001/metrics` → Prometheus text with all 4 metrics

  Closes #517
  Closes #519
  Closes #520
  Closes #524