### PR TITLE
fix: resolve escrow contract compilation and security issues

### DIFF
--- a/agro-production/contract/production_escrow/src/lib.rs
+++ b/agro-production/contract/production_escrow/src/lib.rs
@@ -390,13 +390,9 @@ impl ProductionEscrowContract {
             .persistent()
             .get::<_, i128>(&contribution_key)
             .unwrap_or(0);
-            .get(&DataKey::Contributions(campaign_id))
-            .unwrap_or(Map::new(&env));
-        let prev = contribs.get(investor.clone()).unwrap_or(0);
-        contribs.set(investor.clone(), checked_add(prev, amount)?);
         env.storage()
             .persistent()
-            .set(&contribution_key, &(prev + amount));
+            .set(&contribution_key, &checked_add(prev, amount)?);
 
         // Auto-transition to Funded when target reached.
         if campaign.total_raised == campaign.target_amount {
@@ -638,21 +634,19 @@ impl ProductionEscrowContract {
             return Err(EscrowError::CampaignNotSettled);
         }
 
+        let contribution_key = DataKey::Contribution(campaign_id, investor.clone());
         let contribution = env
             .storage()
             .persistent()
-            .get::<_, i128>(&DataKey::Contribution(campaign_id, investor.clone()))
-        let contribs = load_contribs(&env, campaign_id);
-        // Extend TTL on contribution read to protect investment records (Issue #456).
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Contributions(campaign_id), TTL_THRESHOLD, TTL_EXTEND);
-        let contribution = contribs
-            .get(investor.clone())
+            .get::<_, i128>(&contribution_key)
             .ok_or(EscrowError::NotInvestor)?;
         if contribution <= 0 {
             return Err(EscrowError::NotInvestor);
         }
+        // Extend TTL on contribution read to protect investment records (Issue #456).
+        env.storage()
+            .persistent()
+            .extend_ttl(&contribution_key, TTL_THRESHOLD, TTL_EXTEND);
 
         let claim_key = DataKey::Claimed(campaign_id, investor.clone());
         if env.storage().persistent().has(&claim_key) {
@@ -759,21 +753,19 @@ impl ProductionEscrowContract {
         if campaign.status != CampaignStatus::Failed {
             return Err(EscrowError::CampaignNotFailed);
         }
+        let contribution_key = DataKey::Contribution(campaign_id, investor.clone());
         let contribution = env
             .storage()
             .persistent()
-            .get::<_, i128>(&DataKey::Contribution(campaign_id, investor.clone()))
-        let contribs = load_contribs(&env, campaign_id);
-        // Extend TTL on contribution read to protect refund records (Issue #456).
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Contributions(campaign_id), TTL_THRESHOLD, TTL_EXTEND);
-        let contribution = contribs
-            .get(investor.clone())
+            .get::<_, i128>(&contribution_key)
             .ok_or(EscrowError::NotInvestor)?;
         if contribution <= 0 {
             return Err(EscrowError::NotInvestor);
         }
+        // Extend TTL on contribution read to protect refund records (Issue #456).
+        env.storage()
+            .persistent()
+            .extend_ttl(&contribution_key, TTL_THRESHOLD, TTL_EXTEND);
 
         let claim_key = DataKey::Claimed(campaign_id, investor.clone());
         if env.storage().persistent().has(&claim_key) {
@@ -804,12 +796,15 @@ impl ProductionEscrowContract {
         }
 
         // Proportional refund: remaining pool = raised + revenue - released.
-        let pool = campaign.total_raised + campaign.total_revenue - campaign.tranche_released;
+        let pool = checked_add(
+            campaign.total_raised,
+            checked_sub(campaign.total_revenue, campaign.tranche_released)?
+        )?;
         if pool <= 0 {
             return Err(EscrowError::NothingToClaim);
         }
 
-        let payout = (pool * contribution) / campaign.total_raised;
+        let payout = checked_mul(pool, contribution)? / campaign.total_raised;
         if payout <= 0 {
             return Err(EscrowError::NothingToClaim);
         }
@@ -841,8 +836,11 @@ impl ProductionEscrowContract {
         if campaign.status != CampaignStatus::Failed {
             return 0;
         }
-        let contribs = load_contribs(&env, campaign_id);
-        let contribution = contribs.get(investor.clone()).unwrap_or(0);
+        let contribution = env
+            .storage()
+            .persistent()
+            .get::<_, i128>(&DataKey::Contribution(campaign_id, investor.clone()))
+            .unwrap_or(0);
         if contribution <= 0 {
             return 0;
         }
@@ -853,11 +851,17 @@ impl ProductionEscrowContract {
         if campaign.tranche_released <= 0 {
             return contribution;
         }
-        let pool = campaign.total_raised + campaign.total_revenue - campaign.tranche_released;
+        let pool = match checked_add(
+            campaign.total_raised,
+            checked_sub(campaign.total_revenue, campaign.tranche_released).unwrap_or(0)
+        ) {
+            Ok(p) => p,
+            Err(_) => return 0,
+        };
         if pool <= 0 {
             return 0;
         }
-        (pool * contribution) / campaign.total_raised
+        checked_mul(pool, contribution).unwrap_or(0) / campaign.total_raised
     }
 
     // -----------------------------------------------------------------------
@@ -982,7 +986,10 @@ impl ProductionEscrowContract {
         }
         let token_client = token::Client::new(&env, &campaign.token);
 
-        let pool = campaign.total_raised + campaign.total_revenue - campaign.tranche_released;
+        let pool = checked_add(
+            campaign.total_raised,
+            checked_sub(campaign.total_revenue, campaign.tranche_released)?
+        )?;
         let full_refund = campaign.tranche_released <= 0;
 
         let mut count: u32 = 0;
@@ -1009,7 +1016,10 @@ impl ProductionEscrowContract {
                 if pool <= 0 {
                     continue;
                 }
-                (pool * contribution) / campaign.total_raised
+                match checked_mul(pool, contribution) {
+                    Ok(prod) => prod / campaign.total_raised,
+                    Err(_) => continue,
+                }
             };
             if payout <= 0 {
                 continue;
@@ -1021,8 +1031,7 @@ impl ProductionEscrowContract {
                 &payout,
             );
             count += 1;
-            total = checked_add(total, contribution)?;
-            total += payout;
+            total = checked_add(total, payout)?;
         }
 
         // Emit a single summary event for the whole batch.
@@ -1076,7 +1085,7 @@ impl ProductionEscrowContract {
                 .extend_ttl(&DataKey::Order(order_id), TTL_THRESHOLD, TTL_EXTEND);
 
             // Refund full amount (net + fee) to buyer since order was not delivered.
-            let refund_amount = order.amount + order.fee;
+            let refund_amount = checked_add(order.amount, order.fee)?;
             let token_client = token::Client::new(&env, &campaign.token);
             token_client.transfer(
                 &env.current_contract_address(),
@@ -1090,8 +1099,7 @@ impl ProductionEscrowContract {
                 );
             }
             count += 1;
-            total += refund_amount;
-            total = checked_add(total, order.amount)?;
+            total = checked_add(total, refund_amount)?;
         }
 
         // Emit a single summary event for the whole batch.

--- a/agro-production/contract/production_escrow/src/lib.rs
+++ b/agro-production/contract/production_escrow/src/lib.rs
@@ -152,6 +152,7 @@ pub struct Order {
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
+    Attester,
     SupportedTokens,
     RegistryContract,
     FeeCollector,
@@ -270,6 +271,20 @@ impl ProductionEscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::FeeRateBps, &fee_rate_bps);
+        Ok(())
+    }
+
+    /// Set the independent attester role. Can be called by admin.
+    /// The attester is required to sign off on mark_harvest to prevent farmer self-attest exploits.
+    pub fn set_attester(env: Env, admin_caller: Address, attester: Address) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let admin = admin(&env)?;
+        if admin_caller != admin {
+            return Err(EscrowError::NotAdmin);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Attester, &attester);
         Ok(())
     }
 
@@ -447,8 +462,14 @@ impl ProductionEscrowContract {
     }
 
     /// Farmer signals harvest done. Releases the harvest tranche.
-    pub fn mark_harvest(env: Env, farmer: Address, campaign_id: u64) -> Result<(), EscrowError> {
+    /// Requires independent attester co-signature to prevent farmer self-attest exploits.
+    pub fn mark_harvest(env: Env, farmer: Address, attester_caller: Address, campaign_id: u64) -> Result<(), EscrowError> {
         farmer.require_auth();
+        attester_caller.require_auth();
+        let attester_addr = attester(&env)?;
+        if attester_caller != attester_addr {
+            return Err(EscrowError::NotAdmin);
+        }
         let mut campaign = load_campaign(&env, campaign_id)?;
         if campaign.farmer != farmer {
             return Err(EscrowError::NotFarmer);
@@ -705,9 +726,9 @@ impl ProductionEscrowContract {
         Ok(())
     }
 
-    /// Farmer or admin can mark a campaign failed from any non-terminal
-    /// state (Funded, InProduction, Harvested). This triggers proportional
-    /// refund logic — investors get their share of the remaining escrow pool.
+    /// Farmer or admin can mark a campaign failed from any non-terminal state.
+    /// Farmer can unilaterally fail from Funded (no tranches released yet).
+    /// Farmer cannot unilaterally fail from InProduction or Harvested (requires admin co-sign).
     ///
     /// Recovery outcomes:
     ///   - Funded: full refund (no tranches released yet).
@@ -722,25 +743,30 @@ impl ProductionEscrowContract {
         let mut campaign = load_campaign(&env, campaign_id)?;
         let admin = admin(&env)?;
 
-        // Only farmer or admin can trigger failure after funding
-        if caller != campaign.farmer && caller != admin {
+        // Determine who can call based on campaign state
+        let can_fail = match campaign.status {
+            CampaignStatus::Funded => {
+                // Farmer can unilaterally fail before production starts
+                caller == campaign.farmer || caller == admin
+            }
+            CampaignStatus::InProduction | CampaignStatus::Harvested => {
+                // Farmer cannot unilaterally fail after production starts; requires admin
+                caller == admin
+            }
+            _ => false,
+        };
+
+        if !can_fail {
             return Err(EscrowError::NotAdmin);
         }
 
-        match campaign.status {
-            CampaignStatus::Funded
-            | CampaignStatus::InProduction
-            | CampaignStatus::Harvested => {
-                campaign.status = CampaignStatus::Failed;
-                save_campaign(&env, &campaign);
-                env.events().publish(
-                    (t_campaign(), symbol_short!("failed")),
-                    (campaign_id,),
-                );
-                Ok(())
-            }
-            _ => Err(EscrowError::CampaignNotFundedOrBeyond),
-        }
+        campaign.status = CampaignStatus::Failed;
+        save_campaign(&env, &campaign);
+        env.events().publish(
+            (t_campaign(), symbol_short!("failed")),
+            (campaign_id,),
+        );
+        Ok(())
     }
 
     /// Investor reclaims their proportional share on a failed campaign.
@@ -885,7 +911,6 @@ impl ProductionEscrowContract {
         }
         if campaign.status == CampaignStatus::Disputed
             || campaign.status == CampaignStatus::Settled
-            || campaign.status == CampaignStatus::Failed
         {
             return Err(EscrowError::CampaignAlreadyDisputed);
         }
@@ -1188,6 +1213,13 @@ fn admin(env: &Env) -> Result<Address, EscrowError> {
     env.storage()
         .instance()
         .get(&DataKey::Admin)
+        .ok_or(EscrowError::ContractNotInitialized)
+}
+
+fn attester(env: &Env) -> Result<Address, EscrowError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Attester)
         .ok_or(EscrowError::ContractNotInitialized)
 }
 

--- a/agro-production/contract/production_escrow/src/test.rs
+++ b/agro-production/contract/production_escrow/src/test.rs
@@ -55,7 +55,8 @@ fn setup() -> TestEnv<'static> {
 
     let mut tokens = Vec::new(&env);
     tokens.push_back(token_id.clone());
-    client.initialize(&admin, &tokens);
+    let fee_collector = Address::generate(&env);
+    client.initialize(&admin, &tokens, &fee_collector, 300);
 
     // Leak lifetimes to 'static for convenience struct.
     let env: Env = unsafe { std::mem::transmute(env) };

--- a/agro-production/contract/production_escrow/src/test.rs
+++ b/agro-production/contract/production_escrow/src/test.rs
@@ -22,6 +22,7 @@ struct TestEnv<'a> {
     client: ProductionEscrowContractClient<'a>,
     token_id: Address,
     admin: Address,
+    attester: Address,
     farmer: Address,
     investor1: Address,
     investor2: Address,
@@ -33,6 +34,7 @@ fn setup() -> TestEnv<'static> {
     env.mock_all_auths();
 
     let admin = Address::generate(&env);
+    let attester = Address::generate(&env);
     let farmer = Address::generate(&env);
     let investor1 = Address::generate(&env);
     let investor2 = Address::generate(&env);
@@ -57,6 +59,7 @@ fn setup() -> TestEnv<'static> {
     tokens.push_back(token_id.clone());
     let fee_collector = Address::generate(&env);
     client.initialize(&admin, &tokens, &fee_collector, 300);
+    client.set_attester(&admin, &attester);
 
     // Leak lifetimes to 'static for convenience struct.
     let env: Env = unsafe { std::mem::transmute(env) };
@@ -67,6 +70,7 @@ fn setup() -> TestEnv<'static> {
         client,
         token_id,
         admin,
+        attester,
         farmer,
         investor1,
         investor2,
@@ -435,7 +439,7 @@ fn test_mark_harvest_ok() {
     t.client.start_production(&t.farmer, &id);
 
     let farmer_before = balance(&t, &t.farmer);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let c = t.client.get_campaign(&id);
     assert_eq!(c.status, CampaignStatus::Harvested);
@@ -454,7 +458,7 @@ fn test_mark_harvest_invalid_transition_from_funded() {
     t.client.invest(&t.investor1, &id, &10_000); // Funded
     let err = t
         .client
-        .try_mark_harvest(&t.farmer, &id)
+        .try_mark_harvest(&t.farmer, &t.attester, &id)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, EscrowError::CampaignNotInProduction);
@@ -469,7 +473,7 @@ fn test_lifecycle_full_happy_path() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     assert_eq!(t.client.get_campaign(&id).status, CampaignStatus::Harvested);
 }
 
@@ -498,7 +502,7 @@ fn test_second_tranche_brings_total_to_70_percent() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     assert_eq!(t.client.get_campaign(&id).tranche_released, 7_000);
 }
 
@@ -515,7 +519,7 @@ fn test_settle_ok() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
     assert_eq!(t.client.get_campaign(&id).status, CampaignStatus::Settled);
 }
@@ -543,7 +547,7 @@ fn test_investor_claims_returns_after_settlement() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
 
     let before = balance(&t, &t.investor1);
@@ -563,7 +567,7 @@ fn test_proportional_payout_two_investors() {
     t.client.invest(&t.investor1, &id, &6_000);
     t.client.invest(&t.investor2, &id, &4_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
 
     // Pool = 10_000 - 7_000 = 3_000
@@ -582,7 +586,7 @@ fn test_double_claim_rejected() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
     t.client.claim_returns(&t.investor1, &id);
     let err = t
@@ -602,7 +606,7 @@ fn test_non_investor_cannot_claim() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
     let err = t
         .client
@@ -625,7 +629,7 @@ fn test_create_order_ok() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     let o = t.client.get_order(&order_id);
@@ -643,7 +647,7 @@ fn test_confirm_order_adds_to_revenue() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     t.client.confirm_order(&t.buyer, &order_id);
@@ -661,7 +665,7 @@ fn test_confirm_order_only_by_buyer() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     let err = t
@@ -681,7 +685,7 @@ fn test_double_confirm_order_rejected() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     t.client.confirm_order(&t.buyer, &order_id);
@@ -717,7 +721,7 @@ fn test_settlement_includes_order_revenue() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &2_000);
     t.client.confirm_order(&t.buyer, &order_id);
@@ -978,7 +982,7 @@ fn test_mark_harvest_non_farmer_rejected() {
     t.client.start_production(&t.farmer, &id);
     let err = t
         .client
-        .try_mark_harvest(&t.buyer, &id)
+        .try_mark_harvest(&t.buyer, &t.attester, &id)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, EscrowError::NotFarmer);
@@ -993,7 +997,7 @@ fn test_settle_unauthorized_caller_rejected() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     let err = t.client.try_settle(&t.buyer, &id).unwrap_err().unwrap();
     assert_eq!(err, EscrowError::NotAdmin);
 }
@@ -1040,7 +1044,7 @@ fn test_create_order_zero_amount_rejected() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     let err = t
         .client
         .try_create_order(&t.buyer, &id, &0)
@@ -1075,7 +1079,7 @@ fn test_open_dispute_on_already_settled_campaign_rejected() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
     let err = t
         .client
@@ -1106,7 +1110,7 @@ fn test_admin_can_also_settle() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.admin, &id);
     assert_eq!(t.client.get_campaign(&id).status, CampaignStatus::Settled);
 }
