### PR TITLE
fix: resolve issues #540 #539 #538 #537

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -23,3 +23,9 @@ NEXT_PUBLIC_TOKEN_CONTRACT_ID=
 # Currency-specific token contracts (used by the cart / checkout flow).
 NEXT_PUBLIC_TOKEN_CONTRACT_ID_USDC=
 NEXT_PUBLIC_TOKEN_CONTRACT_ID_STRK=
+
+# ── Demo / Test Mode ─────────────────────────────────────────────────────────
+# When set to true, services return deterministic dummy data instead of hitting
+# the real backend or Soroban RPC. Used by Playwright E2E tests and local dev.
+# Do NOT set in production.
+NEXT_PUBLIC_DEMO_MODE=false

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -13,7 +13,10 @@ const nextConfig: NextConfig = {
     qualities: [75, 100],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-    formats: ['image/avif', 'image/webp']
+    formats: ['image/avif', 'image/webp'],
+    remotePatterns: [
+      { protocol: "https", hostname: "**" },
+    ],
   },
   experimental: {
     optimizePackageImports: ['lucide-react', '@radix-ui/react-icons']

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -32,5 +32,6 @@ export default defineConfig({
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 300_000,
+    env: { NEXT_PUBLIC_DEMO_MODE: "true" },
   },
 });

--- a/client/src/app/(admin)/admin/products/page.tsx
+++ b/client/src/app/(admin)/admin/products/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
+import { useState } from "react";
 import Image from "next/image";
 import { ColumnDef } from "@tanstack/react-table";
 import { MoreHorizontal, EyeOff, Trash2 } from "lucide-react";
-
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,7 +27,7 @@ import { useProducts, useAdminSetVisibility, useAdminDelistProduct } from "@/hoo
 import { toast } from "sonner";
 import type { Product } from "@/types/product";
 
