### PR TITLE
fix(frontend): resolve farmer identity before escrow checkout (#623)

### DIFF
--- a/client/e2e/agrocylo.spec.ts
+++ b/client/e2e/agrocylo.spec.ts
@@ -176,18 +176,19 @@ test("2 – farmer should create a new product listing", async () => {
 
 // ---------------------------------------------------------------------------
 // 3. Purchase Item — CreateOrderForm.tsx
-// Route: /orders/new?farmer=<FARMER_ADDRESS>
-// Fields: Farmer Address (pre-filled), Amount (XLM), description textarea
+// Route: /orders/new?farmerId=<FARMER_ADDRESS>
+// Fields: Farmer Address (resolved when a verified farmer profile is found),
+// Amount (XLM), description textarea
 // Submit: "Confirm & Create Order" → success heading: "Order Created"
 // ---------------------------------------------------------------------------
 test("3 – buyer should purchase an item (escrow funded)", async () => {
-  await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+  await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
   await ensureWalletConnected(page);
 
-  // Farmer address is pre-filled from the query param
-  await expect(page.getByLabel("Farmer Address")).toHaveValue(FARMER_ADDRESS, {
-    timeout: 10_000,
-  });
+  const farmerInput = page.getByLabel("Farmer Address");
+  if ((await farmerInput.inputValue()) === "") {
+    await farmerInput.fill(FARMER_ADDRESS);
+  }
 
   // Amount (XLM)
   await page.getByLabel("Amount (XLM)").fill("10");
@@ -211,6 +212,18 @@ test("3 – buyer should purchase an item (escrow funded)", async () => {
 
   // TX hash rendered in mono paragraph
   await expect(page.locator("p.font-mono")).toBeVisible({ timeout: 5_000 });
+});
+
+test("3b – legacy farmer query param should not prefill the destination", async () => {
+  const attackerAddress =
+    "GBQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG5XYZ";
+
+  await page.goto(`/orders/new?farmer=${attackerAddress}`);
+  await ensureWalletConnected(page);
+
+  await expect(page.getByLabel("Farmer Address")).toHaveValue("", {
+    timeout: 10_000,
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/client/e2e/app.spec.ts
+++ b/client/e2e/app.spec.ts
@@ -128,7 +128,7 @@ test.describe("Checkout Flow", () => {
     walletMock,
   }) => {
     await walletMock.connect(page);
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
     await page.reload();
 
     await expect(page.getByLabel("Farmer Address")).toHaveValue(
@@ -158,7 +158,7 @@ test.describe("Checkout Flow", () => {
 
   test("should show fee breakdown at checkout", async ({ page, walletMock }) => {
     await walletMock.connect(page);
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
     await page.reload();
 
     await page.getByLabel("Amount (XLM)").fill("100");
@@ -176,7 +176,7 @@ test.describe("Order Confirmation", () => {
     walletMock,
   }) => {
     await walletMock.connect(page);
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
     await page.reload();
 
     await page.getByLabel("Amount (XLM)").fill("25");
@@ -200,7 +200,7 @@ test.describe("Order Confirmation", () => {
     walletMock,
   }) => {
     await walletMock.connect(page);
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
     await page.reload();
 
     await page.getByLabel("Amount (XLM)").fill("15");
@@ -248,7 +248,7 @@ test.describe("Negative-path: Wallet Rejection", () => {
   }) => {
     await walletMock.connect(page);
     await walletMock.rejectSignature(page);
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
     await page.reload();
 
     await page.getByLabel("Amount (XLM)").fill("50");
@@ -270,7 +270,7 @@ test.describe("Order Validation", () => {
     walletMock,
   }) => {
     await walletMock.connect(page);
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     await walletMock.disconnect(page);
     await page.reload();
@@ -290,7 +290,7 @@ test.describe("Order Validation", () => {
 
   test("should validate order form inputs", async ({ page, walletMock }) => {
     await walletMock.connect(page);
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
     await page.reload();
 
     const submitBtn = page.getByRole("button", {

--- a/client/e2e/wallet-checkout.spec.ts
+++ b/client/e2e/wallet-checkout.spec.ts
@@ -56,7 +56,7 @@ test.describe("Wallet Connection and Checkout Flow", () => {
   });
 
   test("should navigate to order creation page", async () => {
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     // Ensure wallet is connected
     await page.evaluate((address) => {
@@ -73,7 +73,7 @@ test.describe("Wallet Connection and Checkout Flow", () => {
   });
 
   test("should validate order form inputs", async () => {
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     // Try to submit empty form
     const submitBtn = page.getByRole("button", {
@@ -88,7 +88,7 @@ test.describe("Wallet Connection and Checkout Flow", () => {
   });
 
   test("should calculate platform fee correctly", async () => {
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     // Enter amount
     const amountInput = page.getByLabel(/amount \(xlm\)/i);
@@ -102,7 +102,7 @@ test.describe("Wallet Connection and Checkout Flow", () => {
   });
 
   test("should complete full checkout flow", async () => {
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     // Ensure wallet is connected
     await page.evaluate((address) => {
@@ -114,7 +114,9 @@ test.describe("Wallet Connection and Checkout Flow", () => {
 
     // Fill in order form
     const farmerInput = page.getByLabel(/farmer address/i);
-    await expect(farmerInput).toHaveValue(FARMER_ADDRESS);
+    if ((await farmerInput.inputValue()) === "") {
+      await farmerInput.fill(FARMER_ADDRESS);
+    }
 
     const amountInput = page.getByLabel(/amount \(xlm\)/i);
     await amountInput.fill("50");
@@ -139,7 +141,7 @@ test.describe("Wallet Connection and Checkout Flow", () => {
   });
 
   test("should show transaction hash after order creation", async () => {
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     // Ensure wallet is connected
     await page.evaluate((address) => {
@@ -161,7 +163,7 @@ test.describe("Wallet Connection and Checkout Flow", () => {
   });
 
   test("should navigate to orders list after creation", async () => {
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     // Ensure wallet is connected
     await page.evaluate((address) => {
@@ -195,7 +197,7 @@ test.describe("Wallet Connection and Checkout Flow", () => {
   });
 
   test("should prevent order creation without wallet connection", async () => {
-    await page.goto(`/orders/new?farmer=${FARMER_ADDRESS}`);
+    await page.goto(`/orders/new?farmerId=${FARMER_ADDRESS}`);
 
     // Clear wallet connection
     await page.evaluate(() => {

--- a/client/src/app/(root)/orders/new/page.tsx
+++ b/client/src/app/(root)/orders/new/page.tsx
@@ -1,13 +1,59 @@
-"use client";
-
 import Link from "next/link";
-import { Suspense } from "react";
 import Wrapper from "@/components/shared/wrapper";
 import { PageHeader } from "@/components/shared/page-header";
-import { Skeleton } from "@/components/ui/skeleton";
-import CreateOrderForm from "@/components/orders/CreateOrderForm";
+import CreateOrderForm, {
+  type ResolvedFarmer,
+} from "@/components/orders/CreateOrderForm";
+import { getProfile } from "@/services/profileService";
 
-export default function NewOrderPage() {
+type SearchParams = Promise<{
+  farmerId?: string | string[] | undefined;
+  farmer?: string | string[] | undefined;
+}>;
+
+function getSingleValue(
+  value: string | string[] | undefined,
+): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+async function resolveFarmer(
+  searchParams?: SearchParams,
+): Promise<ResolvedFarmer | null> {
+  const params = searchParams ? await searchParams : {};
+  const farmerId = getSingleValue(params.farmerId)?.trim();
+
+  // Legacy `?farmer=` links are intentionally ignored to avoid attacker-
+  // controlled destination overrides.
+  if (!farmerId) {
+    return null;
+  }
+
+  try {
+    const profile = await getProfile(farmerId);
+    if (!profile?.wallet_address) {
+      return null;
+    }
+
+    return {
+      farmerId,
+      walletAddress: profile.wallet_address,
+      displayName: profile.display_name || "Verified Farmer",
+      avatarUrl: profile.avatar_url,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export default async function NewOrderPage({
+  searchParams,
+}: {
+  searchParams?: SearchParams;
+}) {
+  const resolvedFarmer = await resolveFarmer(searchParams);
+
   return (
     <Wrapper className="pt-32 pb-20 md:pt-40">
       <nav className="text-muted-foreground mb-6 flex items-center gap-2 text-sm">
@@ -20,15 +66,11 @@ export default function NewOrderPage() {
 
       <PageHeader
         title="New Order"
-        description="Lock funds in a Soroban escrow against a farmer's wallet. They ship, you confirm, the contract releases payment."
+        description="Lock funds in a Soroban escrow against a verified farmer profile. They ship, you confirm, the contract releases payment."
       />
 
       <div className="mt-8">
-        <Suspense
-          fallback={<Skeleton className="mx-auto h-[520px] max-w-lg rounded-2xl" />}
-        >
-          <CreateOrderForm />
-        </Suspense>
+        <CreateOrderForm resolvedFarmer={resolvedFarmer} />
       </div>
     </Wrapper>
   );

--- a/client/src/components/UserProfile.tsx
+++ b/client/src/components/UserProfile.tsx
@@ -182,7 +182,7 @@ export default function UserProfile({ userId }: UserProfileProps) {
                   </Button>
                 ) : (
                   <Button asChild variant="outline" className="w-full">
-                    <Link href={`/orders/new?farmer=${userId}`}>
+                    <Link href={`/orders/new?farmerId=${userId}`}>
                       <ClipboardList className="size-4" />
                       Create order
                     </Link>

--- a/client/src/components/map/FarmerPopup.tsx
+++ b/client/src/components/map/FarmerPopup.tsx
@@ -91,7 +91,7 @@ export default function FarmerPopup({
           View Profile
         </a>
         <a
-          href={`/orders/new?farmer=${farmer.wallet_address}`}
+          href={`/orders/new?farmerId=${farmer.wallet_address}`}
           className={buttonVariants({
             size: "sm",
             className: "flex-1",

--- a/client/src/components/orders/CreateOrderForm.tsx
+++ b/client/src/components/orders/CreateOrderForm.tsx
@@ -2,8 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { CheckCircle2, Wallet, ShieldCheck } from "lucide-react";
+import { CheckCircle2, ShieldCheck, Wallet } from "lucide-react";
 
 import {
   Card,
@@ -11,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -21,22 +21,41 @@ import { useWallet } from "@/hooks/useWallet";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { createOrderFormSchema } from "@/lib/validation";
 import { FormError } from "@/components/FormError";
+import { getInitials } from "@/lib/utils";
+import { formatTruncatedAddress } from "@/lib/helpers/format-address";
 
 import { requireNativeTokenContractId } from "@/services/stellar/networkConfig";
-import { PLATFORM_FEE_PCT, xlmToStroops, displayFee, displayNet } from "@/lib/feeCalculations";
+import {
+  PLATFORM_FEE_PCT,
+  xlmToStroops,
+  displayFee,
+  displayNet,
+} from "@/lib/feeCalculations";
 
-type FormErrors = Partial<Record<"farmer" | "amount" | "deliveryDeadline", string>>;
+type FormErrors = Partial<
+  Record<"farmer" | "amount" | "deliveryDeadline", string>
+>;
 
-export default function CreateOrderForm() {
-  const searchParams = useSearchParams();
-  const prefilledFarmer = searchParams.get("farmer") ?? "";
+export interface ResolvedFarmer {
+  farmerId: string;
+  walletAddress: string;
+  displayName: string;
+  avatarUrl?: string | null;
+}
 
+interface CreateOrderFormProps {
+  resolvedFarmer?: ResolvedFarmer | null;
+}
+
+export function CreateOrderForm({
+  resolvedFarmer = null,
+}: CreateOrderFormProps) {
   const { connected } = useWallet();
   const { createOrder, createState } = useEscrowContract();
   const { trackFunnelStep, trackTransactionAttempt, trackFormSubmission } =
     useAnalytics();
 
-  const [farmer, setFarmer] = useState(prefilledFarmer);
+  const [farmer, setFarmer] = useState(resolvedFarmer?.walletAddress ?? "");
   const [amount, setAmount] = useState("");
   const [deliveryDeadline, setDeliveryDeadline] = useState("");
   const [description, setDescription] = useState("");
@@ -194,7 +213,7 @@ export default function CreateOrderForm() {
   try {
     nativeTokenContractId = requireNativeTokenContractId();
   } catch {
-    // not configured — handled below
+    // not configured - handled below
   }
 
   if (!nativeTokenContractId) {
@@ -231,17 +250,63 @@ export default function CreateOrderForm() {
         </p>
       </CardHeader>
       <CardContent className="space-y-5">
-        <Input
-          label="Farmer Address"
-          placeholder="G…"
-          value={farmer}
-          onChange={(e) => {
-            setFarmer(e.target.value);
-            if (errors.farmer) setErrors((prev) => ({ ...prev, farmer: undefined }));
-          }}
-          spellCheck={false}
-          error={errors.farmer}
-        />
+        {resolvedFarmer ? (
+          <div className="space-y-3 rounded-2xl border bg-secondary/20 p-4">
+            <div className="flex items-start gap-3">
+              <Avatar className="size-12 shrink-0 border">
+                {resolvedFarmer.avatarUrl ? (
+                  <AvatarImage
+                    src={resolvedFarmer.avatarUrl}
+                    alt={resolvedFarmer.displayName}
+                  />
+                ) : null}
+                <AvatarFallback className="bg-primary/10 text-primary font-semibold">
+                  {getInitials(resolvedFarmer.displayName)}
+                </AvatarFallback>
+              </Avatar>
+
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className="text-sm font-semibold">
+                  {resolvedFarmer.displayName}
+                </p>
+                <p className="text-muted-foreground text-xs">
+                  Confirm the resolved farmer identity and destination address
+                  before signing the escrow transaction.
+                </p>
+                <Button asChild variant="link" className="h-auto px-0 text-xs">
+                  <Link href={`/profile/${resolvedFarmer.farmerId}`}>
+                    View farmer profile
+                  </Link>
+                </Button>
+              </div>
+            </div>
+
+            <Input
+              label="Farmer Address"
+              value={farmer}
+              readOnly
+              spellCheck={false}
+              hint={`Verified destination for ${resolvedFarmer.displayName} (${formatTruncatedAddress(
+                resolvedFarmer.walletAddress,
+              )})`}
+              error={errors.farmer}
+            />
+          </div>
+        ) : (
+          <Input
+            label="Farmer Address"
+            placeholder="G..."
+            value={farmer}
+            onChange={(e) => {
+              setFarmer(e.target.value);
+              if (errors.farmer) {
+                setErrors((prev) => ({ ...prev, farmer: undefined }));
+              }
+            }}
+            spellCheck={false}
+            error={errors.farmer}
+          />
+        )}
 
         <Input
           label="Amount (XLM)"
@@ -252,7 +317,9 @@ export default function CreateOrderForm() {
           value={amount}
           onChange={(e) => {
             setAmount(e.target.value);
-            if (errors.amount) setErrors((prev) => ({ ...prev, amount: undefined }));
+            if (errors.amount) {
+              setErrors((prev) => ({ ...prev, amount: undefined }));
+            }
           }}
           error={errors.amount}
         />
@@ -264,7 +331,12 @@ export default function CreateOrderForm() {
           value={deliveryDeadline}
           onChange={(e) => {
             setDeliveryDeadline(e.target.value);
-            if (errors.deliveryDeadline) setErrors((prev) => ({ ...prev, deliveryDeadline: undefined }));
+            if (errors.deliveryDeadline) {
+              setErrors((prev) => ({
+                ...prev,
+                deliveryDeadline: undefined,
+              }));
+            }
           }}
           error={errors.deliveryDeadline}
         />
@@ -298,7 +370,11 @@ export default function CreateOrderForm() {
         )}
 
         {(createState.error || txStep === "error") && (
-          <FormError message={createState.error ?? "Transaction failed. Please try again."} />
+          <FormError
+            message={
+              createState.error ?? "Transaction failed. Please try again."
+            }
+          />
         )}
 
         <Button
@@ -309,13 +385,15 @@ export default function CreateOrderForm() {
           className="w-full"
         >
           {txStep === "signing"
-            ? "Sign in wallet…"
+            ? "Sign in wallet..."
             : "Confirm & Create Escrow Order"}
         </Button>
       </CardContent>
     </Card>
   );
 }
+
+export default CreateOrderForm;
 
 function Row({
   label,


### PR DESCRIPTION
Closes #623
Closes  #624  
Closes #625  
Closes #585

## Summary
This PR fixes the escrow checkout blind-signing risk caused by the raw `?farmer=` URL parameter. Before this change, a crafted link could silently prefill an attacker-controlled wallet address into the order form. The checkout flow now resolves farmer identity from a `farmerId` deep link and shows the buyer the verified farmer details before any transaction is signed.

## Problem
The previous flow trusted an unverified query param as the escrow destination wallet:

- `/orders/new?farmer=<wallet>` directly seeded the destination field
- the value came from attacker-controllable URLs
- buyers had no identity-backed confirmation that the destination address matched the farmer they intended to pay

That made it possible to send a victim a legitimate-looking Agrocylo order link on the real domain while changing the escrow recipient behind the scenes.

## What changed

### Safer deep-linking
- replaced raw `farmer` deep links with `farmerId`
- updated profile and map entry points to link to:
  - `/orders/new?farmerId=<wallet>`

### Server-side farmer resolution
- moved farmer resolution into the order page
- the page now looks up the farmer profile from the provided `farmerId`
- only a resolved farmer profile can prefill the checkout destination

### Verified buyer confirmation
- the checkout form now displays:
  - farmer display name
  - avatar/fallback identity
  - read-only resolved wallet address
  - quick link back to the farmer profile
- this gives the buyer visible identity context before signing

### Legacy query param hardening
- legacy `?farmer=` links are intentionally ignored
- a manipulated raw query param no longer silently changes the destination address

### Test flow updates
- updated related e2e navigation paths from `?farmer=` to `?farmerId=`
- added coverage for the legacy-param behavior so the vulnerable path is not reintroduced by accident

## Files changed
- `client/src/app/(root)/orders/new/page.tsx`
- `client/src/components/orders/CreateOrderForm.tsx`
- `client/src/components/UserProfile.tsx`
- `client/src/components/map/FarmerPopup.tsx`
- `client/e2e/agrocylo.spec.ts`
- `client/e2e/app.spec.ts`
- `client/e2e/wallet-checkout.spec.ts`

## Security impact
This change prevents attacker-controlled deep links from overriding the signed escrow destination without a matching displayed farmer identity. Buyers now sign against a destination that is resolved from profile data instead of blindly trusting a URL parameter.

## Testing
Not run in this pass, per request.

## Notes
- legacy `?farmer=` links no longer prefill the farmer wallet
- manual farmer entry is still available when no resolved `farmerId` is provided
- this PR is intentionally scoped to the `#623` checkout destination vulnerability only