@@ -1145,7 +1149,7 @@ fn test_order_valid_transition_pending_to_confirmed() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     let o_before = t.client.get_order(&order_id);
@@ -1165,7 +1169,7 @@ fn test_cannot_confirm_order_twice() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &200);
     t.client.confirm_order(&t.buyer, &order_id);
@@ -1223,7 +1227,7 @@ fn test_campaign_valid_transition_in_production_to_harvested() {
         t.client.get_campaign(&id).status,
         CampaignStatus::InProduction
     );
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     assert_eq!(
         t.client.get_campaign(&id).status,
         CampaignStatus::Harvested
@@ -1239,7 +1243,7 @@ fn test_campaign_valid_transition_harvested_to_settled() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     assert_eq!(
         t.client.get_campaign(&id).status,
         CampaignStatus::Harvested
@@ -1368,7 +1372,7 @@ fn test_cannot_mark_harvest_from_funded() {
     t.client.invest(&t.investor1, &id, &10_000); // → Funded
     let err = t
         .client
-        .try_mark_harvest(&t.farmer, &id)
+        .try_mark_harvest(&t.farmer, &t.attester, &id)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, EscrowError::CampaignNotInProduction);
@@ -1400,7 +1404,7 @@ fn test_cannot_refund_settled_campaign() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id); // → Settled
     let err = t
         .client
@@ -1465,7 +1469,7 @@ fn test_state_persisted_after_mark_harvest() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     let c = t.client.get_campaign(&id);
     assert_eq!(c.status, CampaignStatus::Harvested);
     assert_eq!(c.tranche_released, 7_000);
@@ -1585,7 +1589,7 @@ fn test_order_not_refunded_before_96h() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     let buyer_before = balance(&t, &t.buyer);
@@ -1610,7 +1614,7 @@ fn test_order_refunded_at_exactly_96h() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     let buyer_before = balance(&t, &t.buyer);
@@ -1634,7 +1638,7 @@ fn test_order_refunded_after_96h() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &300);
     let buyer_before = balance(&t, &t.buyer);
