### PR TITLE
fix: resolve issues #557 #563 #564 #527

### DIFF
--- a/agro-production/.env.example
+++ b/agro-production/.env.example
@@ -63,3 +63,6 @@ NEXT_PUBLIC_PRODUCTION_CONTRACT_ID=C...
 
 # XLM native token SAC address (testnet default provided)
 NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID=
+
+# Main client URL for navigation back to the main Agrocylo app
+NEXT_PUBLIC_MAIN_CLIENT_URL=http://localhost:3000

--- a/agro-production/client/.env.example
+++ b/agro-production/client/.env.example
@@ -20,3 +20,6 @@ NEXT_PUBLIC_PRODUCTION_CONTRACT_ID=C...
 
 # XLM native token SAC address (leave blank on testnet unless overriding)
 NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID=
+
+# Main client URL for navigation back to the main Agrocylo app
+NEXT_PUBLIC_MAIN_CLIENT_URL=http://localhost:3000

--- a/agro-production/client/src/components/NavBar.tsx
+++ b/agro-production/client/src/components/NavBar.tsx
@@ -4,15 +4,26 @@ import Link from "next/link";
 import WalletConnect from "@/components/WalletConnect";
 import { useTheme } from "@/context/ThemeContext";
 
+const MAIN_CLIENT_URL = process.env.NEXT_PUBLIC_MAIN_CLIENT_URL ?? "http://localhost:3000";
+
 export default function NavBar() {
   const { resolvedTheme, toggleTheme } = useTheme();
 
   return (
     <nav className="border-b border-border bg-surface sticky top-0 z-10" aria-label="Main navigation">
       <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between gap-4">
-        <Link href="/home" className="font-bold text-lg text-primary-600 hover:text-primary-700" aria-label="AgroProduction home">
-          🌾 AgroProduction
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link href="/home" className="font-bold text-lg text-primary-600 hover:text-primary-700" aria-label="AgroProduction home">
+            🌾 AgroProduction
+          </Link>
+          <a
+            href={MAIN_CLIENT_URL}
+            className="text-xs text-muted hover:text-foreground border border-border px-2 py-1 rounded transition-colors"
+            aria-label="Back to Agrocylo main app"
+          >
+            ← Back to Agrocylo
+          </a>
+        </div>
         <div className="flex items-center gap-4 text-sm">
           <Link href="/marketplace" className="text-muted hover:text-foreground" aria-label="Browse marketplace">Marketplace</Link>
           <Link href="/campaigns" className="text-muted hover:text-foreground" aria-label="View campaigns">Campaigns</Link>

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,6 @@
     "@prisma/client": "^7.5.0",
     "@stellar/stellar-sdk": "^14.6.1",
     "@supabase/supabase-js": "^2.100.0",
-    "better-sqlite3": "^12.8.0",
     "bullmq": "^5.76.1",
     "cors": "^2.8.5",
     "envalid": "^8.1.1",
@@ -38,7 +37,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.10",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -78,6 +78,8 @@ model BuyerDemand {
   updatedAt       DateTime  @updatedAt @map("updated_at")
 
   @@index([buyerWallet])
+  @@index([buyerWallet, createdAt(sort: Desc)])
+  @@index([cropName])
   @@map("buyer_demands")
 }
 
@@ -96,6 +98,8 @@ model FarmerSupply {
   updatedAt         DateTime  @updatedAt @map("updated_at")
 
   @@index([farmerWallet])
+  @@index([farmerWallet, availableFrom])
+  @@index([cropName, pricePerUnit])
   @@map("farmer_supplies")
 }
 

--- a/server/src/routes/demandSupplyRoutes.ts
+++ b/server/src/routes/demandSupplyRoutes.ts
@@ -1,10 +1,31 @@
 import express from "express";
 import { requireWallet, type WalletRequest } from "../middleware/walletAuth.js";
 import { ApiError } from "../http/errors.js";
-import { createBuyerDemand } from "../services/demandService.js";
-import { createFarmerSupply } from "../services/supplyService.js";
+import { createBuyerDemand, listBuyerDemands } from "../services/demandService.js";
+import { createFarmerSupply, listFarmerSupplies } from "../services/supplyService.js";
 
 const router = express.Router();
+
+router.get("/demand", async (req, res) => {
+  const result = await listBuyerDemands({
+    buyerWallet: typeof req.query['buyerWallet'] === 'string' ? req.query['buyerWallet'] : undefined,
+    cropName: typeof req.query['cropName'] === 'string' ? req.query['cropName'] : undefined,
+    region: typeof req.query['region'] === 'string' ? req.query['region'] : undefined,
+    page: typeof req.query['page'] === 'string' ? req.query['page'] : undefined,
+    pageSize: typeof req.query['page_size'] === 'string' ? req.query['page_size'] : undefined,
+  });
+  res.status(200).json(result);
+});
+
+router.get("/supply", async (req, res) => {
+  const result = await listFarmerSupplies({
+    farmerWallet: typeof req.query['farmerWallet'] === 'string' ? req.query['farmerWallet'] : undefined,
+    cropName: typeof req.query['cropName'] === 'string' ? req.query['cropName'] : undefined,
+    page: typeof req.query['page'] === 'string' ? req.query['page'] : undefined,
+    pageSize: typeof req.query['page_size'] === 'string' ? req.query['page_size'] : undefined,
+  });
+  res.status(200).json(result);
+});
 
 router.post("/demand", requireWallet, async (req: WalletRequest, res, next) => {
   try {

--- a/server/src/services/demandService.ts
+++ b/server/src/services/demandService.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from "../config/database.js";
 import { ApiError } from "../http/errors.js";
 import { z } from "zod";
@@ -35,6 +36,55 @@ async function assertBuyerProfile(wallet: string): Promise<void> {
       "https://cylos.io/errors/forbidden",
     );
   }
+}
+
+function parsePage(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+}
+
+function decimalFilter(value: string | undefined): Prisma.Decimal | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) return undefined;
+  return new Prisma.Decimal(value);
+}
+
+export async function listBuyerDemands(params: {
+  buyerWallet?: string;
+  cropName?: string;
+  region?: string;
+  minPrice?: string;
+  maxPrice?: string;
+  page?: string;
+  pageSize?: string;
+}): Promise<{ page: number; page_size: number; total: number; totalPages: number; items: unknown[] }> {
+  const page = parsePage(params.page, 1);
+  const pageSize = Math.min(parsePage(params.pageSize, 20), 100);
+  const where: Prisma.BuyerDemandWhereInput = {};
+
+  if (params.buyerWallet) {
+    where.buyerWallet = params.buyerWallet.toLowerCase();
+  }
+  if (params.cropName) {
+    where.cropName = { contains: params.cropName, mode: 'insensitive' };
+  }
+  if (params.region) {
+    where.region = { contains: params.region, mode: 'insensitive' };
+  }
+
+  const [total, items] = await prisma.$transaction([
+    prisma.buyerDemand.count({ where }),
+    prisma.buyerDemand.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: pageSize,
+      skip: (page - 1) * pageSize,
+    }),
+  ]);
+
+  return { page, page_size: pageSize, total, totalPages: Math.ceil(total / pageSize), items };
 }
 
 export async function createBuyerDemand(buyerWallet: string, body: unknown) {

--- a/server/src/services/supplyService.ts
+++ b/server/src/services/supplyService.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from "../config/database.js";
 import { ApiError } from "../http/errors.js";
 import { z } from "zod";
@@ -35,6 +36,51 @@ async function assertFarmerProfile(wallet: string): Promise<void> {
       "https://cylos.io/errors/forbidden",
     );
   }