-function ActionCell({ product }: { product: Product }) {
+function ActionCell({ product, onDelist }: { product: Product; onDelist: (p: Product) => void }) {
   const setVisibility = useAdminSetVisibility();
   const delist = useAdminDelistProduct();
 
@@ -34,11 +42,7 @@ function ActionCell({ product }: { product: Product }) {
   };
 
   const handleDelist = () => {
-    if (!confirm(`Permanently delist "${product.name}"? This cannot be undone.`)) return;
-    delist.mutate(product.id, {
-      onSuccess: () => toast("Product delisted"),
-      onError: (e) => toast.error((e as Error).message),
-    });
+    onDelist(product);
   };
 
   return (
@@ -137,13 +141,15 @@ const columns: ColumnDef<Product>[] = [
     header: "",
     enableGlobalFilter: false,
     enableSorting: false,
-    cell: ({ row }) => <ActionCell product={row.original} />,
+    cell: ({ row }) => <ActionCell product={row.original} onDelist={setConfirmDelistProduct} />,
   },
 ];
 
 export default function AdminProductsPage() {
   const { data, isLoading, error } = useProducts({ pageSize: 100 });
   const products = data?.items ?? [];
+  const delist = useAdminDelistProduct();
+  const [confirmDelistProduct, setConfirmDelistProduct] = useState<Product | null>(null);
 
   return (
     <div className="space-y-8">
@@ -173,6 +179,44 @@ export default function AdminProductsPage() {
           searchPlaceholder="Search products…"
         />
       )}
+
+      <Dialog
+        open={confirmDelistProduct !== null}
+        onOpenChange={(open) => !open && setConfirmDelistProduct(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delist Product</DialogTitle>
+            <DialogDescription>
+              Permanently delist "{confirmDelistProduct?.name}"? This cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDelistProduct(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (!confirmDelistProduct) return;
+                delist.mutate(confirmDelistProduct.id, {
+                  onSuccess: () => {
+                    toast("Product delisted");
+                    setConfirmDelistProduct(null);
+                  },
+                  onError: (e) => toast.error((e as Error).message),
+                });
+              }}
+            >
+              Delist
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/app/(dashboard)/dashboard/products/page.tsx
+++ b/client/src/app/(dashboard)/dashboard/products/page.tsx
@@ -8,6 +8,14 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -36,6 +44,7 @@ export default function FarmerProductsDashboard() {
   const [modalOpen, setModalOpen] = useState(false);
   const [modalMode, setModalMode] = useState<"add" | "edit">("add");
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
+  const [confirmDeleteProduct, setConfirmDeleteProduct] = useState<Product | null>(null);
 
   function openAdd() {
     setModalMode("add");
@@ -57,11 +66,7 @@ export default function FarmerProductsDashboard() {
   }
 
   async function handleDelete(p: Product) {
-    const ok = window.confirm(
-      `Delete "${p.name}"? This will soft-delete the product.`,
-    );
-    if (!ok) return;
-    await deleteProduct.mutateAsync(p.id);
+    setConfirmDeleteProduct(p);
   }
 
   const columns: ColumnDef<Product>[] = [
@@ -231,6 +236,39 @@ export default function FarmerProductsDashboard() {
           // useMutation invalidates queries on success — nothing more to do here.
         }}
       />
+
+      <Dialog
+        open={confirmDeleteProduct !== null}
+        onOpenChange={(open) => !open && setConfirmDeleteProduct(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Product</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete "{confirmDeleteProduct?.name}"?
+              This will soft-delete the product.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeleteProduct(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={async () => {
+                if (!confirmDeleteProduct) return;
+                await deleteProduct.mutateAsync(confirmDeleteProduct.id);
+                setConfirmDeleteProduct(null);
+              }}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/app/(root)/market/[productId]/page.tsx
+++ b/client/src/app/(root)/market/[productId]/page.tsx
@@ -1,5 +1,6 @@
-"use client";
+ "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
@@ -108,13 +109,14 @@ export default function ProductDetailPage() {
       </nav>
 
       <div className="grid grid-cols-1 gap-10 md:grid-cols-2">
-        <div className="bg-secondary aspect-square overflow-hidden rounded-2xl">
+        <div className="bg-secondary relative aspect-square overflow-hidden rounded-2xl">
           {product.image_url ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={product.image_url}
               alt={product.name}
-              className="size-full object-cover"
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="object-cover"
             />
           ) : (
             <div className="grid size-full place-content-center text-7xl">

--- a/client/src/app/messages/page.tsx
+++ b/client/src/app/messages/page.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { useMessaging } from '../../hooks/useMessaging';
 import ConversationList from '../../components/ConversationList';
 import ChatWindow from '../../components/ChatWindow';
@@ -14,6 +23,7 @@ export default function MessagesPage({ initialConversationId }: MessagesPageProp
   const [activeConversationId, setActiveConversationId] = useState<string | undefined>(
     initialConversationId,
   );
+  const [blockConfirmUser, setBlockConfirmUser] = useState<{ id: string; name: string } | null>(null);
   const {
     conversations,
     messages,
@@ -34,9 +44,13 @@ export default function MessagesPage({ initialConversationId }: MessagesPageProp
 
   const handleBlock = async () => {
     if (!currentConversation || !otherUser) return;
-    if (confirm(`Block ${otherUser.name}? You won't receive messages from them.`)) {
-      await blockUser(currentConversation.id, otherUser.id);
-    }
+    setBlockConfirmUser({ id: otherUser.id, name: otherUser.name });
+  };
+
+  const confirmBlock = async () => {
+    if (!currentConversation || !blockConfirmUser) return;
+    await blockUser(currentConversation.id, blockConfirmUser.id);
+    setBlockConfirmUser(null);
   };
 
   const handleMute = async () => {
@@ -95,6 +109,32 @@ export default function MessagesPage({ initialConversationId }: MessagesPageProp
           </div>
         )}
       </div>
+
+      <Dialog
+        open={blockConfirmUser !== null}
+        onOpenChange={(open) => !open && setBlockConfirmUser(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Block User</DialogTitle>
+            <DialogDescription>
+              Block {blockConfirmUser?.name}? You won't receive messages from
+              them.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setBlockConfirmUser(null)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmBlock}>
+              Block
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/components/CartDrawer.tsx
+++ b/client/src/components/CartDrawer.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/services/stellar/contractService";
 import { getNetworkConfig, requireTokenContractId } from "@/services/stellar/networkConfig";
 import { formatTruncatedAddress } from "@/lib/helpers/format-address";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -104,12 +105,12 @@ export default function CartDrawer() {
 
   async function createOrdersForCart(groups: CartGroup[]) {
     if (!address || !connected) {
-      alert("Connect your wallet to checkout.");
+      toast.error("Connect your wallet to checkout.");
       return;
     }
     const deadline = deliveryDeadline?.trim();
     if (!deadline) {
-      alert("Please select a delivery deadline.");
+      toast.error("Please select a delivery deadline.");
       return;
     }
 

--- a/client/src/lib/testMode.ts
+++ b/client/src/lib/testMode.ts
@@ -1,13 +1,12 @@
 /**
- * Centralised E2E test-mode detection.
+ * Centralised demo / test-mode detection.
  *
- * Playwright tests inject a mock at `window.freighter.signTransaction`. When that
- * mock is present, services return deterministic dummy data instead of hitting
- * the real backend or Soroban RPC.
+ * When NEXT_PUBLIC_DEMO_MODE=true, services return deterministic dummy data
+ * instead of hitting the real backend or Soroban RPC. This is used by
+ * Playwright E2E tests and local development.
  *
- * This is the single source of truth — every other module imports it from here.
+ * In production this env var is unset, so services always call real endpoints.
  */
 export function isTestMode(): boolean {
-  if (typeof window === "undefined") return false;
-  return typeof window.freighter?.signTransaction === "function";
+  return process.env.NEXT_PUBLIC_DEMO_MODE === "true";
 }

--- a/client/src/theme/tokens.css
+++ b/client/src/theme/tokens.css
@@ -88,8 +88,8 @@
   --spacing-24: 6rem;     /* 96px */
 
   /* ---------- Typography ---------- */
-  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
-  --font-mono: var(--font-geist-mono), ui-monospace, monospace;
+  --font-sans: var(--font-montserrat-alternates), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, monospace;
 
   --text-xs: 0.75rem;     /* 12px */
   --text-sm: 0.875rem;    /* 14px */


### PR DESCRIPTION
## Summary

This PR resolves four issues assigned to me, improving the market experience, accessibility, build reliability, and production safety.

### Closes #540 - Improve Market Product Card Navigation And Image Optimization
- Added `remotePatterns` to `next.config.ts` so external product images work with Next.js `<Image>`
- Migrated the product detail page from plain `<img>` to Next.js `<Image>` with proper `fill` and `sizes`
- Product cards on the market page already link to `/market/[productId]` via `<Link>`

### Closes #539 - Add Accessible, Non-Blocking Feedback For Cart And Dashboard Actions
- **CartDrawer.tsx**: Replaced `alert()` calls with `toast.error()` via sonner
- **Dashboard products**: Replaced `window.confirm()` with a keyboard-accessible shadcn Dialog for delete confirmation
- **Admin products**: Replaced `confirm()` with a Dialog for delist confirmation
- **Messages page**: Replaced `confirm()` with a Dialog for block confirmation

### Closes #538 - Make Next.js Builds Independent Of Google Font Network Fetches
- The project already uses `next/font/local` for MontserratAlternates (no Google font dependency)
- Cleaned up stale `--font-geist-sans` / `--font-geist-mono` references in `tokens.css` to match the actual font variable

### Closes #537 - Remove Test Mode Detection From Production Services
- Changed `isTestMode()` from checking `window.freighter?.signTransaction` to checking `process.env.NEXT_PUBLIC_DEMO_MODE === "true"`
- Updated Playwright config to set `NEXT_PUBLIC_DEMO_MODE=true` via the `env` property
- Added documentation to `.env.example`
- In production, the env var is unset so services always call real endpoints regardless of Freighter presence