### PR TITLE
feat: milestone-based partial escrow release + agro-production nav link

### DIFF
--- a/agro-production/contract/production_escrow/src/lib.rs
+++ b/agro-production/contract/production_escrow/src/lib.rs
@@ -83,6 +83,10 @@ pub enum EscrowError {
     InvalidResolution = 72,
 
     NoShortfall = 80,
+    InvalidMilestone = 81,
+    MilestoneNotConfigured = 82,
+    MilestoneAlreadyAdvanced = 83,
+    NotBuyerOrOracle = 84,
 }
 
 // ---------------------------------------------------------------------------
@@ -121,6 +125,28 @@ pub enum DisputeResolution {
     Partial(u32),
 }
 
+/// Production milestone stages. Each milestone can be configured to release a
+/// percentage of the total raised funds when advanced by a buyer or oracle.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Milestone {
+    Planted,
+    Growing,
+    Harvested,
+    Shipped,
+    Delivered,
+}
+
+/// Configuration for a single milestone: which stage it is and what percentage
+/// (in basis points) of total_raised to release when advanced.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestoneConfig {
+    pub milestone: Milestone,
+    /// Basis points of total_raised to release (e.g. 1000 = 10%).
+    pub release_bps: u32,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Campaign {
@@ -134,6 +160,9 @@ pub struct Campaign {
     pub deadline: u64,
     pub created_at: u64,
     pub status: CampaignStatus,
+    /// Index into the milestone configs for the last advanced milestone.
+    /// 0 = no milestones advanced yet (before Planted).
+    pub current_milestone: u32,
 }
 
 #[contracttype]
@@ -167,6 +196,8 @@ pub enum DataKey {
     /// Per-campaign per-investor claim flag (true if already claimed/refunded).
     Claimed(u64, Address),
     Order(u64),
+    /// Per-campaign milestone release configuration (Vec<MilestoneConfig>).
+    MilestoneConfigs(u64),
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +218,20 @@ const TTL_EXTEND: u32 = 100_000;
 
 /// Orders expire and become refundable after 96 hours of inactivity.
 pub const ORDER_EXPIRY_SECS: u64 = 96 * 3600;
+
+/// The ordered sequence of milestones. Index 1 = Planted, 2 = Growing, etc.
+/// A campaign starts at milestone 0 (no milestones advanced).
+/// Validates that the given milestone index matches the expected milestone type.
+fn validate_milestone_order(idx: u32, milestone: &Milestone) -> bool {
+    match (idx, milestone) {
+        (0, Milestone::Planted) => true,
+        (1, Milestone::Growing) => true,
+        (2, Milestone::Harvested) => true,
+        (3, Milestone::Shipped) => true,
+        (4, Milestone::Delivered) => true,
+        _ => false,
+    }
+}
 
 // Event topic helpers.
 fn t_campaign() -> Symbol {
@@ -322,6 +367,7 @@ impl ProductionEscrowContract {
             deadline,
             created_at: now,
             status: CampaignStatus::Funding,
+            current_milestone: 0,
         };
 
         env.storage()
@@ -390,10 +436,6 @@ impl ProductionEscrowContract {
             .persistent()
             .get::<_, i128>(&contribution_key)
             .unwrap_or(0);
-            .get(&DataKey::Contributions(campaign_id))
-            .unwrap_or(Map::new(&env));
-        let prev = contribs.get(investor.clone()).unwrap_or(0);
-        contribs.set(investor.clone(), checked_add(prev, amount)?);
         env.storage()
             .persistent()
             .set(&contribution_key, &(prev + amount));
@@ -473,6 +515,107 @@ impl ProductionEscrowContract {
         env.events().publish(
             (t_campaign(), symbol_short!("harvest")),
             (campaign_id, farmer),
+        );
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Milestone-based partial release
+    // -----------------------------------------------------------------------
+
+    /// Admin sets the milestone release configuration for a campaign.
+    /// Each config entry maps a milestone stage to a percentage (basis points)
+    /// of total_raised to release when that milestone is advanced.
+    /// Configs must be provided in sequential order (Planted -> Growing -> ...).
+    pub fn set_milestone_configs(
+        env: Env,
+        admin_caller: Address,
+        campaign_id: u64,
+        configs: Vec<MilestoneConfig>,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let admin_addr = admin(&env)?;
+        if admin_caller != admin_addr {
+            return Err(EscrowError::NotAdmin);
+        }
+        let campaign = load_campaign(&env, campaign_id)?;
+        // Only allow config before any milestones have been advanced.
+        if campaign.current_milestone > 0 {
+            return Err(EscrowError::MilestoneAlreadyAdvanced);
+        }
+        // Validate sequential order of milestones.
+        for i in 0..configs.len() {
+            let cfg = configs.get(i).unwrap();
+            if cfg.release_bps == 0 || cfg.release_bps > 10000 {
+                return Err(EscrowError::InvalidAmount);
+            }
+            if !validate_milestone_order(i, &cfg.milestone) {
+                return Err(EscrowError::InvalidMilestone);
+            }
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::MilestoneConfigs(campaign_id), &configs);
+        Ok(())
+    }
+
+    /// Advance to the next production milestone and release the configured
+    /// percentage of funds to the farmer. Restricted to buyers and oracles
+    /// (not the farmer) to prevent self-serving milestone claims.
+    ///
+    /// The caller must be a buyer (has a confirmed order on this campaign)
+    /// or an oracle (admin address acting as oracle).
+    pub fn advance_milestone(
+        env: Env,
+        caller: Address,
+        campaign_id: u64,
+    ) -> Result<(), EscrowError> {
+        caller.require_auth();
+        let mut campaign = load_campaign(&env, campaign_id)?;
+
+        // Only allow milestone advances during active production.
+        if campaign.status != CampaignStatus::Funded
+            && campaign.status != CampaignStatus::InProduction
+            && campaign.status != CampaignStatus::Harvested
+        {
+            return Err(EscrowError::CampaignNotFundedOrBeyond);
+        }
+
+        // Verify caller is buyer or oracle (admin).
+        let admin_addr = admin(&env)?;
+        let is_oracle = caller == admin_addr;
+        if !is_oracle {
+            // Check if caller is a buyer (has any confirmed order on this campaign).
+            let is_buyer = has_confirmed_order(&env, campaign_id, &caller);
+            if !is_buyer {
+                return Err(EscrowError::NotBuyerOrOracle);
+            }
+        }
+
+        // Load milestone configs.
+        let configs: Vec<MilestoneConfig> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestoneConfigs(campaign_id))
+            .ok_or(EscrowError::MilestoneNotConfigured)?;
+
+        let next_idx = campaign.current_milestone;
+        if next_idx >= configs.len() {
+            return Err(EscrowError::InvalidMilestone);
+        }
+
+        let cfg = configs.get(next_idx).unwrap();
+        let tranche_amount = checked_mul(campaign.total_raised, cfg.release_bps as i128)? / BPS_DENOM;
+        if tranche_amount > 0 {
+            release_tranche_internal(&env, &mut campaign, tranche_amount)?;
+        }
+
+        campaign.current_milestone = next_idx + 1;
+        save_campaign(&env, &campaign);
+
+        env.events().publish(
+            (t_campaign(), symbol_short!("milestone")),
+            (campaign_id, caller, next_idx + 1, tranche_amount),
         );
         Ok(())
     }
@@ -642,13 +785,6 @@ impl ProductionEscrowContract {
             .storage()
             .persistent()
             .get::<_, i128>(&DataKey::Contribution(campaign_id, investor.clone()))
-        let contribs = load_contribs(&env, campaign_id);
-        // Extend TTL on contribution read to protect investment records (Issue #456).
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Contributions(campaign_id), TTL_THRESHOLD, TTL_EXTEND);
-        let contribution = contribs
-            .get(investor.clone())
             .ok_or(EscrowError::NotInvestor)?;
         if contribution <= 0 {
             return Err(EscrowError::NotInvestor);
@@ -763,13 +899,6 @@ impl ProductionEscrowContract {
             .storage()
             .persistent()
             .get::<_, i128>(&DataKey::Contribution(campaign_id, investor.clone()))
-        let contribs = load_contribs(&env, campaign_id);
-        // Extend TTL on contribution read to protect refund records (Issue #456).
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Contributions(campaign_id), TTL_THRESHOLD, TTL_EXTEND);
-        let contribution = contribs
-            .get(investor.clone())
             .ok_or(EscrowError::NotInvestor)?;
         if contribution <= 0 {
             return Err(EscrowError::NotInvestor);
@@ -1134,6 +1263,13 @@ impl ProductionEscrowContract {
     pub fn get_admin(env: Env) -> Result<Address, EscrowError> {
         admin(&env)
     }
+
+    pub fn get_milestone_configs(env: Env, campaign_id: u64) -> Vec<MilestoneConfig> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MilestoneConfigs(campaign_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1160,6 +1296,8 @@ mod registry_client {
         let _: () = env.invoke_contract(registry, &func, args);
         Ok(())
     }
+}
+
 // Checked arithmetic for monetary values (Issue #457).
 fn checked_add(a: i128, b: i128) -> Result<i128, EscrowError> {
     a.checked_add(b)
@@ -1195,6 +1333,29 @@ fn save_campaign(env: &Env, c: &Campaign) {
     env.storage()
         .persistent()
         .extend_ttl(&DataKey::Campaign(c.id), TTL_THRESHOLD, TTL_EXTEND);
+}
+
+/// Check if a buyer has at least one confirmed order on a campaign.
+/// Used by advance_milestone to verify caller authorization.
+fn has_confirmed_order(env: &Env, campaign_id: u64, buyer: &Address) -> bool {
+    // Scan orders by checking up to order_count for confirmed orders by this buyer.
+    let order_count: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::OrderCount)
+        .unwrap_or(0);
+    for i in 1..=order_count {
+        if let Some(order) = env
+            .storage()
+            .persistent()
+            .get::<_, Order>(&DataKey::Order(i))
+        {
+            if order.campaign_id == campaign_id && order.buyer == *buyer && order.status == OrderStatus::Confirmed {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 

--- a/agro-production/contract/production_escrow/src/test.rs
+++ b/agro-production/contract/production_escrow/src/test.rs
@@ -2964,3 +2964,251 @@ fn test_token_balance_invariant_proportional_failure() {
     // Investor has original - 10_000 + 7_000 (refund)
     assert_eq!(balance(&t, &t.investor1), inv1_before - 3_000);
 }
+
+// ---------------------------------------------------------------------------
+// Milestone-based partial release tests
+// ---------------------------------------------------------------------------
+
+use crate::{Milestone, MilestoneConfig};
+
+fn milestone_configs_50pct(t: &TestEnv) -> Vec<MilestoneConfig> {
+    let mut configs = Vec::new(&t.env);
+    configs.push_back(MilestoneConfig { milestone: Milestone::Planted, release_bps: 1000 });
+    configs.push_back(MilestoneConfig { milestone: Milestone::Growing, release_bps: 1000 });
+    configs.push_back(MilestoneConfig { milestone: Milestone::Harvested, release_bps: 1000 });
+    configs.push_back(MilestoneConfig { milestone: Milestone::Shipped, release_bps: 1000 });
+    configs.push_back(MilestoneConfig { milestone: Milestone::Delivered, release_bps: 1000 });
+    configs // 5 x 10% = 50% total
+}
+
+#[test]
+fn test_set_milestone_configs_ok() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+    let stored = t.client.get_milestone_configs(&id);
+    assert_eq!(stored.len(), 5);
+    assert_eq!(stored.get(0).unwrap().milestone, Milestone::Planted);
+    assert_eq!(stored.get(0).unwrap().release_bps, 1000);
+}
+
+#[test]
+fn test_set_milestone_configs_rejects_non_admin() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    let configs = milestone_configs_50pct(&t);
+    let err = t.client.try_set_milestone_configs(&t.farmer, &id, &configs)
+        .unwrap_err().unwrap();
+    assert_eq!(err, EscrowError::NotAdmin);
+}
+
+#[test]
+fn test_set_milestone_configs_rejects_wrong_order() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    // Put Growing first instead of Planted.
+    let mut configs = Vec::new(&t.env);
+    configs.push_back(MilestoneConfig { milestone: Milestone::Growing, release_bps: 1000 });
+    configs.push_back(MilestoneConfig { milestone: Milestone::Planted, release_bps: 1000 });
+    let err = t.client.try_set_milestone_configs(&t.admin, &id, &configs)
+        .unwrap_err().unwrap();
+    assert_eq!(err, EscrowError::InvalidMilestone);
+}
+
+#[test]
+fn test_advance_milestone_planted_ok() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    // Buyer must have a confirmed order — create and confirm one first.
+    let order_id = t.client.create_order(&t.buyer, &id, &1_000);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    let farmer_before = balance(&t, &t.farmer);
+    t.client.advance_milestone(&t.buyer, &id);
+    // 10% of 10_000 = 1_000
+    assert_eq!(balance(&t, &t.farmer), farmer_before + 1_000);
+
+    let c = t.client.get_campaign(&id);
+    assert_eq!(c.current_milestone, 1);
+    assert_eq!(c.tranche_released, 1_000);
+}
+
+#[test]
+fn test_advance_milestone_growing_ok() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &1_000);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    t.client.advance_milestone(&t.buyer, &id); // Planted: 1_000
+    let farmer_before = balance(&t, &t.farmer);
+    t.client.advance_milestone(&t.buyer, &id); // Growing: 1_000
+    assert_eq!(balance(&t, &t.farmer), farmer_before + 1_000);
+
+    let c = t.client.get_campaign(&id);
+    assert_eq!(c.current_milestone, 2);
+    assert_eq!(c.tranche_released, 2_000);
+}
+
+#[test]
+fn test_advance_milestone_all_five_ok() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &1_000);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    let farmer_before = balance(&t, &t.farmer);
+    for _ in 0..5 {
+        t.client.advance_milestone(&t.buyer, &id);
+    }
+    // 5 x 1_000 = 5_000 (50% of 10_000)
+    assert_eq!(balance(&t, &t.farmer), farmer_before + 5_000);
+    let c = t.client.get_campaign(&id);
+    assert_eq!(c.current_milestone, 5);
+    assert_eq!(c.tranche_released, 5_000);
+}
+
+#[test]
+fn test_advance_milestone_rejects_farmer() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    // Farmer cannot advance milestones (not a buyer).
+    let err = t.client.try_advance_milestone(&t.farmer, &id)
+        .unwrap_err().unwrap();
+    assert_eq!(err, EscrowError::NotBuyerOrOracle);
+}
+
+#[test]
+fn test_advance_milestone_admin_as_oracle_ok() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    // Admin acts as oracle — no order needed.
+    let farmer_before = balance(&t, &t.farmer);
+    t.client.advance_milestone(&t.admin, &id);
+    assert_eq!(balance(&t, &t.farmer), farmer_before + 1_000);
+}
+
+#[test]
+fn test_advance_milestone_rejects_no_config() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &1_000);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    let err = t.client.try_advance_milestone(&t.buyer, &id)
+        .unwrap_err().unwrap();
+    assert_eq!(err, EscrowError::MilestoneNotConfigured);
+}
+
+#[test]
+fn test_advance_milestone_rejects_past_end() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &1_000);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    for _ in 0..5 {
+        t.client.advance_milestone(&t.buyer, &id);
+    }
+    // 6th advance should fail — no more milestones.
+    let err = t.client.try_advance_milestone(&t.buyer, &id)
+        .unwrap_err().unwrap();
+    assert_eq!(err, EscrowError::InvalidMilestone);
+}
+
+#[test]
+fn test_advance_milestone_over_release_prevented() {
+    // 5 milestones each at 30% = 150% total. The 70% MAX_TRANCHE_BPS cap
+    // should reject the 3rd milestone (cumulative 90% > 70%).
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+
+    let mut configs = Vec::new(&t.env);
+    for i in 0..5 {
+        configs.push_back(MilestoneConfig {
+            milestone: match i {
+                0 => Milestone::Planted,
+                1 => Milestone::Growing,
+                2 => Milestone::Harvested,
+                3 => Milestone::Shipped,
+                _ => Milestone::Delivered,
+            },
+            release_bps: 3000, // 30% each
+        });
+    }
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &1_000);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    t.client.advance_milestone(&t.buyer, &id); // 30% = 3_000
+    t.client.advance_milestone(&t.buyer, &id); // 30% = 3_000 (total 6_000)
+    let err = t.client.try_advance_milestone(&t.buyer, &id)
+        .unwrap_err().unwrap();
+    // 3rd milestone would push to 9_000 > 7_000 max.
+    assert_eq!(err, EscrowError::InvalidTranche);
+}
+
+#[test]
+fn test_advance_milestone_refund_after_partial_release() {
+    // After advancing some milestones, campaign fails.
+    // Investor gets proportional refund from remaining pool.
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t.client.create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    let configs = milestone_configs_50pct(&t);
+    t.client.set_milestone_configs(&t.admin, &id, &configs);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &1_000);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    // Advance 2 milestones: 2_000 released (20%).
+    t.client.advance_milestone(&t.buyer, &id);
+    t.client.advance_milestone(&t.buyer, &id);
+
+    // Campaign fails. Remaining pool = 10_000 - 2_000 = 8_000.
+    t.client.mark_campaign_failed(&t.farmer, &id);
+    let refund = t.client.refund(&t.investor1, &id);
+    // Investor has 100% of contribution -> 100% of pool = 8_000.
+    assert_eq!(refund, 8_000);
+}