+}
+
+function parsePage(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+}
+
+function decimalFilter(value: string | undefined): Prisma.Decimal | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) return undefined;
+  return new Prisma.Decimal(value);
+}
+
+export async function listFarmerSupplies(params: {
+  farmerWallet?: string;
+  cropName?: string;
+  minPrice?: string;
+  maxPrice?: string;
+  page?: string;
+  pageSize?: string;
+}): Promise<{ page: number; page_size: number; total: number; totalPages: number; items: unknown[] }> {
+  const page = parsePage(params.page, 1);
+  const pageSize = Math.min(parsePage(params.pageSize, 20), 100);
+  const where: Prisma.FarmerSupplyWhereInput = {};
+
+  if (params.farmerWallet) {
+    where.farmerWallet = params.farmerWallet.toLowerCase();
+  }
+  if (params.cropName) {
+    where.cropName = { contains: params.cropName, mode: 'insensitive' };
+  }
+
+  const [total, items] = await prisma.$transaction([
+    prisma.farmerSupply.count({ where }),
+    prisma.farmerSupply.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: pageSize,
+      skip: (page - 1) * pageSize,
+    }),
+  ]);
+
+  return { page, page_size: pageSize, total, totalPages: Math.ceil(total / pageSize), items };
 }
 
 export async function createFarmerSupply(farmerWallet: string, body: unknown) {


### PR DESCRIPTION
## Summary

Closes #557 - Missing Database Models in Prisma Schema
Closes #563 - Wrong Database Driver in productController.ts
Closes #564 - Missing Indexes and Performance Optimization
Closes #527 - [Frontend] Add navigation from agro-production app back to main frontend

## Changes

### #557 - Nonce & RefreshToken models
Already present in `server/prisma/schema.prisma`. Verified both models exist with correct fields and indexes.

### #563 - Remove better-sqlite3
Removed unused `better-sqlite3` and `@types/better-sqlite3` dependencies from `server/package.json`. The old `productController.ts` using SQLite was already deleted; product endpoints now use Prisma via `productService.ts`.

### #564 - Indexes & pagination
- Added composite indexes to `BuyerDemand`: `[buyerWallet, createdAt(sort: Desc)]` and `[cropName]`
- Added composite indexes to `FarmerSupply`: `[farmerWallet, availableFrom]` and `[cropName, pricePerUnit]`
- Added paginated `GET /demand` and `GET /supply` list endpoints with filtering by wallet, cropName, region, and page/pageSize params

### #527 - Back navigation
- Added `← Back to Agrocylo` link in the agro-production `NavBar.tsx` header
- Link uses `NEXT_PUBLIC_MAIN_CLIENT_URL` env var (defaults to `http://localhost:3000`)
- Updated both `.env.example` files with the new variable