@@ -1659,7 +1663,7 @@ fn test_order_expiration_idempotent() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &400);
     advance_ledger(&t.env, ORDER_EXPIRY_SECS);
@@ -1688,7 +1692,7 @@ fn test_confirmed_order_not_eligible_for_batch_refund() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     t.client.confirm_order(&t.buyer, &order_id); // already confirmed
@@ -1739,7 +1743,7 @@ fn test_error_not_farmer_mark_harvest() {
     t.client.start_production(&t.farmer, &id);
     let err = t
         .client
-        .try_mark_harvest(&t.investor1, &id)
+        .try_mark_harvest(&t.investor1, &t.attester, &id)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, EscrowError::NotFarmer);
@@ -1754,7 +1758,7 @@ fn test_error_not_buyer_confirm_order() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     let order_id = t.client.create_order(&t.buyer, &id, &100);
     let err = t
         .client
@@ -1773,7 +1777,7 @@ fn test_error_not_investor_cannot_claim() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
     // investor2 never invested
     let err = t
@@ -1810,7 +1814,7 @@ fn test_error_not_admin_settle() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     let err = t
         .client
         .try_settle(&t.investor1, &id)
@@ -1882,7 +1886,7 @@ fn test_error_campaign_not_in_production_mark_harvest() {
     t.client.invest(&t.investor1, &id, &10_000); // → Funded, not InProduction
     let err = t
         .client
-        .try_mark_harvest(&t.farmer, &id)
+        .try_mark_harvest(&t.farmer, &t.attester, &id)
         .unwrap_err()
         .unwrap();
     assert_eq!(err, EscrowError::CampaignNotInProduction);
@@ -1988,7 +1992,7 @@ fn test_error_order_not_pending_confirm_twice() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     let order_id = t.client.create_order(&t.buyer, &id, &200);
     t.client.confirm_order(&t.buyer, &order_id);
     let err = t
@@ -2066,7 +2070,7 @@ fn test_error_invalid_amount_create_order_zero() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     let err = t
         .client
         .try_create_order(&t.buyer, &id, &0)
@@ -2215,7 +2219,7 @@ fn test_error_already_claimed_returns() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
     t.client.settle(&t.farmer, &id);
     t.client.claim_returns(&t.investor1, &id);
     let err = t
@@ -2448,7 +2452,7 @@ fn test_batch_refund_orders_refunds_expired_orders() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let sac = soroban_sdk::token::StellarAssetClient::new(&t.env, &t.token_id);
     let buyer2 = Address::generate(&t.env);
@@ -2485,7 +2489,7 @@ fn test_batch_refund_orders_emits_single_summary_event() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &400);
     advance_ledger(&t.env, ORDER_EXPIRY_SECS);
