### PR TITLE
fix: resolve critical backend bugs and improve error handling

### DIFF
--- a/agro-production/server/src/index.ts
+++ b/agro-production/server/src/index.ts
@@ -40,4 +40,13 @@ process.on('SIGINT', () => {
   shutdown('SIGINT').then(() => process.exit(0));
 });
 
+process.on('unhandledRejection', (reason: unknown) => {
+  logger.error('Unhandled promise rejection', { reason: reason instanceof Error ? reason.message : String(reason), stack: reason instanceof Error ? reason.stack : undefined });
+});
+
+process.on('uncaughtException', (error: Error) => {
+  logger.error('Uncaught exception — shutting down', { error: error.message, stack: error.stack });
+  process.exit(1);
+});
+
 bootstrap();

--- a/agro-production/server/src/routes/orders.ts
+++ b/agro-production/server/src/routes/orders.ts
@@ -18,7 +18,12 @@ import {
   type ListOrdersQuery,
 } from "../schemas/order.js";
 import { OrderSchema } from "../schemas/responses.js";
-import { requireIdempotencyKey, getCachedResponse, setCachedResponse } from "../middleware/idempotency.js";
+import {
+  requireIdempotencyKey,
+  getCachedResponse,
+  setCachedResponse,
+} from "../middleware/idempotency.js";
+import logger from "../config/logger.js";
 
 const router = Router();
 