--- a/client/.env.example
+++ b/client/.env.example
@@ -25,6 +25,10 @@ NEXT_PUBLIC_TOKEN_CONTRACT_ID_USDC=
 NEXT_PUBLIC_TOKEN_CONTRACT_ID_XLM=
 NEXT_PUBLIC_TOKEN_CONTRACT_ID_STRK=
 
+# ── Agro Production App ─────────────────────────────────────────────────────
+# URL of the agro-production sub-app. Used by the header nav link.
+NEXT_PUBLIC_AGRO_PRODUCTION_URL=http://localhost:3001
+
 # ── Demo / Test Mode ─────────────────────────────────────────────────────────
 # When set to true, services return deterministic dummy data instead of hitting
 # the real backend or Soroban RPC. Used by Playwright E2E tests and local dev.

--- a/client/src/app/(root)/_components/header.tsx
+++ b/client/src/app/(root)/_components/header.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { Menu, ShoppingBag } from "lucide-react";
+import { Menu, ShoppingBag, ExternalLink } from "lucide-react";
 
 import Wrapper from "@/components/shared/wrapper";
 import { ThemeToggle } from "@/components/shared/theme-toggle";
@@ -78,6 +78,19 @@ export default function Header() {
               </Link>
             </li>
           ))}
+          {process.env.NEXT_PUBLIC_AGRO_PRODUCTION_URL && (
+            <li>
+              <a
+                href={process.env.NEXT_PUBLIC_AGRO_PRODUCTION_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm font-normal transition-colors hover:text-primary lg:text-lg"
+              >
+                Agro Production
+                <ExternalLink className="ml-1 inline-block size-3" />
+              </a>
+            </li>
+          )}
         </ul>
 
         <div className="flex items-center justify-end gap-1">
@@ -141,6 +154,17 @@ export default function Header() {
                       </Link>
                     );
                   })}
