### PR TITLE
feat: graceful lifecycle management, readiness checks, and transaction status API

### DIFF
--- a/agro-production/server/src/app.ts
+++ b/agro-production/server/src/app.ts
@@ -5,7 +5,7 @@ import { config } from './config/index.js';
 import { defaultLimiter } from './middleware/rateLimit.js';
 import { jsonValidated } from './middleware/validate.js';
 import { requireMetricsAuth } from './middleware/metricsAuth.js';
-import { isGracefullyShuttingDown } from './services/lifecycle.js';
+import { isGracefullyShuttingDown, getShutdownPhase, getShutdownSignal } from './services/lifecycle.js';
 import authRoutes from './routes/auth.js';
 import campaignImageRoutes, {
   campaignImageErrorHandler,
@@ -46,9 +46,12 @@ app.use(defaultLimiter);
 app.use((_req: Request, _res: Response, next: express.NextFunction) => { _requestTotal++; next(); });
 
 app.use((req: Request, _res: Response, next: express.NextFunction) => {
-  if (isGracefullyShuttingDown() && req.method !== 'GET') {
-    _res.status(503).json({ message: 'Server is shutting down' });
-    return;
+  if (isGracefullyShuttingDown()) {
+    _res.setHeader('Connection', 'close');
+    if (req.method !== 'GET') {
+      _res.status(503).json({ message: 'Server is shutting down' });
+      return;
+    }
   }
   next();
 });
@@ -79,6 +82,16 @@ app.get('/livez', async (_req: Request, res: Response) => {
 });
 
 app.get('/readyz', async (_req: Request, res: Response) => {
+  if (isGracefullyShuttingDown()) {
+    jsonValidated(res, ReadyzResponseSchema, 503, {
+      status: 'not_ready',
+      checks: { shutdown: { status: 'DOWN', message: `Server shutting down: ${getShutdownPhase()}` } },
+      lastLedger: 0,
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+
   const checks: Record<string, { status: string; message?: string }> = {};
   let lastLedger = 0;
 
@@ -86,7 +99,10 @@ app.get('/readyz', async (_req: Request, res: Response) => {
     await prisma.$queryRaw`SELECT 1`;
     checks.database = { status: 'UP' };
   } catch (err) {
-    checks.database = { status: 'DOWN', message: (err as Error).message };
+    checks.database = {
+      status: 'DOWN',
+      message: err instanceof Error ? 'database unreachable' : 'database unreachable',
+    };
   }
 
   try {
@@ -94,7 +110,10 @@ app.get('/readyz', async (_req: Request, res: Response) => {
     lastLedger = latest.sequence;
     checks.rpc = { status: 'UP' };
   } catch (err) {
-    checks.rpc = { status: 'DOWN', message: (err as Error).message };
+    checks.rpc = {
+      status: 'DOWN',
+      message: err instanceof Error ? 'RPC endpoint unreachable' : 'RPC endpoint unreachable',
+    };
   }
 
   const ready = Object.values(checks).every((c) => c.status === 'UP');

--- a/agro-production/server/src/config/database.ts
+++ b/agro-production/server/src/config/database.ts
@@ -39,3 +39,17 @@ export async function withTransaction<T>(
 }
 
 export default pool;
+
+export async function disconnectDb(): Promise<void> {
+  await pool.end();
+  logger.info('Raw database pool disconnected');
+}
+
+export async function isPoolHealthy(): Promise<boolean> {
+  try {
+    await pool.query('SELECT 1');
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/agro-production/server/src/db/client.ts
+++ b/agro-production/server/src/db/client.ts
@@ -25,3 +25,12 @@ export async function disconnectDB(): Promise<void> {
   await prisma.$disconnect();
   logger.info("Database disconnected");
 }
+
+export async function isPrismaHealthy(): Promise<boolean> {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/agro-production/server/src/openapi/registry.ts
+++ b/agro-production/server/src/openapi/registry.ts
@@ -38,6 +38,8 @@ import {
   TransactionIntentCreateSchema,
   TransactionRequestIdParamSchema,
   TransactionStatusResponseSchema,
+  TransactionStatusUpdateSchema,
+  TransactionReconciliationResponseSchema,
 } from "../schemas/transaction.js";
 
 extendZodWithOpenApi(z);
@@ -361,5 +363,42 @@ registry.registerPath({
     204: { description: "Image deleted" },
     400: validationResponse,
     401: problemResponse,
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/api/v1/transactions/{requestId}/status",
+  tags: ["Transactions"],
+  summary: "Update transaction status",
+  request: {
+    params: TransactionRequestIdParamSchema,
+    body: { content: { "application/json": { schema: TransactionStatusUpdateSchema } } },
+  },
+  responses: {
+    200: {
+      description: "Transaction status updated",
+      content: { "application/json": { schema: TransactionStatusResponseSchema } },
+    },
+    400: validationResponse,
+    403: problemResponse,
+    404: problemResponse,
+    409: problemResponse,
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/v1/transactions/{requestId}/reconcile",
+  tags: ["Transactions"],
+  summary: "Reconcile transaction against indexer data",
+  request: { params: TransactionRequestIdParamSchema },
+  responses: {
+    200: {
+      description: "Reconciliation result",
+      content: { "application/json": { schema: TransactionReconciliationResponseSchema } },
+    },
+    400: validationResponse,
+    404: problemResponse,
   },
 });

--- a/agro-production/server/src/routes/campaigns.ts
+++ b/agro-production/server/src/routes/campaigns.ts
@@ -10,6 +10,7 @@ import {
 } from "../middleware/validate.js";
 import { writeLimiter } from "../middleware/rateLimit.js";
 import { requireWallet, type WalletRequest } from "../middleware/walletAuth.js";
+import { requireIdempotencyKey } from "../middleware/idempotency.js";
 import { problemDetail } from "../middleware/errors.js";
 import {
   CampaignIdParamSchema,

--- a/agro-production/server/src/routes/transactions.ts
+++ b/agro-production/server/src/routes/transactions.ts
@@ -12,8 +12,45 @@ import {
   TransactionIntentCreateSchema,
   TransactionRequestIdParamSchema,
   TransactionStatusResponseSchema,
+  TransactionStatusUpdateSchema,
+  TransactionReconciliationResponseSchema,
 } from '../schemas/transaction.js';
+import type { TransactionStatus } from '../schemas/transaction.js';
+import { broadcast } from '../services/wsServer.js';
+import { reconcileTransaction } from '../services/transactionReconciler.js';
+
 const router = Router();
+
+const VALID_TRANSITIONS: Record<TransactionStatus, readonly TransactionStatus[]> = {
+  awaiting_signature: ['submitted', 'failed'],
+  submitted: ['confirmed', 'failed'],
+  confirmed: ['indexed', 'failed'],
+  indexed: [],
+  failed: [],
+};
+
+function txToResponse(tx: {
+  id: string;
+  txHash: string | null;
+  walletAddress: string | null;
+  status: string;
+  eventType: string;
+  campaignId: string | null;
+  ledger: number;
+  processedAt: Date;
+}, fallbackWallet?: string) {
+  return {
+    requestId: tx.id,
+    txHash: tx.txHash ?? '',
+    walletAddress: tx.walletAddress ?? fallbackWallet ?? '',
+    status: tx.status as TransactionStatus,
+    eventType: tx.eventType,
+    campaignId: tx.campaignId,
+    ledger: tx.ledger || undefined,
+    createdAt: tx.processedAt.toISOString(),
+    updatedAt: tx.processedAt.toISOString(),
+  };
+}
 
 router.post(
   '/transactions',
@@ -33,17 +70,7 @@ router.post(
     });
 
     if (existing) {
-      jsonValidated(res, TransactionStatusResponseSchema, 200, {
-        requestId: existing.id,
-        txHash: existing.txHash ?? '',
-        walletAddress: existing.walletAddress ?? walletAddress,
-        status: existing.status,
-        eventType: existing.eventType,
-        campaignId: existing.campaignId,
-        ledger: existing.ledger || undefined,
-        createdAt: existing.processedAt.toISOString(),
-        updatedAt: existing.processedAt.toISOString(),
-      });
+      jsonValidated(res, TransactionStatusResponseSchema, 200, txToResponse(existing, walletAddress));
       return;
     }
 
@@ -61,17 +88,15 @@ router.post(
       },
     });
 
-    jsonValidated(res, TransactionStatusResponseSchema, 201, {
-      requestId: tx.id,
-      txHash: tx.txHash ?? '',
-      walletAddress: tx.walletAddress ?? walletAddress,
-      status: tx.status,
-      eventType: tx.eventType,
-      campaignId: tx.campaignId,
-      ledger: tx.ledger || undefined,
-      createdAt: tx.processedAt.toISOString(),
-      updatedAt: tx.processedAt.toISOString(),
+    const response = txToResponse(tx, walletAddress);
+    broadcast('transaction.status', {
+      requestId: response.requestId,
+      txHash: response.txHash,
+      walletAddress: response.walletAddress,
+      status: response.status,
     });
+
+    jsonValidated(res, TransactionStatusResponseSchema, 201, response);
   },
 );
 
@@ -88,17 +113,7 @@ router.get(
       return;
     }
 
-    jsonValidated(res, TransactionStatusResponseSchema, 200, {
-      requestId: tx.id,
-      txHash: tx.txHash ?? '',
-      walletAddress: tx.walletAddress ?? '',
-      status: tx.status,
-      eventType: tx.eventType,
-      campaignId: tx.campaignId,
-      ledger: tx.ledger || undefined,
-      createdAt: tx.processedAt.toISOString(),
-      updatedAt: tx.processedAt.toISOString(),
-    });
+    jsonValidated(res, TransactionStatusResponseSchema, 200, txToResponse(tx));
   },
 );
 
@@ -114,19 +129,108 @@ router.get(
       take: 50,
     });
 
-    const results = transactions.map((tx) => ({
+    const results = transactions.map((tx) => txToResponse(tx, walletAddress));
+    jsonValidated(res, TransactionStatusResponseSchema.array(), 200, results);
+  },
+);
+
+router.patch(
+  '/transactions/:requestId/status',
+  requireWallet,
+  writeLimiter,
+  validateParams(TransactionRequestIdParamSchema),
+  validateBody(TransactionStatusUpdateSchema),
+  async (req: WalletRequest, res: Response) => {
+    const { status: newStatus, message } = req.body;
+
+    const tx = await prisma.transaction.findUnique({
+      where: { id: req.params.requestId },
+    });
+
+    if (!tx) {
+      problemDetail(res, req, 404, 'Transaction Not Found', `No transaction with id ${req.params.requestId}`);
+      return;
+    }
+
+    if (tx.walletAddress !== req.walletAddress) {
+      problemDetail(res, req, 403, 'Forbidden', 'This transaction belongs to a different wallet');
+      return;
+    }
+
+    const currentStatus = tx.status as TransactionStatus;
+    const allowed = VALID_TRANSITIONS[currentStatus];
+    if (!allowed?.includes(newStatus)) {
+      problemDetail(
+        res,
+        req,
+        409,
+        'Invalid Status Transition',
+        `Cannot transition from ${currentStatus} to ${newStatus}. Allowed: ${allowed?.join(', ') ?? 'none'}`,
+      );
+      return;
+    }
+
+    const updated = await prisma.transaction.update({
+      where: { id: req.params.requestId },
+      data: {
+        status: newStatus,
+        payload: {
+          ...((tx.payload as Record<string, unknown>) ?? {}),
+          statusHistory: [
+            ...(((tx.payload as Record<string, unknown>)?.statusHistory as unknown[]) ?? []),
+            {
+              from: currentStatus,
+              to: newStatus,
+              at: new Date().toISOString(),
+              message: message ?? null,
+            },
+          ],
+        },
+      },
+    });
+
+    const response = txToResponse(updated);
+    broadcast('transaction.status', {
+      requestId: response.requestId,
+      txHash: response.txHash,
+      walletAddress: response.walletAddress,
+      status: response.status,
+      previousStatus: currentStatus,
+    });
+
+    jsonValidated(res, TransactionStatusResponseSchema, 200, response);
+  },
+);
+
+router.get(
+  '/transactions/:requestId/reconcile',
+  validateParams(TransactionRequestIdParamSchema),
+  async (req: Request, res: Response) => {
+    const tx = await prisma.transaction.findUnique({
+      where: { id: req.params.requestId },
+    });
+
+    if (!tx) {
+      problemDetail(res, req, 404, 'Transaction Not Found', `No transaction with id ${req.params.requestId}`);
+      return;
+    }
+
+    const result = await reconcileTransaction(
+      tx.txHash ?? '',
+      tx.status as TransactionStatus,
+    );
+
+    jsonValidated(res, TransactionReconciliationResponseSchema, 200, {
       requestId: tx.id,
       txHash: tx.txHash ?? '',
-      walletAddress: tx.walletAddress ?? walletAddress,
-      status: tx.status,
-      eventType: tx.eventType,
-      campaignId: tx.campaignId,
-      ledger: tx.ledger || undefined,
+      dbStatus: result.dbStatus,
+      reconciledStatus: result.reconciledStatus,
+      confirmedInLedger: result.confirmedInLedger,
+      indexedByWatcher: result.indexedByWatcher,
+      latestIndexedLedger: result.latestIndexedLedger,
       createdAt: tx.processedAt.toISOString(),
       updatedAt: tx.processedAt.toISOString(),
-    }));
-
-    jsonValidated(res, TransactionStatusResponseSchema.array(), 200, results);
+    });
   },
 );
 

--- a/agro-production/server/src/schemas/transaction.ts
+++ b/agro-production/server/src/schemas/transaction.ts
@@ -39,3 +39,24 @@ export const TransactionStatusResponseSchema = z.object({
 });
 
 export type TransactionStatusResponse = z.infer<typeof TransactionStatusResponseSchema>;
+
+export const TransactionStatusUpdateSchema = z.object({
+  status: z.enum(['submitted', 'confirmed', 'failed']),
+  message: z.string().max(256).optional(),
+});
+
+export type TransactionStatusUpdate = z.infer<typeof TransactionStatusUpdateSchema>;
+
+export const TransactionReconciliationResponseSchema = z.object({
+  requestId: uuidParam,
+  txHash: z.string(),
+  dbStatus: TransactionStatusEnum,
+  reconciledStatus: TransactionStatusEnum,
+  confirmedInLedger: z.boolean(),
+  indexedByWatcher: z.boolean(),
+  latestIndexedLedger: z.number().int().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type TransactionReconciliationResponse = z.infer<typeof TransactionReconciliationResponseSchema>;

--- a/agro-production/server/src/services/lifecycle.ts
+++ b/agro-production/server/src/services/lifecycle.ts
@@ -1,12 +1,25 @@
 import http from 'http';
 import logger from '../config/logger.js';
 import { disconnectDB } from '../db/client.js';
-import { closeWebSocketServer } from './wsServer.js';
+import { closeWebSocketServer, drainWebSocketServer } from './wsServer.js';
 import { config } from '../config/index.js';
+import pool from '../config/database.js';
 
 type WatcherHandle = { stop: () => void } | ReturnType<typeof setInterval>;
 
+export enum ShutdownPhase {
+  RUNNING = 'RUNNING',
+  HTTP_CLOSING = 'HTTP_CLOSING',
+  WS_DRAINING = 'WS_DRAINING',
+  WATCHERS_STOPPING = 'WATCHERS_STOPPING',
+  DB_DISCONNECTING = 'DB_DISCONNECTING',
+  COMPLETE = 'COMPLETE',
+}
+
 const watchers: WatcherHandle[] = [];
+let server: http.Server | null = null;
+let shutdownPhase: ShutdownPhase = ShutdownPhase.RUNNING;
+let shutdownSignal: string | null = null;
 
 export function registerWatcher(handle: WatcherHandle): void {
   watchers.push(handle);
@@ -18,7 +31,11 @@ export function getWatchers(): WatcherHandle[] {
 
 function stopAllWatchers(): void {
   for (const handle of watchers) {
-    if (typeof handle === 'object' && 'stop' in handle && typeof (handle as { stop: () => void }).stop === 'function') {
+    if (
+      typeof handle === 'object' &&
+      'stop' in handle &&
+      typeof (handle as { stop: () => void }).stop === 'function'
+    ) {
       (handle as { stop: () => void }).stop();
     } else {
       clearInterval(handle as ReturnType<typeof setInterval>);
@@ -28,37 +45,82 @@ function stopAllWatchers(): void {
   logger.info('All watchers stopped');
 }
 
-let server: http.Server | null = null;
-let isShuttingDown = false;
-
 export function registerHttpServer(s: http.Server): void {
   server = s;
 }
 
 export function isGracefullyShuttingDown(): boolean {
-  return isShuttingDown;
+  return shutdownPhase !== ShutdownPhase.RUNNING;
+}
+
+export function getShutdownPhase(): ShutdownPhase {
+  return shutdownPhase;
+}
+
+export function getShutdownSignal(): string | null {
+  return shutdownSignal;
+}
+
+function promisifyServerClose(s: http.Server, timeoutMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      logger.warn(`HTTP server close timed out after ${timeoutMs}ms, forcing close`);
+      s.closeAllConnections?.();
+      resolve();
+    }, timeoutMs);
+
+    s.close(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
 }
 
 export async function shutdown(signal?: string): Promise<void> {
-  if (isShuttingDown) return;
-  isShuttingDown = true;
+  if (shutdownPhase !== ShutdownPhase.RUNNING) return;
 
-  logger.info(`Received ${signal ?? 'shutdown command'} — starting graceful shutdown`);
+  shutdownPhase = ShutdownPhase.HTTP_CLOSING;
+  shutdownSignal = signal ?? 'shutdown command';
 
+  logger.info(`Received ${shutdownSignal} — starting graceful shutdown`);
+
+  // Phase 1: Stop accepting new HTTP requests
   if (server) {
-    server.close(() => {
-      logger.info('HTTP server closed');
-    });
+    shutdownPhase = ShutdownPhase.HTTP_CLOSING;
+    logger.info('Closing HTTP server to new connections');
+    await promisifyServerClose(server, config.shutdownTimeoutMs);
+    logger.info('HTTP server closed');
   }
 
-  await Promise.race([
-    closeWebSocketServer(),
-    new Promise((resolve) => setTimeout(resolve, config.shutdownTimeoutMs)),
-  ]);
+  // Phase 2: Drain WebSocket connections
+  shutdownPhase = ShutdownPhase.WS_DRAINING;
+  try {
+    await Promise.race([
+      drainWebSocketServer(),
+      new Promise((resolve) => setTimeout(resolve, config.shutdownTimeoutMs)),
+    ]);
+  } catch (err) {
+    logger.warn('WebSocket drain error', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  await closeWebSocketServer();
+  logger.info('WebSocket server closed');
 
+  // Phase 3: Stop indexer watchers
+  shutdownPhase = ShutdownPhase.WATCHERS_STOPPING;
   stopAllWatchers();
 
+  // Phase 4: Disconnect databases
+  shutdownPhase = ShutdownPhase.DB_DISCONNECTING;
   await disconnectDB();
+  try {
+    await pool.end();
+    logger.info('Raw database pool disconnected');
+  } catch {
+    // pool may already be ended
+  }
 
+  shutdownPhase = ShutdownPhase.COMPLETE;
   logger.info('Graceful shutdown complete');
 }

--- a/agro-production/server/src/services/tests/lifecycle.test.ts
+++ b/agro-production/server/src/services/tests/lifecycle.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+
+const { mockIsShuttingDown, mockGetShutdownPhase } = vi.hoisted(() => ({
+  mockIsShuttingDown: vi.fn(() => false),
+  mockGetShutdownPhase: vi.fn(() => 'RUNNING'),
+}));
+
+vi.mock('../lifecycle.js', () => ({
+  isGracefullyShuttingDown: mockIsShuttingDown,
+  getShutdownPhase: mockGetShutdownPhase,
+  getShutdownSignal: vi.fn(() => null),
+  registerHttpServer: vi.fn(),
+  registerWatcher: vi.fn(),
+  shutdown: vi.fn(),
+  ShutdownPhase: {
+    RUNNING: 'RUNNING',
+    HTTP_CLOSING: 'HTTP_CLOSING',
+    WS_DRAINING: 'WS_DRAINING',
+    WATCHERS_STOPPING: 'WATCHERS_STOPPING',
+    DB_DISCONNECTING: 'DB_DISCONNECTING',
+    COMPLETE: 'COMPLETE',
+  },
+}));
+
+vi.mock('../../db/client.js', () => ({
+  prisma: {
+    campaign: { findMany: vi.fn(), count: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), upsert: vi.fn() },
+    investment: { findMany: vi.fn(), create: vi.fn() },
+    order: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+    user: { upsert: vi.fn(), findUnique: vi.fn() },
+    transaction: { findFirst: vi.fn(), findUnique: vi.fn(), findMany: vi.fn(), create: vi.fn() },
+    dispute: { findMany: vi.fn(), count: vi.fn(), findUnique: vi.fn() },
+    eventCursor: { findUnique: vi.fn(), upsert: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+  connectDB: vi.fn(),
+  disconnectDB: vi.fn(),
+  isPrismaHealthy: vi.fn(),
+}));
+
+vi.mock('../wsServer.js', () => ({
+  broadcast: vi.fn(),
+  attachWebSocketServer: vi.fn(),
+  closeWebSocketServer: vi.fn(),
+  drainWebSocketServer: vi.fn(),
+  getWsClientCount: vi.fn(() => 0),
+}));
+
+vi.mock('../sorobanEventListener.js', () => ({
+  server: {
+    getLatestLedger: vi.fn().mockResolvedValue({ sequence: 12345 }),
+  },
+}));
+
+vi.mock('../../config/database.js', () => ({
+  default: { end: vi.fn(), query: vi.fn() },
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+}));
+
+vi.mock('../walletAuthService.js', () => ({
+  verifySession: vi.fn(),
+}));
+
+import app from '../../app.js';
+
+describe('Graceful lifecycle & readiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsShuttingDown.mockReturnValue(false);
+    mockGetShutdownPhase.mockReturnValue('RUNNING');
+  });
+
+  describe('GET /livez', () => {
+    it('returns alive with uptime', async () => {
+      const res = await request(app).get('/livez');
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('alive');
+      expect(typeof res.body.uptime).toBe('number');
+      expect(res.body.uptime).toBeGreaterThan(0);
+      expect(typeof res.body.timestamp).toBe('string');
+    });
+  });
+
+  describe('GET /readyz', () => {
+    it('returns ready when all checks pass', async () => {
+      const { prisma } = await import('../../db/client.js');
+      const { server: rpcServer } = await import('../sorobanEventListener.js');
+      (prisma.$queryRaw as ReturnType<typeof vi.fn>).mockResolvedValue([{ 1: 1 }]);
+      (rpcServer.getLatestLedger as ReturnType<typeof vi.fn>).mockResolvedValue({ sequence: 99999 });
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('ready');
+      expect(res.body.checks.database.status).toBe('UP');
+      expect(res.body.checks.rpc.status).toBe('UP');
+      expect(res.body.lastLedger).toBe(99999);
+    });
+
+    it('returns not_ready when database is unreachable', async () => {
+      const { prisma } = await import('../../db/client.js');
+      const { server: rpcServer } = await import('../sorobanEventListener.js');
+      (prisma.$queryRaw as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('connect ECONNREFUSED 127.0.0.1:5432'),
+      );
+      (rpcServer.getLatestLedger as ReturnType<typeof vi.fn>).mockResolvedValue({ sequence: 12345 });
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.status).toBe('not_ready');
+      expect(res.body.checks.database.status).toBe('DOWN');
+    });
+
+    it('returns not_ready when RPC is unreachable', async () => {
+      const { prisma } = await import('../../db/client.js');
+      const { server: rpcServer } = await import('../sorobanEventListener.js');
+      (prisma.$queryRaw as ReturnType<typeof vi.fn>).mockResolvedValue([{ 1: 1 }]);
+      (rpcServer.getLatestLedger as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('ENOTFOUND rpc.example.com'),
+      );
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.status).toBe('not_ready');
+      expect(res.body.checks.rpc.status).toBe('DOWN');
+    });
+
+    it('does not leak connection details in error messages', async () => {
+      const { prisma } = await import('../../db/client.js');
+      const { server: rpcServer } = await import('../sorobanEventListener.js');
+      (prisma.$queryRaw as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('password authentication failed for user "admin" at postgres://admin:secret@db.example.com:5432/db'),
+      );
+      (rpcServer.getLatestLedger as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('connect failed to https://rpc:secret-token@internal.stellar.org'),
+      );
+
+      const res = await request(app).get('/readyz');
+      expect(res.body.checks.database.message).toBe('database unreachable');
+      expect(res.body.checks.rpc.message).toBe('RPC endpoint unreachable');
+    });
+
+    it('returns 503 when server is shutting down', async () => {
+      mockIsShuttingDown.mockReturnValue(true);
+      mockGetShutdownPhase.mockReturnValue('HTTP_CLOSING');
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.status).toBe('not_ready');
+      expect(res.body.checks.shutdown.status).toBe('DOWN');
+      expect(res.body.checks.shutdown.message).toContain('HTTP_CLOSING');
+    });
+  });
+
+  describe('Shutdown middleware', () => {
+    it('accepts GET requests during shutdown', async () => {
+      mockIsShuttingDown.mockReturnValue(true);
+
+      const res = await request(app).get('/health');
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('UP');
+    });
+
+    it('rejects POST requests during shutdown with 503', async () => {
+      mockIsShuttingDown.mockReturnValue(true);
+
+      const res = await request(app)
+        .post('/api/v1/campaigns')
+        .set('Authorization', 'Bearer test')
+        .send({});
+      expect(res.status).toBe(503);
+      expect(res.body.message).toBe('Server is shutting down');
+    });
+
+    it('rejects PATCH requests during shutdown with 503', async () => {
+      mockIsShuttingDown.mockReturnValue(true);
+
+      const res = await request(app)
+        .patch('/api/v1/orders/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa/confirm')
+        .set('Authorization', 'Bearer test');
+      expect(res.status).toBe(503);
+    });
+
+    it('rejects DELETE requests during shutdown with 503', async () => {
+      mockIsShuttingDown.mockReturnValue(true);
+
+      const res = await request(app).delete('/campaigns/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa/image');
+      expect(res.status).toBe(503);
+    });
+
+    it('sets Connection: close header during shutdown', async () => {
+      mockIsShuttingDown.mockReturnValue(true);
+
+      const res = await request(app).get('/health');
+      expect(res.headers['connection']).toBe('close');
+    });
+  });
+
+  describe('Lifecycle shutdown order', () => {
+    it('shutdown function is importable and has expected phases', async () => {
+      const { shutdown, ShutdownPhase } = await import('../lifecycle.js');
+      expect(typeof shutdown).toBe('function');
+      expect(ShutdownPhase.RUNNING).toBe('RUNNING');
+      expect(ShutdownPhase.COMPLETE).toBe('COMPLETE');
+    });
+  });
+});

--- a/agro-production/server/src/services/transactionReconciler.ts
+++ b/agro-production/server/src/services/transactionReconciler.ts
@@ -1,0 +1,51 @@
+import { prisma } from '../db/client.js';
+import type { TransactionStatus } from '../schemas/transaction.js';
+
+export interface ReconciliationResult {
+  dbStatus: TransactionStatus;
+  reconciledStatus: TransactionStatus;
+  confirmedInLedger: boolean;
+  indexedByWatcher: boolean;
+  latestIndexedLedger: number | null;
+}
+
+const STATIC: readonly TransactionStatus[] = ['indexed', 'failed'];
+
+export async function reconcileTransaction(txHash: string, currentStatus: TransactionStatus): Promise<ReconciliationResult> {
+  let latestIndexedLedger: number | null = null;
+
+  const cursor = await prisma.eventCursor.findFirst({
+    orderBy: { updatedAt: 'desc' },
+  });
+  if (cursor) {
+    latestIndexedLedger = cursor.ledger;
+  }
+
+  const indexedTx = await prisma.transaction.findFirst({
+    where: { txHash, status: 'indexed' },
+    select: { id: true, ledger: true },
+  });
+
+  const confirmedInLedger = indexedTx !== null;
+  const indexedByWatcher = indexedTx !== null && indexedTx.ledger > 0;
+
+  let reconciledStatus: TransactionStatus;
+
+  if (STATIC.includes(currentStatus)) {
+    reconciledStatus = currentStatus;
+  } else if (indexedByWatcher) {
+    reconciledStatus = 'indexed';
+  } else if (confirmedInLedger) {
+    reconciledStatus = 'confirmed';
+  } else {
+    reconciledStatus = currentStatus;
+  }
+
+  return {
+    dbStatus: currentStatus,
+    reconciledStatus,
+    confirmedInLedger,
+    indexedByWatcher,
+    latestIndexedLedger,
+  };
+}

--- a/agro-production/server/src/services/wsServer.ts
+++ b/agro-production/server/src/services/wsServer.ts
@@ -18,6 +18,7 @@ export type WsEventType =
   | "dispute.evidence_submitted"
   | "dispute.resolved"
   | "dispute.dismissed"
+  | "transaction.status"
   | "error";
 
 export interface WsEventEnvelope<T = unknown> {

--- a/agro-production/server/src/services/wsServer.ts
+++ b/agro-production/server/src/services/wsServer.ts
@@ -116,6 +116,53 @@ export class WsServer {
     return this.wss.clients.size;
   }
 
+  drain(): Promise<void> {
+    return new Promise((resolve) => {
+      const clients = Array.from(this.wss.clients);
+      if (clients.length === 0) {
+        resolve();
+        return;
+      }
+
+      let remaining = clients.length;
+      const timeout = setTimeout(() => {
+        logger.warn('WebSocket drain timed out, terminating remaining connections');
+        for (const c of clients) {
+          if (c.readyState === c.OPEN) {
+            c.terminate();
+          }
+        }
+        resolve();
+      }, 5000);
+
+      for (const client of clients) {
+        try {
+          const msg = JSON.stringify({
+            version: '1',
+            type: 'server.shutdown',
+            payload: { reason: 'graceful_shutdown' },
+            timestamp: new Date().toISOString(),
+          });
+          client.send(msg, () => {
+            client.close(1001, 'Server shutting down');
+            remaining--;
+            if (remaining <= 0) {
+              clearTimeout(timeout);
+              resolve();
+            }
+          });
+        } catch {
+          client.terminate();
+          remaining--;
+          if (remaining <= 0) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        }
+      }
+    });
+  }
+
   close(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.wss.close((error) => (error ? reject(error) : resolve()));
@@ -146,4 +193,10 @@ export function closeWebSocketServer(): Promise<void> {
     activeServer = null;
     logger.info("WebSocket server closed");
   });
+}
+
+export function drainWebSocketServer(): Promise<void> {
+  const server = activeServer;
+  if (!server) return Promise.resolve();
+  return server.drain();
 }

--- a/agro-production/server/src/test/smoke.test.ts
+++ b/agro-production/server/src/test/smoke.test.ts
@@ -55,6 +55,9 @@ vi.mock("../services/wsServer.js", () => ({
 
 vi.mock("../services/sorobanEventListener.js", () => ({
   startSorobanEventListener: vi.fn().mockResolvedValue(null),
+  server: {
+    getLatestLedger: vi.fn().mockResolvedValue({ sequence: 12345 }),
+  },
 }));
 
 vi.mock("../events/watcher.js", () => ({

--- a/agro-production/server/src/test/transaction.test.ts
+++ b/agro-production/server/src/test/transaction.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+const { mockVerifySession } = vi.hoisted(() => ({
+  mockVerifySession: vi.fn(),
+}));
+
+vi.mock('../services/walletAuthService.js', () => ({
+  verifySession: mockVerifySession,
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+}));
+
+vi.mock('../services/wsServer.js', () => ({
+  broadcast: vi.fn(),
+  attachWebSocketServer: vi.fn(),
+  closeWebSocketServer: vi.fn(),
+  drainWebSocketServer: vi.fn(),
+  getWsClientCount: vi.fn(() => 0),
+}));
+
+vi.mock('../services/sorobanEventListener.js', () => ({
+  startSorobanEventListener: vi.fn().mockResolvedValue(null),
+  server: {
+    getLatestLedger: vi.fn().mockResolvedValue({ sequence: 12345 }),
+  },
+}));
+
+vi.mock('../events/watcher.js', () => ({
+  startProductionWatcher: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../config/database.js', () => ({
+  default: { end: vi.fn(), query: vi.fn() },
+}));
+
+vi.mock('../db/client.js', () => ({
+  prisma: {
+    transaction: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    eventCursor: {
+      findFirst: vi.fn(),
+    },
+    campaign: { findMany: vi.fn(), findUnique: vi.fn(), count: vi.fn(), create: vi.fn(), update: vi.fn(), upsert: vi.fn() },
+    investment: { findMany: vi.fn(), create: vi.fn() },
+    order: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+    user: { upsert: vi.fn(), findUnique: vi.fn() },
+    dispute: { findMany: vi.fn(), count: vi.fn(), findUnique: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+  connectDB: vi.fn(),
+  disconnectDB: vi.fn(),
+  isPrismaHealthy: vi.fn(),
+}));
+
+import app from '../app.js';
+import { prisma } from '../db/client.js';
+import { broadcast } from '../services/wsServer.js';
+
+const WALLET = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const OTHER_WALLET = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const TX_HASH = 'abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890';
+const REQUEST_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+
+function makeTx(overrides: Record<string, unknown> = {}) {
+  return {
+    id: REQUEST_ID,
+    txHash: TX_HASH,
+    walletAddress: WALLET,
+    status: 'awaiting_signature',
+    eventType: 'transaction.submitted',
+    campaignId: null,
+    ledger: 0,
+    eventIndex: 0,
+    payload: {},
+    processedAt: new Date('2025-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('Transaction Status & Reconciliation API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifySession.mockResolvedValue({
+      walletAddress: WALLET,
+      sessionToken: 'test-session',
+    });
+  });
+
+  describe('POST /api/v1/transactions', () => {
+    it('creates a transaction intent with awaiting_signature status', async () => {
+      (prisma.transaction.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (prisma.transaction.create as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx());
+
+      const res = await request(app)
+        .post('/api/v1/transactions')
+        .set('Authorization', 'Bearer test-session')
+        .send({
+          requestId: REQUEST_ID,
+          txHash: TX_HASH,
+          walletAddress: WALLET,
+          eventType: 'campaign.invested',
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.status).toBe('awaiting_signature');
+      expect(res.body.requestId).toBe(REQUEST_ID);
+      expect(res.body.txHash).toBe(TX_HASH);
+      expect(broadcast).toHaveBeenCalledWith('transaction.status', expect.objectContaining({
+        status: 'awaiting_signature',
+        walletAddress: WALLET,
+      }));
+    });
+
+    it('returns existing transaction on duplicate requestId (idempotent)', async () => {
+      (prisma.transaction.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeTx({ status: 'confirmed', ledger: 500 }),
+      );
+
+      const res = await request(app)
+        .post('/api/v1/transactions')
+        .set('Authorization', 'Bearer test-session')
+        .send({
+          requestId: REQUEST_ID,
+          txHash: TX_HASH,
+          walletAddress: WALLET,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('confirmed');
+      expect(res.body.ledger).toBe(500);
+      expect(prisma.transaction.create).not.toHaveBeenCalled();
+    });
+
+    it('returns existing transaction on duplicate txHash', async () => {
+      (prisma.transaction.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeTx({ id: 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb', status: 'submitted' }),
+      );
+
+      const res = await request(app)
+        .post('/api/v1/transactions')
+        .set('Authorization', 'Bearer test-session')
+        .send({
+          requestId: REQUEST_ID,
+          txHash: TX_HASH,
+          walletAddress: WALLET,
+        });
+
+      expect(res.status).toBe(200);
+      expect(prisma.transaction.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects wallet address mismatch', async () => {
+      mockVerifySession.mockResolvedValue({
+        walletAddress: WALLET,
+        sessionToken: 'test-session',
+      });
+
+      const res = await request(app)
+        .post('/api/v1/transactions')
+        .set('Authorization', 'Bearer test-session')
+        .send({
+          requestId: REQUEST_ID,
+          txHash: TX_HASH,
+          walletAddress: OTHER_WALLET,
+        });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('GET /api/v1/transactions/:requestId', () => {
+    it('returns transaction status by requestId', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx());
+
+      const res = await request(app)
+        .get(`/api/v1/transactions/${REQUEST_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('awaiting_signature');
+      expect(res.body.requestId).toBe(REQUEST_ID);
+    });
+
+    it('returns 404 for unknown requestId', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const res = await request(app)
+        .get(`/api/v1/transactions/${REQUEST_ID}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/v1/transactions', () => {
+    it('lists transactions for authenticated wallet', async () => {
+      (prisma.transaction.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeTx(),
+        makeTx({ id: 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb', status: 'indexed' }),
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/transactions')
+        .set('Authorization', 'Bearer test-session');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+      expect(res.body[0].status).toBe('awaiting_signature');
+      expect(res.body[1].status).toBe('indexed');
+    });
+  });
+
+  describe('PATCH /api/v1/transactions/:requestId/status', () => {
+    it('transitions from awaiting_signature to submitted', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx());
+      (prisma.transaction.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx({ status: 'submitted' }));
+
+      const res = await request(app)
+        .patch(`/api/v1/transactions/${REQUEST_ID}/status`)
+        .set('Authorization', 'Bearer test-session')
+        .send({ status: 'submitted' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('submitted');
+      expect(broadcast).toHaveBeenCalledWith('transaction.status', expect.objectContaining({
+        status: 'submitted',
+        previousStatus: 'awaiting_signature',
+      }));
+    });
+
+    it('transitions from submitted to confirmed', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx({ status: 'submitted' }));
+      (prisma.transaction.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx({ status: 'confirmed' }));
+
+      const res = await request(app)
+        .patch(`/api/v1/transactions/${REQUEST_ID}/status`)
+        .set('Authorization', 'Bearer test-session')
+        .send({ status: 'confirmed' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('confirmed');
+    });
+
+    it('transitions to failed from any non-terminal state', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx({ status: 'submitted' }));
+      (prisma.transaction.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx({ status: 'failed' }));
+
+      const res = await request(app)
+        .patch(`/api/v1/transactions/${REQUEST_ID}/status`)
+        .set('Authorization', 'Bearer test-session')
+        .send({ status: 'failed', message: 'Simulation failed: insufficient funds' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('failed');
+    });
+
+    it('rejects invalid transition: awaiting_signature -> confirmed', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx());
+
+      const res = await request(app)
+        .patch(`/api/v1/transactions/${REQUEST_ID}/status`)
+        .set('Authorization', 'Bearer test-session')
+        .send({ status: 'confirmed' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.title).toContain('Invalid Status Transition');
+    });
+
+    it('rejects transition from terminal indexed state', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx({ status: 'indexed' }));
+
+      const res = await request(app)
+        .patch(`/api/v1/transactions/${REQUEST_ID}/status`)
+        .set('Authorization', 'Bearer test-session')
+        .send({ status: 'failed' });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('rejects transition from terminal failed state', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(makeTx({ status: 'failed' }));
+
+      const res = await request(app)
+        .patch(`/api/v1/transactions/${REQUEST_ID}/status`)
+        .set('Authorization', 'Bearer test-session')
+        .send({ status: 'submitted' });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('forbids status update from a different wallet', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeTx({ walletAddress: OTHER_WALLET }),
+      );
+
+      const res = await request(app)
+        .patch(`/api/v1/transactions/${REQUEST_ID}/status`)
+        .set('Authorization', 'Bearer test-session')
+        .send({ status: 'submitted' });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('GET /api/v1/transactions/:requestId/reconcile', () => {
+    it('returns indexed when transaction found in watcher data', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeTx({ status: 'submitted' }),
+      );
+      (prisma.eventCursor.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ ledger: 5000 });
+
+      (prisma.transaction.findFirst as ReturnType<typeof vi.fn>)
+        .mockResolvedValue({ id: 'indexed-tx', ledger: 1234, status: 'indexed' });
+
+      const res = await request(app)
+        .get(`/api/v1/transactions/${REQUEST_ID}/reconcile`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.dbStatus).toBe('submitted');
+      expect(res.body.reconciledStatus).toBe('indexed');
+      expect(res.body.confirmedInLedger).toBe(true);
+      expect(res.body.indexedByWatcher).toBe(true);
+      expect(res.body.latestIndexedLedger).toBe(5000);
+    });
+
+    it('returns confirmed when tx found in DB but not fully indexed', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeTx({ status: 'confirmed' }),
+      );
+      (prisma.eventCursor.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ ledger: 5000 });
+
+      (prisma.transaction.findFirst as ReturnType<typeof vi.fn>)
+        .mockResolvedValue({ id: 'indexed-tx', ledger: 0, status: 'indexed' });
+
+      const res = await request(app)
+        .get(`/api/v1/transactions/${REQUEST_ID}/reconcile`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.confirmedInLedger).toBe(true);
+      expect(res.body.indexedByWatcher).toBe(false);
+    });
+
+    it('returns current status when tx not yet in indexer', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeTx({ status: 'submitted' }),
+      );
+      (prisma.eventCursor.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ ledger: 5000 });
+
+      (prisma.transaction.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const res = await request(app)
+        .get(`/api/v1/transactions/${REQUEST_ID}/reconcile`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.reconciledStatus).toBe('submitted');
+      expect(res.body.confirmedInLedger).toBe(false);
+      expect(res.body.indexedByWatcher).toBe(false);
+    });
+
+    it('preserves terminal states during reconciliation', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeTx({ status: 'failed' }),
+      );
+      (prisma.eventCursor.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const res = await request(app)
+        .get(`/api/v1/transactions/${REQUEST_ID}/reconcile`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.reconciledStatus).toBe('failed');
+    });
+
+    it('returns 404 for unknown transaction', async () => {
+      (prisma.transaction.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const res = await request(app)
+        .get(`/api/v1/transactions/${REQUEST_ID}/reconcile`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/agro-production/server/vitest.config.ts
+++ b/agro-production/server/vitest.config.ts
@@ -5,5 +5,9 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     globals: false,
+    env: {
+      DATABASE_URL: "postgresql://test:test@localhost:5432/test",
+      RPC_URL: "https://soroban-testnet.stellar.org",
+    },
   },
 });


### PR DESCRIPTION
## Summary
Implements graceful lifecycle management with coordinated shutdown/readiness probes, plus a transaction status state machine with reconciliation API.

---

## Part 1: Graceful Lifecycle & Readiness

### Lifecycle Controller (\services/lifecycle.ts\)
- Phased shutdown: HTTP close → WS drain → watchers stop → DB disconnect
- \ShutdownPhase\ enum for deterministic ordering
- Promisified HTTP server close with configurable timeout
- Raw database pool (\pg\) disconnect integrated into shutdown

### WebSocket (\services/wsServer.ts\)
- \drain()\ method: sends \server.shutdown\ notification to all connected clients, then closes with code 1001
- 5-second drain timeout before forceful termination

### Readiness Endpoints (\pp.ts\)
- \/livez\ — liveness probe (unchanged)
- \/readyz\ — now:
  - Returns 503 + shutdown status when server is shutting down
  - Never leaks connection strings/credentials in error messages
  - Adds \Connection: close\ header during graceful shutdown
- Non-GET requests rejected during shutdown with 503

### Database (\db/client.ts\, \config/database.ts\)
- \isPrismaHealthy()\ exported for external health checks
- \disconnectDb()\ / \isPoolHealthy()\ added to raw pg pool

---

## Part 2: Transaction Status & Reconciliation API

### Status State Machine (\schemas/transaction.ts\)
- Explicit states: \waiting_signature\ → \submitted\ → \confirmed\ → \indexed\
- Terminal states: \indexed\, \ailed\
- Validated transitions enforced server-side

### New Endpoints (\outes/transactions.ts\)
- \PATCH /api/v1/transactions/:requestId/status\ — authenticated status transitions
- \GET /api/v1/transactions/:requestId/reconcile\ — compare DB state against indexer data
- Existing \POST /transactions\ — idempotent creation with WebSocket broadcast

### Transaction Reconciler (\services/transactionReconciler.ts\)
- Checks indexer (Prisma) for matching txHash with indexed status
- Derives \confirmed\ vs \indexed\ from event cursor data
- Preserves terminal states (never downgrades \ailed\ to \submitted\)

### WebSocket (\services/wsServer.ts\)
- Added \	ransaction.status\ event type
- Broadcasts status changes with \previousStatus\ for client-side diffing

### OpenAPI (\openapi/registry.ts\)
- Registered \PATCH /transactions/{requestId}/status\ and \GET /transactions/{requestId}/reconcile\

### Tests
- **Lifecycle:** 12 tests covering readiness, shutdown middleware, secret leak prevention
- **Transactions:** 19 tests covering idempotent creation, status transitions, reconciliation, terminal state immutability, wallet ownership enforcement

---

### Bug Fixes
- Fixed missing \equireIdempotencyKey\ import in \outes/campaigns.ts\
- Fixed incomplete mock for \sorobanEventListener\ server export in smoke tests
- Set \DATABASE_URL\ in vitest config for test environment