@@ -62,60 +67,73 @@ router.get(
 router.post(
   "/orders",
   requireWallet,
+  requireIdempotencyKey,
   writeLimiter,
   validateBody(CreateOrderSchema.omit({ buyerAddress: true })),
   validateResponse(OrderSchema),
   async (req: WalletRequest, res: Response) => {
-    const buyerAddress = req.walletAddress!;
-    const { campaignId, amount } = req.body;
+    try {
+      const buyerAddress = req.walletAddress!;
+      const idempotencyKey = (req as any).idempotencyKey as string;
+      const { campaignId, amount } = req.body;
 
-    const campaign = await prisma.campaign.findUnique({ where: { id: campaignId } });
-    if (!campaign) {
-      problemDetail(res, req, 404, "Campaign Not Found", `No campaign with id ${campaignId}`);
-      return;
+      const cached = getCachedResponse(idempotencyKey);
+      if (cached) {
+        res.status(cached.status).json(cached.body);
+        return;
+      }
+
+      const campaign = await prisma.campaign.findUnique({ where: { id: campaignId } });
+      if (!campaign) {
+        problemDetail(res, req, 404, "Campaign Not Found", `No campaign with id ${campaignId}`);
+        return;
+      }
+      if (campaign.status !== "HARVESTED" && campaign.status !== "IN_PRODUCTION") {
+        problemDetail(
+          res,
+          req,
+          409,
+          "Campaign Not Accepting Orders",
+          `Campaign status is ${campaign.status}`,
+        );
+        return;
+      }
+
+      await prisma.user.upsert({
+        where: { walletAddress: buyerAddress },
+        create: { walletAddress: buyerAddress, role: "BUYER" },
+        update: {},
+      });
+
+      const order = await prisma.order.create({
+        data: {
+          onChainId: "pending",
+          campaignId: campaign.id,
+          buyerAddress,
+          amount,
+          ledger: 0,
+          txHash: null,
+        },
+      });
+
+      await prisma.transaction.create({
+        data: {
+          campaignId: campaign.id,
+          eventType: "order.created_intent",
+          payload: { idempotencyKey, intent: true },
+          ledger: 0,
+          eventIndex: 0,
+          txHash: null,
+        },
+      });
+
+      const response = order;
+      setCachedResponse(idempotencyKey, 201, response);
+      jsonValidated(res, OrderSchema, 201, response);
+    } catch (error) {
+      logger.error("[POST /orders] Failed to create order", { error });
+      problemDetail(res, req, 500, "Internal Server Error", "Failed to create order");
     }
-    if (campaign.status !== "HARVESTED" && campaign.status !== "IN_PRODUCTION") {
-      problemDetail(
-        res,
-        req,
-        409,
-        "Campaign Not Accepting Orders",
-        `Campaign status is ${campaign.status}`,
-      );
-      return;
-    }
-
-    await prisma.user.upsert({
-      where: { walletAddress: buyerAddress },
-      create: { walletAddress: buyerAddress, role: "BUYER" },
-      update: {},
-    });
-
-    const order = await prisma.order.create({
-      data: {
-        onChainId: "pending",
-        campaignId: campaign.id,
-        buyerAddress,
-        amount,
-        ledger: 0,
-        txHash: transactionHash,
-      },
-    });
-
-    await prisma.transaction.create({
-      data: {
-        campaignId: campaign.id,
-        eventType: "order.created_intent",
-        payload: { transactionHash, intent: true },
-        ledger: 0,
-        eventIndex: 0,
-        txHash: transactionHash,
-      },
-    });
-
-    const response = order;
-    setCachedResponse(key, 201, response);
-    jsonValidated(res, OrderSchema, 201, response);
   },
 );
 

--- a/server/src/http/errors.ts
+++ b/server/src/http/errors.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import logger from '../config/logger.js';
 
 export class ApiError extends Error {
   constructor(
@@ -9,6 +10,42 @@ export class ApiError extends Error {
   ) {
     super(detail);
     this.name = 'ApiError';
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(resource: string, identifier?: string) {
+    const detail = identifier ? `${resource} not found: ${identifier}` : `${resource} not found`;
+    super(404, 'Not Found', detail, 'https://cylos.io/errors/not-found');
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends ApiError {
+  constructor(message: string, public readonly details?: Record<string, string>) {
+    super(400, 'Bad Request', message, 'https://cylos.io/errors/validation');
+    this.name = 'ValidationError';
+  }
+}
+
+export class AuthError extends ApiError {
+  constructor(message = 'Authentication required') {
+    super(401, 'Unauthorized', message, 'https://cylos.io/errors/unauthorized');
+    this.name = 'AuthError';
+  }
+}
+
+export class ForbiddenError extends ApiError {
+  constructor(message = 'You do not have permission to perform this action') {
+    super(403, 'Forbidden', message, 'https://cylos.io/errors/forbidden');
+    this.name = 'ForbiddenError';
+  }
+}
+
+export class ConflictError extends ApiError {
+  constructor(message: string) {
+    super(409, 'Conflict', message, 'https://cylos.io/errors/conflict');
+    this.name = 'ConflictError';
   }
 }
 
@@ -23,4 +60,22 @@ export function sendProblem(res: Response, req: Request, error: ApiError): void 
       detail: error.message,
       instance: req.originalUrl,
     });
+}
+
+export function handleServiceError(err: unknown, req: Request, res: Response): void {
+  if (err instanceof ApiError) {
+    logger.warn(`[${err.name}] ${err.message}`, { path: req.path, method: req.method, status: err.status });
+    sendProblem(res, req, err);
+    return;
+  }
+
+  const error = err instanceof Error ? err : new Error(String(err));
+  logger.error('Unhandled service error', {
+    error: error.message,
+    stack: error.stack,
+    path: req.path,
+    method: req.method,
+  });
+
+  sendProblem(res, req, new ApiError(500, 'Internal Server Error', 'An unexpected error occurred'));
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -60,4 +60,16 @@ async function bootstrap() {
   }
 }
 
+process.on("unhandledRejection", (reason: unknown) => {
+  logger.error("Unhandled promise rejection", {
+    reason: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? reason.stack : undefined,
+  });
+});
+
+process.on("uncaughtException", (error: Error) => {
+  logger.error("Uncaught exception — shutting down", { error: error.message, stack: error.stack });
+  process.exit(1);
+});
+
 bootstrap();

--- a/server/src/middleware/adminAuth.ts
+++ b/server/src/middleware/adminAuth.ts
@@ -1,6 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { config } from '../config/index.js';
+import { prisma } from '../config/database.js';
+import logger from '../config/logger.js';
 
 export interface AdminRequest extends Request {
   adminWallet?: string;
@@ -24,8 +26,27 @@ export function requireAdmin(req: AdminRequest, res: Response, next: NextFunctio
       res.status(403).json({ message: 'Forbidden: Admin access required.' });
       return;
     }
+
     req.adminWallet = decoded.walletAddress;
-    next();
+
+    // DB cross-check: verify the wallet still holds the ADMIN role
+    prisma.user
+      .findUnique({ where: { walletAddress: decoded.walletAddress }, select: { role: true } })
+      .then((user) => {
+        if (!user || user.role !== 'ADMIN') {
+          logger.warn('[requireAdmin] Stale admin JWT rejected — role not found in DB', {
+            walletAddress: decoded.walletAddress,
+            dbRole: user?.role ?? null,
+          });
+          res.status(403).json({ message: 'Forbidden: Admin privileges have been revoked.' });
+          return;
+        }
+        next();
+      })
+      .catch((err) => {
+        logger.error('[requireAdmin] Failed to verify admin role against DB', { error: err });
+        res.status(500).json({ message: 'Internal Server Error: could not verify admin role.' });
+      });
   } catch {
     res.status(401).json({ message: 'Invalid or expired token.' });
   }

--- a/server/src/services/contractWatcher.ts
+++ b/server/src/services/contractWatcher.ts
@@ -5,6 +5,8 @@ import { prisma } from "../config/database.js";
 import { NotificationService } from "./notificationService.js";
 import { wsManager } from "./wsManager.js";
 import type { RawRpcEvent } from "../types/rawRpcEvent.js";
+import { BlockchainEventIngestionService } from "./events/blockchainEventIngestionService.js";
+import { EscrowEventIngestionService } from "./events/escrowEventIngestionService.js";
 
 const POLL_INTERVAL_MS = 5_000;
 const CHECKPOINT_SERVICE_NAME = "contract-watcher";
@@ -209,13 +211,25 @@ export async function startContractWatcher(): Promise<void> {
           continue;
         }
 
-        void import("./events/blockchainEventIngestionService.js")
-          .then(({ BlockchainEventIngestionService }) => BlockchainEventIngestionService.ingestEvent(event))
-          .catch((err) => logger.error("[ContractWatcher] BlockchainEventIngestionService import failed", err));
+        const ingestionResults = await Promise.allSettled([
+          BlockchainEventIngestionService.ingestEvent(event),
+          EscrowEventIngestionService.ingestEvent(event),
+        ]);
 
-        void import("./events/escrowEventIngestionService.js")
-          .then(({ EscrowEventIngestionService }) => EscrowEventIngestionService.ingestEvent(event))
-          .catch((err) => logger.error("[ContractWatcher] EscrowEventIngestionService import failed", err));
+        const failures = ingestionResults.filter((r) => r.status === "rejected");
+        if (failures.length > 0) {
+          for (const f of failures) {
+            logger.error("[ContractWatcher] Ingestion failed for event", {
+              error: f.status === "rejected" ? f.reason : undefined,
+              ledger: event.ledger,
+              eventIndex: event.eventIndex,
+            });
+          }
+          logger.error(
+            `[ContractWatcher] Halting checkpoint advance at ledger ${event.ledger} due to ingestion failure. Will retry on next poll.`,
+          );
+          return;
+        }
 
         handleEvent(event);
 

--- a/server/src/services/disputeService.ts
+++ b/server/src/services/disputeService.ts
@@ -1,52 +1,73 @@
 import { prisma } from "../config/database.js";
 import { EvidenceStorageService } from "./evidenceStorageService.js";
-import { ApiError } from "../http/errors.js";
+import { ApiError, NotFoundError } from "../http/errors.js";
+import logger from "../config/logger.js";
 
 export class DisputeService {
   /**
    * Fetch all disputes with full order and product metadata
    */
   static async getAllDisputes() {
-    return prisma.dispute.findMany({
-      include: {
-        order: {
-          include: {
-            product: true,
-            buyerUser: true,
-            sellerUser: true,
+    try {
+      return await prisma.dispute.findMany({
+        include: {
+          order: {
+            include: {
+              product: true,
+              buyerUser: true,
+              sellerUser: true,
+            },
           },
         },
-      },
-      orderBy: { createdAt: "desc" },
-    });
+        orderBy: { createdAt: "desc" },
+      });
+    } catch (error) {
+      logger.error("Failed to fetch disputes", { error });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch disputes");
+    }
   }
 
   /**
    * Fetch a single dispute by its on-chain order ID
    */
   static async getDisputeByOrderId(orderIdOnChain: string) {
-    return prisma.dispute.findUnique({
-      where: { orderIdOnChain },
-      include: {
-        order: {
-          include: {
-            product: true,
-            buyerUser: true,
-            sellerUser: true,
+    try {
+      const dispute = await prisma.dispute.findUnique({
+        where: { orderIdOnChain },
+        include: {
+          order: {
+            include: {
+              product: true,
+              buyerUser: true,
+              sellerUser: true,
+            },
           },
         },
-      },
-    });
+      });
+      if (!dispute) {
+        throw new NotFoundError("Dispute", orderIdOnChain);
+      }
+      return dispute;
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+      logger.error("Failed to fetch dispute by order ID", { error, orderIdOnChain });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch dispute");
+    }
   }
 
   /**
    * Attach evidence hash to a dispute
    */
   static async attachEvidence(orderIdOnChain: string, evidenceHash: string) {
-    return prisma.dispute.update({
-      where: { orderIdOnChain },
-      data: { evidenceHash },
-    });
+    try {
+      return await prisma.dispute.update({
+        where: { orderIdOnChain },
+        data: { evidenceHash },
+      });
+    } catch (error) {
+      logger.error("Failed to attach evidence to dispute", { error, orderIdOnChain });
+      throw new ApiError(500, "Internal Server Error", "Failed to attach evidence");
+    }
   }
 
   /**
@@ -54,9 +75,6 @@ export class DisputeService {
    */
   static async provideEvidence(orderIdOnChain: string, file: Express.Multer.File) {
     const dispute = await this.getDisputeByOrderId(orderIdOnChain);
-    if (!dispute) {
-      throw new ApiError(404, "Not Found", `Dispute not found for order ${orderIdOnChain}`);
-    }
 
     const evidenceHash = await EvidenceStorageService.uploadEvidence(file, orderIdOnChain);
 

--- a/server/src/services/events/blockchainEventIngestionService.ts
+++ b/server/src/services/events/blockchainEventIngestionService.ts
@@ -5,12 +5,8 @@ import type { RawRpcEvent } from "../../types/rawRpcEvent.js";
 
 export class BlockchainEventIngestionService {
   static async ingestEvent(rawEvent: RawRpcEvent): Promise<void> {
-    try {
-      const parsed = BlockchainEventParser.parse(rawEvent);
-      if (!parsed) return;
-      await BlockchainEventPersistenceService.persist(parsed);
-    } catch (error) {
-      logger.error("Failed to ingest blockchain event", { error, rawEvent });
-    }
+    const parsed = BlockchainEventParser.parse(rawEvent);
+    if (!parsed) return;
+    await BlockchainEventPersistenceService.persist(parsed);
   }
 }

--- a/server/src/services/events/escrowEventIngestionService.ts
+++ b/server/src/services/events/escrowEventIngestionService.ts
@@ -12,36 +12,31 @@ import type { RawRpcEvent } from "../../types/rawRpcEvent.js";
 export class EscrowEventIngestionService {
   /**
    * Main flow to ingest a single raw event.
+   * Throws on failure so the contract-watcher can retry the ledger.
    */
   static async ingestEvent(rawEvent: RawRpcEvent) {
-    try {
-      // 1. Parse
-      const parsed = EscrowEventParser.parse(rawEvent);
-      logger.info(`Processing ${parsed.action} event for order ${parsed.orderId}`);
+    // 1. Parse
+    const parsed = EscrowEventParser.parse(rawEvent);
+    logger.info(`Processing ${parsed.action} event for order ${parsed.orderId}`);
 
-      // 2. Map
-      const mapped = EscrowEventMapper.mapToModel(parsed);
+    // 2. Map
+    const mapped = EscrowEventMapper.mapToModel(parsed);
 
-      // 3. Persist
-      const record = await EscrowEventRepository.createEscrowEvent(mapped);
-      logger.info(`Escrow event stored in DB: ${record.id}`);
+    // 3. Persist
+    const record = await EscrowEventRepository.createEscrowEvent(mapped);
+    logger.info(`Escrow event stored in DB: ${record.id}`);
 
-      // --- NEW: Project to Application Domain (Issue #44) ---
-      await EscrowEventProjectionService.projectEvent(mapped);
+    // 4. Project to Application Domain
+    await EscrowEventProjectionService.projectEvent(mapped);
 
-      // --- NEW: Implement Notification System for Disputes ---
-      if (mapped.action === "dispute" || mapped.action === "resolved") {
-        await NotificationService.notifyOrderEvent(
-          mapped.action === "dispute" ? "dispute_opened" : "dispute_resolved",
-          mapped
-        );
-      }
-
-      return record;
-    } catch (error) {
-      // Structured logging without crashing the whole process
-      logger.error(`Failed to ingest event:`, error);
-      return null;
+    // 5. Notification System for Disputes
+    if (mapped.action === "dispute" || mapped.action === "resolved") {
+      await NotificationService.notifyOrderEvent(
+        mapped.action === "dispute" ? "dispute_opened" : "dispute_resolved",
+        mapped,
+      );
     }
+
+    return record;
   }
 }

--- a/server/src/services/metricsService.ts
+++ b/server/src/services/metricsService.ts
@@ -1,4 +1,6 @@
 import { prisma } from "../config/database.js";
+import { ApiError } from "../http/errors.js";
+import logger from "../config/logger.js";
 
 // Request counter for metrics
 let requestCount = 0;
@@ -62,41 +64,46 @@ const ACTIVE_USER_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
  * - active_users: distinct buyer or seller wallets with an order in the last 30 days.
  */
 export async function getPlatformMetrics() {
-  const { start, end, day } = utcCalendarDayBounds();
-  const activeSince = new Date(Date.now() - ACTIVE_USER_WINDOW_MS);
+  try {
+    const { start, end, day } = utcCalendarDayBounds();
+    const activeSince = new Date(Date.now() - ACTIVE_USER_WINDOW_MS);
 
-  const [ordersPerDay, campaignsCreated, orderAmounts, recentOrders] =
-    await Promise.all([
-      prisma.order.count({
-        where: { createdAt: { gte: start, lt: end } },
-      }),
-      prisma.product.count({
-        where: { createdAt: { gte: start, lt: end } },
-      }),
-      prisma.order.findMany({ select: { amount: true } }),
-      prisma.order.findMany({
-        where: { createdAt: { gte: activeSince } },
-        select: { buyerAddress: true, sellerAddress: true },
-      }),
-    ]);
+    const [ordersPerDay, campaignsCreated, orderAmounts, recentOrders] =
+      await Promise.all([
+        prisma.order.count({
+          where: { createdAt: { gte: start, lt: end } },
+        }),
+        prisma.product.count({
+          where: { createdAt: { gte: start, lt: end } },
+        }),
+        prisma.order.findMany({ select: { amount: true } }),
+        prisma.order.findMany({
+          where: { createdAt: { gte: activeSince } },
+          select: { buyerAddress: true, sellerAddress: true },
+        }),
+      ]);
 
-  const totalVolume = sumNumericAmounts(orderAmounts.map((o) => o.amount));
+    const totalVolume = sumNumericAmounts(orderAmounts.map((o) => o.amount));
 
-  const wallets = new Set<string>();
-  for (const o of recentOrders) {
-    wallets.add(o.buyerAddress);
-    wallets.add(o.sellerAddress);
+    const wallets = new Set<string>();
+    for (const o of recentOrders) {
+      wallets.add(o.buyerAddress);
+      wallets.add(o.sellerAddress);
+    }
+
+    return {
+      generated_at: new Date().toISOString(),
+      utc_calendar_day: day,
+      orders_per_day: ordersPerDay,
+      campaigns_created: campaignsCreated,
+      total_volume: totalVolume,
+      active_users: wallets.size,
+      request_count: requestCount,
+      error_count: errorCount,
+      error_rate: requestCount > 0 ? (errorCount / requestCount) * 100 : 0,
+    };
+  } catch (error) {
+    logger.error("Failed to fetch platform metrics", { error });
+    throw new ApiError(500, "Internal Server Error", "Failed to fetch platform metrics");
   }
-
-  return {
-    generated_at: new Date().toISOString(),
-    utc_calendar_day: day,
-    orders_per_day: ordersPerDay,
-    campaigns_created: campaignsCreated,
-    total_volume: totalVolume,
-    active_users: wallets.size,
-    request_count: requestCount,
-    error_count: errorCount,
-    error_rate: requestCount > 0 ? (errorCount / requestCount) * 100 : 0,
-  };
 }

--- a/server/src/services/notificationPreferenceService.ts
+++ b/server/src/services/notificationPreferenceService.ts
@@ -1,4 +1,6 @@
 import { prisma } from '../config/database.js';
+import { ApiError } from '../http/errors.js';
+import logger from '../config/logger.js';
 import { z } from 'zod';
 
 export const notificationPrefsSchema = z.object({
@@ -58,21 +60,27 @@ export async function upsertNotificationPreferences(
   walletAddress: string,
   body: unknown,
 ): Promise<NotificationPrefs> {
-  const parsed = notificationPrefsSchema.safeParse(body);
-  if (!parsed.success) {
-    throw new Error(parsed.error.message);
+  try {
+    const parsed = notificationPrefsSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new ApiError(400, 'Bad Request', parsed.error.message, 'https://cylos.io/errors/validation');
+    }
+
+    const row = await prisma.notificationPreference.upsert({
+      where: { walletAddress },
+      create: {
+        walletAddress,
+        preferences: parsed.data,
+      },
+      update: {
+        preferences: parsed.data,
+      },
+    });
+
+    return notificationPrefsSchema.parse(row.preferences);
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    logger.error('Failed to upsert notification preferences', { error, walletAddress });
+    throw new ApiError(500, 'Internal Server Error', 'Failed to update notification preferences');
   }
-
-  const row = await prisma.notificationPreference.upsert({
-    where: { walletAddress },
-    create: {
-      walletAddress,
-      preferences: parsed.data,
-    },
-    update: {
-      preferences: parsed.data,
-    },
-  });
-
-  return notificationPrefsSchema.parse(row.preferences);
 }

--- a/server/src/services/orderService.ts
+++ b/server/src/services/orderService.ts
@@ -1,4 +1,6 @@
 import { prisma } from "../config/database.js";
+import { ApiError, NotFoundError } from "../http/errors.js";
+import logger from "../config/logger.js";
 
 const ORDER_INCLUDE = {
   product: true,
@@ -9,63 +11,93 @@ const ORDER_INCLUDE = {
 const ORDER_BY_CREATED_DESC = { createdAt: "desc" } as const;
 
 export class OrderService {
-  static getAll() {
-    return prisma.order.findMany({
-      include: ORDER_INCLUDE,
-      orderBy: ORDER_BY_CREATED_DESC,
-    });
+  static async getAll() {
+    try {
+      return await prisma.order.findMany({
+        include: ORDER_INCLUDE,
+        orderBy: ORDER_BY_CREATED_DESC,
+      });
+    } catch (error) {
+      logger.error("Failed to fetch orders", { error });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch orders");
+    }
   }
 
-  static getByOrderId(orderIdOnChain: string) {
-    return prisma.order.findUnique({
-      where: { orderIdOnChain },
-      include: ORDER_INCLUDE,
-    });
+  static async getByOrderId(orderIdOnChain: string) {
+    try {
+      const order = await prisma.order.findUnique({
+        where: { orderIdOnChain },
+        include: ORDER_INCLUDE,
+      });
+      if (!order) {
+        throw new NotFoundError("Order", orderIdOnChain);
+      }
+      return order;
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+      logger.error("Failed to fetch order by ID", { error, orderIdOnChain });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch order");
+    }
   }
 
-  static getByBuyerAddress(buyerAddress: string) {
-    return prisma.order.findMany({
-      where: { buyerAddress },
-      include: ORDER_INCLUDE,
-      orderBy: ORDER_BY_CREATED_DESC,
-    });
+  static async getByBuyerAddress(buyerAddress: string) {
+    try {
+      return await prisma.order.findMany({
+        where: { buyerAddress },
+        include: ORDER_INCLUDE,
+        orderBy: ORDER_BY_CREATED_DESC,
+      });
+    } catch (error) {
+      logger.error("Failed to fetch orders by buyer", { error, buyerAddress });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch buyer orders");
+    }
   }
 
-  static getByFarmerAddress(sellerAddress: string) {
-    return prisma.order.findMany({
-      where: { sellerAddress },
-      include: ORDER_INCLUDE,
-      orderBy: ORDER_BY_CREATED_DESC,
-    });
+  static async getByFarmerAddress(sellerAddress: string) {
+    try {
+      return await prisma.order.findMany({
+        where: { sellerAddress },
+        include: ORDER_INCLUDE,
+        orderBy: ORDER_BY_CREATED_DESC,
+      });
+    } catch (error) {
+      logger.error("Failed to fetch orders by farmer", { error, sellerAddress });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch farmer orders");
+    }
   }
 
   static async getSellerStats(sellerAddress: string) {
-    const [totalOrders, completedCount, refundedCount, disputedCount] =
-      await Promise.all([
-        prisma.order.count({ where: { sellerAddress } }),
-        prisma.order.count({ where: { sellerAddress, status: "COMPLETED" } }),
-        prisma.order.count({ where: { sellerAddress, status: "REFUNDED" } }),
-        prisma.dispute.count({
-          where: {
-            order: { sellerAddress },
-          },
-        }),
-      ]);
+    try {
+      const [totalOrders, completedCount, refundedCount, disputedCount] =
+        await Promise.all([
+          prisma.order.count({ where: { sellerAddress } }),
+          prisma.order.count({ where: { sellerAddress, status: "COMPLETED" } }),
+          prisma.order.count({ where: { sellerAddress, status: "REFUNDED" } }),
+          prisma.dispute.count({
+            where: {
+              order: { sellerAddress },
+            },
+          }),
+        ]);
 
-    if (totalOrders === 0) {
+      if (totalOrders === 0) {
+        return {
+          totalOrders: 0,
+          successRate: 100,
+          disputeRate: 0,
+          refundRatio: 0,
+        };
+      }
+
       return {
-        totalOrders: 0,
-        successRate: 100,
-        disputeRate: 0,
-        refundRatio: 0,
+        totalOrders,
+        successRate: (completedCount / totalOrders) * 100,
+        disputeRate: (disputedCount / totalOrders) * 100,
+        refundRatio: (refundedCount / totalOrders) * 100,
       };
+    } catch (error) {
+      logger.error("Failed to fetch seller stats", { error, sellerAddress });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch seller statistics");
     }
-
-    return {
-      totalOrders,
-      successRate: (completedCount / totalOrders) * 100,
-      disputeRate: (disputedCount / totalOrders) * 100,
-      refundRatio: (refundedCount / totalOrders) * 100,
-    };
   }
 }


### PR DESCRIPTION
## Summary

This PR resolves four critical backend issues:

### #566 — Incomplete Error Handling in Services
- Added custom error classes (, , , , ) to `server/src/http/errors.ts`
- Added `handleServiceError` helper for unified error responses
- Wrapped service methods in `orderService`, `disputeService`, `metricsService`, and `notificationPreferenceService` with try-catch blocks that log context and throw typed errors
- Stack traces are no longer exposed to clients

### #618 — POST /orders throws on undefined variables
- Wired `requireIdempotencyKey` middleware onto the POST /orders route
- Replaced undefined `transactionHash` references with `txHash: null` (no on-chain tx yet at intent stage)
- Replaced undefined `key` with `req.idempotencyKey` for cache lookups
- Added try-catch to the async handler to prevent process crashes
- Added process-level `unhandledRejection` and `uncaughtException` handlers to both `server/src/index.ts` and `agro-production/server/src/index.ts`

### #620 — Contract-watcher checkpoint advances before event ingestion completes
- Replaced fire-and-forget `void import(...)` with awaited `Promise.allSettled` calls
- Ingestion services (`BlockchainEventIngestionService`, `EscrowEventIngestionService`) now throw on failure instead of swallowing errors
- Checkpoint only advances after all ingestions succeed; halts and retries on next poll if any fail

### #622 — Admin role trusted from JWT alone, no DB cross-check
- `requireAdmin` middleware now queries the `User` table after JWT verification to confirm the wallet still holds the `ADMIN` role
- Stale or revoked admin JWTs are rejected with 403

Closes #566, Closes #618, Closes #620, Closes #622