@@ -2508,7 +2512,7 @@ fn test_batch_refund_orders_skips_unexpired_orders() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &500);
     let buyer_before = balance(&t, &t.buyer);
@@ -2546,7 +2550,7 @@ fn test_batch_refund_orders_count_and_total_are_correct() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let o1 = t.client.create_order(&t.buyer, &id, &100);
     let o2 = t.client.create_order(&t.buyer, &id, &200);
@@ -2587,7 +2591,7 @@ fn test_mark_campaign_failed_from_funded_state_full_refund() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     // Create order before settlement is OK
     let order_id = t.client.create_order(&t.buyer, &id, &2_000);
@@ -2634,8 +2638,8 @@ fn test_mark_campaign_failed_from_in_production_proportional_refund() {
     t.client.start_production(&t.farmer, &id); // 30% tranche released (3_000)
     assert_eq!(t.client.get_campaign(&id).tranche_released, 3_000);
 
-    // Farmer marks campaign as failed during production
-    t.client.mark_campaign_failed(&t.farmer, &id);
+    // Admin marks campaign as failed during production (farmer cannot unilaterally fail after production starts)
+    t.client.mark_campaign_failed(&t.admin, &id);
     assert_eq!(t.client.get_campaign(&id).status, CampaignStatus::Failed);
 
     // Pool = 10_000 - 3_000 = 7_000
@@ -2656,7 +2660,7 @@ fn test_mark_campaign_failed_from_harvested_proportional_refund() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000); // → Funded
     t.client.start_production(&t.farmer, &id); // 30% → 3_000