+                  {process.env.NEXT_PUBLIC_AGRO_PRODUCTION_URL && (
+                    <a
+                      href={process.env.NEXT_PUBLIC_AGRO_PRODUCTION_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex min-h-11 items-center rounded-2xl px-4 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+                    >
+                      Agro Production
+                      <ExternalLink className="ml-auto size-4" />
+                    </a>
+                  )}
                 </div>
 
                 <div className="border-t px-4 py-4 pb-[calc(env(safe-area-inset-bottom)+1rem)]">


### PR DESCRIPTION
## Changes

Closes #516
Closes #526
Closes #542
Closes #586

### Milestone-based partial escrow release (#586)

- Added `Milestone` enum with 5 stages: `Planted`, `Growing`, `Harvested`, `Shipped`, `Delivered`
- Added `MilestoneConfig` type mapping each stage to a configurable percentage (basis points) of `total_raised`
- New `set_milestone_configs(admin, campaign_id, configs)` — admin sets per-campaign milestone configs before any milestones are advanced
- New `advance_milestone(caller, campaign_id)` — buyer or oracle (admin) advances to the next milestone, releasing the configured tranche
- New `get_milestone_configs(campaign_id)` view function
- Milestone releases share the existing 70% `MAX_TRANCHE_BPS` cap — over-release is prevented
- Remaining balance only releasable through existing `confirm_order`/`settle`/dispute flows
- 12 new tests: config validation, sequential order, buyer-only restriction, oracle bypass, all-5-milestones, over-release prevention, refund-after-partial-release

### Navigation to agro-production app (#526)

- Added "Agro Production" link in the desktop header nav bar and mobile sheet menu
- Link is conditionally rendered only when `NEXT_PUBLIC_AGRO_PRODUCTION_URL` is set
- Opens in new tab with `target="_blank"` and `rel="noopener noreferrer"`
- Added `NEXT_PUBLIC_AGRO_PRODUCTION_URL` to `.env.example`

### Soroban event listener high-watermark (#516)

- Already implemented in `agro-production/server/src/events/watcher.ts` — the canonical event watcher persists per-contract watermarks via the `EventCursor` Prisma table
- The deprecated `sorobanEventListener.ts` also had cursor persistence
- No additional code changes needed

### Client README (#542)

- Already rewritten — `client/README.md` contains proper AgroCylo setup instructions, wallet setup, env vars table (required + optional + testnet values), architecture overview, all dev/test/lint/build commands, and troubleshooting
- No create-next-app boilerplate remains
- No additional code changes needed

### Bug fixes

- Fixed dead code remnants in `invest`/`claim_returns`/`refund` from the old `Contributions` map migration
- Fixed unclosed `registry_client` module (missing closing `}`)

## Acceptance Criteria

- [x] `advance_milestone` entrypoint restricted to buyer/oracle confirmation
- [x] Remaining balance only releasable through existing confirm/dispute flows
- [x] Tests for partial release accounting, over-release prevention, and refund-of-remainder
- [x] A visible navigation link exists in the main app header that says "Agro Production"
- [x] Clicking the link navigates the user to the agro-production app
- [x] The link correctly uses the environment variable for the agro-production URL
- [x] The link is accessible (keyboard navigation, screen reader support)
- [x] The link works in both dev and production builds
- [x] Soroban event listener high-watermark already persisted in watcher.ts (#516)
- [x] Client README already rewritten with full contributor guide (#542)