-    t.client.mark_harvest(&t.farmer, &id); // +40% → 7_000 total
+    t.client.mark_harvest(&t.farmer, &t.attester, &id); // +40% → 7_000 total
 
     // Add some revenue via an order
     let order_id = t.client.create_order(&t.buyer, &id, &2_000);
@@ -2699,7 +2703,7 @@ fn test_mark_campaign_failed_non_farmer_non_admin_rejected() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     // Create and confirm order before settlement
     let order_id = t.client.create_order(&t.buyer, &id, &2_000);
@@ -2769,7 +2773,7 @@ fn test_refundable_amount_proportional_after_production() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id);
-    t.client.mark_harvest(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
 
     let order_id = t.client.create_order(&t.buyer, &id, &2_000);
 
@@ -2786,7 +2790,7 @@ fn test_refundable_amount_proportional_after_production() {
     let order = t.client.get_order(&order_id);
     assert_eq!(order.status, OrderStatus::Refunded);
     t.client.start_production(&t.farmer, &id); // 3_000 released
-    t.client.mark_campaign_failed(&t.farmer, &id);
+    t.client.mark_campaign_failed(&t.admin, &id);
 
     // Pool = 10_000 - 3_000 = 7_000
     // Investor1 has 100% share → 7_000
@@ -2847,7 +2851,7 @@ fn test_batch_refund_investors_proportional_after_production_failure() {
     t.client.invest(&t.investor1, &id, &6_000);
     t.client.invest(&t.investor2, &id, &4_000); // → Funded
     t.client.start_production(&t.farmer, &id); // 30% → 3_000 released
-    t.client.mark_campaign_failed(&t.farmer, &id);
+    t.client.mark_campaign_failed(&t.admin, &id);
 
     let before1 = balance(&t, &t.investor1);
     let before2 = balance(&t, &t.investor2);
@@ -2875,7 +2879,7 @@ fn test_batch_refund_investors_proportional_with_revenue() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id); // 3_000 released
-    t.client.mark_harvest(&t.farmer, &id); // +4_000 = 7_000 total
+    t.client.mark_harvest(&t.farmer, &t.attester, &id); // +4_000 = 7_000 total
 
     // Order adds revenue
     let order_id = t.client.create_order(&t.buyer, &id, &2_000);
@@ -2910,7 +2914,7 @@ fn test_tranche_cannot_exceed_max_tranche_bps() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000);
     t.client.start_production(&t.farmer, &id); // 3_000 (30%)
-    t.client.mark_harvest(&t.farmer, &id); // +4_000 = 7_000 (70%)
+    t.client.mark_harvest(&t.farmer, &t.attester, &id); // +4_000 = 7_000 (70%)
 
     // Verify the campaign at least 30% remains in escrow
     let c = t.client.get_campaign(&id);
@@ -2956,7 +2960,7 @@ fn test_token_balance_invariant_proportional_failure() {
         .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
     t.client.invest(&t.investor1, &id, &10_000); // investor loses 10_000
     t.client.start_production(&t.farmer, &id); // farmer gets 3_000
-    t.client.mark_campaign_failed(&t.farmer, &id);
+    t.client.mark_campaign_failed(&t.admin, &id);
     // investor gets back proportional: 10_000 - 3_000 = 7_000
     t.client.refund(&t.investor1, &id);
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -331,11 +331,19 @@ impl EscrowContract {
         Ok(())
     }
 
-    pub fn refund_expired_order(env: Env, order_id: u64) -> Result<(), EscrowError> {
+    pub fn refund_expired_order(env: Env, caller: Address, order_id: u64) -> Result<(), EscrowError> {
+        caller.require_auth();
         let mut order = read_order(&env, order_id)?;
+        if order.buyer != caller {
+            return Err(EscrowError::NotBuyer);
+        }
 
         if order.status != OrderStatus::Pending {
             return Err(EscrowError::OrderNotPending);
+        }
+
+        if order.delivery_timestamp != 0 {
+            return Err(EscrowError::OrderNotDelivered);
         }
 
         if env.ledger().timestamp() <= order.timestamp + NINETY_SIX_HOURS_IN_SECONDS {
@@ -369,6 +377,10 @@ impl EscrowContract {
 
             if order.status != OrderStatus::Pending {
                 return Err(EscrowError::OrderNotPending);
+            }
+
+            if order.delivery_timestamp != 0 {
+                return Err(EscrowError::OrderNotDelivered);
             }
 
             if current_time <= order.timestamp + NINETY_SIX_HOURS_IN_SECONDS {


### PR DESCRIPTION
## What
Resolves critical compilation error in production_escrow contract, implements independent attester role for production lifecycle gates, and adds delivery timestamp validation for order refunds.

## Issues Resolved
Closes #610
Closes #611
Closes #612
Closes #613

## Changes

### #610 - [Contract] production_escrow fails to compile
Fixed duplicate/conflicting implementations in invest, claim_returns, and refund functions. Removed dead code referencing undefined load_contribs() helper and non-existent DataKey::Contributions variant. Kept only the indexed-key Contribution(campaign_id, Address) implementation. Updated test.rs to pass 5 required arguments to initialize (admin, tokens, fee_collector, fee_rate_bps).

### #613 - [Contract] Inconsistent use of checked arithmetic
Replaced raw arithmetic with checked operations throughout: refund(), refundable_amount(), batch_refund_investors(), and batch_refund_orders() now use checked_add/checked_sub/checked_mul to prevent overflow panics and provide proper error handling via EscrowError.

### #611 - [Contract] Delivered orders can still be refunded
Added delivery_timestamp gate to refund_expired_order and refund_expired_orders - both now reject refunds when delivery_timestamp is set. Added require_auth() to refund_expired_order to ensure only the buyer can claim their refund.

### #612 - [Contract] mark_harvest is live despite being documented as frozen
Implemented independent Attester role: added Attester DataKey and set_attester() function for admin configuration. Updated mark_harvest() to require both farmer and attester co-signatures, preventing unilateral harvest marking. Updated mark_campaign_failed() to restrict farmer-initiated failures to Funded state only; InProduction and Harvested failures require admin authorization. Allowed open_dispute() even after Failed state to ensure investors can contest self-declared failures.