### PR TITLE
fix: add batch cap, fix event totals, secure auth & routes (closes #614 #615 #616 #617)

### DIFF
--- a/agro-production/contract/production_escrow/src/lib.rs
+++ b/agro-production/contract/production_escrow/src/lib.rs
@@ -1021,8 +1021,7 @@ impl ProductionEscrowContract {
                 &payout,
             );
             count += 1;
-            total = checked_add(total, contribution)?;
-            total += payout;
+            total = checked_add(total, payout)?;
         }
 
         // Emit a single summary event for the whole batch.
@@ -1034,12 +1033,17 @@ impl ProductionEscrowContract {
     }
 
     /// Batch refund pending orders that are older than ORDER_EXPIRY_SECS (96 h).
+    /// Enforces a hard cap of 50 orders per call to prevent excessive ledger reads.
     /// Silently skips orders that are not pending or have not expired yet.
     /// Emits ONE `order:batch_ref` summary event with (count, total).
     pub fn batch_refund_orders(
         env: Env,
         order_ids: Vec<u64>,
     ) -> Result<(u32, i128), EscrowError> {
+        const MAX_BATCH: u32 = 50;
+        if order_ids.len() > MAX_BATCH {
+            return Err(EscrowError::InvalidAmount);
+        }
         let now = env.ledger().timestamp();
 
         let mut count: u32 = 0;
@@ -1090,8 +1094,7 @@ impl ProductionEscrowContract {
                 );
             }
             count += 1;
-            total += refund_amount;
-            total = checked_add(total, order.amount)?;
+            total = checked_add(total, refund_amount)?;
         }
 
         // Emit a single summary event for the whole batch.

--- a/agro-production/server/src/middleware/walletAuth.ts
+++ b/agro-production/server/src/middleware/walletAuth.ts
@@ -6,60 +6,36 @@ export interface WalletRequest extends Request {
   sessionToken?: string;
 }
 
-const STELLAR_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/;
-
-function isProtectedMethod(method: string): boolean {
-  return ['POST', 'PATCH', 'PUT', 'DELETE'].includes(method.toUpperCase());
-}
-
 export function requireWallet(
   req: WalletRequest,
   res: Response,
   next: NextFunction,
 ): void {
   const authHeader = req.header('authorization');
-  const walletHeader = req.header('x-wallet-address');
 
-  // Session token via Authorization header
-  if (authHeader) {
-    const parts = authHeader.split(' ');
-    if (parts.length === 2 && parts[0] === 'Bearer') {
-      const sessionToken = parts[1];
-      verifySession(sessionToken)
-        .then((session) => {
-          req.walletAddress = session.walletAddress;
-          req.sessionToken = session.sessionToken;
-          next();
-        })
-        .catch((err: unknown) => {
-          if (err instanceof AuthError) {
-            res.status(err.status).json({ message: err.message });
-            return;
-          }
-          res.status(401).json({ message: 'Authentication failed.' });
-        });
-      return;
-    }
-  }
-
-  // Legacy x-wallet-address header — only allow for read operations
-  if (!isProtectedMethod(req.method) && walletHeader) {
-    if (!STELLAR_ADDRESS_REGEX.test(walletHeader)) {
-      res.status(400).json({ message: 'Invalid Stellar wallet address format.' });
-      return;
-    }
-    req.walletAddress = walletHeader;
-    next();
+  if (!authHeader) {
+    res.status(401).json({ message: 'Authentication required. Provide Authorization: Bearer <session_token>.' });
     return;
   }
 
-  // Mutations require signed auth
-  if (isProtectedMethod(req.method)) {
-    res.status(401).json({
-      message: 'Authentication required. Provide Authorization: Bearer <session_token> for mutations.',
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    res.status(401).json({ message: 'Invalid Authorization header format. Expected: Bearer <session_token>.' });
+    return;
+  }
+
+  const sessionToken = parts[1];
+  verifySession(sessionToken)
+    .then((session) => {
+      req.walletAddress = session.walletAddress;
+      req.sessionToken = session.sessionToken;
+      next();
+    })
+    .catch((err: unknown) => {
+      if (err instanceof AuthError) {
+        res.status(err.status).json({ message: err.message });
+        return;
+      }
+      res.status(401).json({ message: 'Authentication failed.' });
     });
-    return;
-  }
-
-  res.status(401).json({ message: 'Missing x-wallet-address header.' });
 }

--- a/server/src/controllers/disputeController.ts
+++ b/server/src/controllers/disputeController.ts
@@ -1,15 +1,22 @@
 import type { Request, Response } from "express";
 import { DisputeService } from "../services/disputeService.js";
+import { EvidenceController } from "../controllers/evidenceController.js";
 import logger from "../config/logger.js";
+import type { WalletRequest } from "../middleware/walletAuth.js";
 
 export class DisputeController {
   /**
    * GET /disputes
-   * Retrieve all disputes with order metadata
+   * Retrieve disputes scoped to the authenticated wallet
    */
   static async getAllDisputes(req: Request, res: Response) {
     try {
-      const disputes = await DisputeService.getAllDisputes();
+      const walletReq = req as WalletRequest;
+      const walletAddress = walletReq.walletAddress;
+      if (!walletAddress) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+      const disputes = await DisputeService.getAllDisputesForWallet(walletAddress);
       return res.status(200).json(disputes);
     } catch (error) {
       logger.error("Error fetching all disputes:", error);
@@ -19,15 +26,24 @@ export class DisputeController {
 
   /**
    * GET /disputes/:order_id
-   * Retrieve a single dispute by its on-chain order ID
+   * Retrieve a single dispute by its on-chain order ID (scoped to wallet)
    */
   static async getDisputeByOrderId(req: Request, res: Response) {
-    const { order_id } = req.params ;
+    const { order_id } = req.params;
     try {
+      const walletReq = req as WalletRequest;
+      const walletAddress = walletReq.walletAddress;
+      if (!walletAddress) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
       const dispute = await DisputeService.getDisputeByOrderId(order_id as string);
 
       if (!dispute) {
         return res.status(404).json({ error: "Dispute not found" });
+      }
+
+      if (dispute.order.buyerAddress !== walletAddress && dispute.order.sellerAddress !== walletAddress) {
+        return res.status(403).json({ error: "Forbidden: you do not have access to this dispute" });
       }
 
       return res.status(200).json(dispute);

--- a/server/src/controllers/evidenceController.ts
+++ b/server/src/controllers/evidenceController.ts
@@ -2,17 +2,23 @@ import type { Request, Response } from "express";
 import { DisputeService } from "../services/disputeService.js";
 import logger from "../config/logger.js";
 import { ApiError, sendProblem } from "../http/errors.js";
+import type { WalletRequest } from "../middleware/walletAuth.js";
 
 export class EvidenceController {
   /**
    * POST /disputes/:order_id/evidence
-   * Upload evidence for a dispute
+   * Upload evidence for a dispute (participants only, OPEN disputes only)
    */
   static async uploadEvidence(req: Request, res: Response) {
     const { order_id } = req.params;
     const file = req.file;
+    const walletReq = req as WalletRequest;
+    const walletAddress = walletReq.walletAddress;
 
     try {
+      if (!walletAddress) {
+        throw new ApiError(401, "Unauthorized", "Authentication required");
+      }
       if (!order_id) {
         throw new ApiError(400, "Bad Request", "Missing order_id");
       }
@@ -20,8 +26,7 @@ export class EvidenceController {
         throw new ApiError(400, "Bad Request", "No file provided");
       }
 
-      // Delegate validation and upload to service
-      const result = await DisputeService.provideEvidence(order_id as string, file);
+      const result = await DisputeService.provideEvidence(order_id as string, file, walletAddress);
 
       return res.status(201).json({
         message: "Evidence uploaded successfully",

--- a/server/src/controllers/orderController.ts
+++ b/server/src/controllers/orderController.ts
@@ -1,11 +1,17 @@
 import type { Request, Response } from "express";
 import logger from "../config/logger.js";
 import { OrderService } from "../services/orderService.js";
+import type { WalletRequest } from "../middleware/walletAuth.js";
 
 export class OrderController {
   static async getAllOrders(req: Request, res: Response) {
     try {
-      const orders = await OrderService.getAll();
+      const walletReq = req as WalletRequest;
+      const walletAddress = walletReq.walletAddress;
+      if (!walletAddress) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+      const orders = await OrderService.getAllForWallet(walletAddress);
       return res.status(200).json(orders);
     } catch (error) {
       logger.error("Error fetching all orders:", error);
@@ -17,9 +23,17 @@ export class OrderController {
     const { id } = req.params;
     if (!id) return res.status(400).json({ error: "Order id is required" });
     try {
+      const walletReq = req as WalletRequest;
+      const walletAddress = walletReq.walletAddress;
+      if (!walletAddress) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
       const order = await OrderService.getByOrderId(id);
       if (!order) {
         return res.status(404).json({ error: "Order not found" });
+      }
+      if (order.buyerAddress !== walletAddress && order.sellerAddress !== walletAddress) {
+        return res.status(403).json({ error: "Forbidden: you do not have access to this order" });
       }
       return res.status(200).json(order);
     } catch (error) {
@@ -33,6 +47,14 @@ export class OrderController {
     if (!address)
       return res.status(400).json({ error: "Buyer address is required" });
     try {
+      const walletReq = req as WalletRequest;
+      const walletAddress = walletReq.walletAddress;
+      if (!walletAddress) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+      if (walletAddress !== address) {
+        return res.status(403).json({ error: "Forbidden: you can only view your own orders" });
+      }
       const orders = await OrderService.getByBuyerAddress(address);
       return res.status(200).json(orders);
     } catch (error) {
@@ -45,6 +67,14 @@ export class OrderController {
     if (!address)
       return res.status(400).json({ error: "Seller address is required" });
     try {
+      const walletReq = req as WalletRequest;
+      const walletAddress = walletReq.walletAddress;
+      if (!walletAddress) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+      if (walletAddress !== address) {
+        return res.status(403).json({ error: "Forbidden: you can only view your own orders" });
+      }
       const orders = await OrderService.getByFarmerAddress(address);
       return res.status(200).json(orders);
     } catch (error) {
@@ -58,6 +88,14 @@ export class OrderController {
       return res.status(400).json({ error: "Seller address is required" });
     }
     try {
+      const walletReq = req as WalletRequest;
+      const walletAddress = walletReq.walletAddress;
+      if (!walletAddress) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+      if (walletAddress !== sellerAddress) {
+        return res.status(403).json({ error: "Forbidden: you can only view your own stats" });
+      }
       const stats = await OrderService.getSellerStats(sellerAddress);
       return res.status(200).json(stats);
     } catch (error) {

--- a/server/src/routes/disputeRoutes.ts
+++ b/server/src/routes/disputeRoutes.ts
@@ -2,26 +2,27 @@ import { Router } from "express";
 import multer from "multer";
 import { DisputeController } from "../controllers/disputeController.js";
 import { EvidenceController } from "../controllers/evidenceController.js";
+import { requireWallet } from "../middleware/walletAuth.js";
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
 /**
  * @route GET /disputes
- * @desc Retrieve all disputes
+ * @desc Retrieve disputes scoped to the authenticated wallet
  */
-router.get("/", DisputeController.getAllDisputes);
+router.get("/", requireWallet, DisputeController.getAllDisputes);
 
 /**
  * @route GET /disputes/:order_id
  * @desc Retrieve a single dispute by its on-chain order ID
  */
-router.get("/:order_id", DisputeController.getDisputeByOrderId);
+router.get("/:order_id", requireWallet, DisputeController.getDisputeByOrderId);
 
 /**
  * @route POST /disputes/:order_id/evidence
- * @desc Upload evidence for a dispute
+ * @desc Upload evidence for a dispute (participants only, OPEN disputes only)
  */
-router.post("/:order_id/evidence", upload.single("file"), EvidenceController.uploadEvidence);
+router.post("/:order_id/evidence", requireWallet, upload.single("file"), EvidenceController.uploadEvidence);
 
 export default router;

--- a/server/src/routes/orderRoutes.ts
+++ b/server/src/routes/orderRoutes.ts
@@ -1,18 +1,19 @@
 import { Router, type Request, type Response, type NextFunction } from "express";
 import { OrderController } from "../controllers/orderController.js";
 import { ApiError, sendProblem } from "../http/errors.js";
+import { requireWallet, type WalletRequest } from "../middleware/walletAuth.js";
 
 const router = Router();
 
-router.get("/", OrderController.getAllOrders);
+router.get("/", requireWallet, OrderController.getAllOrders);
 
-router.get("/buyer/:address", OrderController.getOrdersByBuyer);
+router.get("/buyer/:address", requireWallet, OrderController.getOrdersByBuyer);
 
-router.get("/seller/:address", OrderController.getOrdersBySeller);
+router.get("/seller/:address", requireWallet, OrderController.getOrdersBySeller);
 
-router.get("/stats/:sellerAddress", OrderController.getSellerStats);
+router.get("/stats/:sellerAddress", requireWallet, OrderController.getSellerStats);
 
-router.get("/:id", OrderController.getOrderById);
+router.get("/:id", requireWallet, OrderController.getOrderById);
 
 export function orderErrorHandler(error: unknown, req: Request, res: Response, next: NextFunction): void {
   if (error instanceof ApiError) {

--- a/server/src/services/disputeService.ts
+++ b/server/src/services/disputeService.ts
@@ -28,6 +28,35 @@ export class DisputeService {
   }
 
   /**
+   * Fetch disputes scoped to a specific wallet (buyer or seller)
+   */
+  static async getAllDisputesForWallet(walletAddress: string) {
+    try {
+      return await prisma.dispute.findMany({
+        where: {
+          OR: [
+            { order: { buyerAddress: walletAddress } },
+            { order: { sellerAddress: walletAddress } },
+          ],
+        },
+        include: {
+          order: {
+            include: {
+              product: true,
+              buyerUser: true,
+              sellerUser: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+      });
+    } catch (error) {
+      logger.error("Failed to fetch disputes for wallet", { error, walletAddress });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch disputes");
+    }
+  }
+
+  /**
    * Fetch a single dispute by its on-chain order ID
    */
   static async getDisputeByOrderId(orderIdOnChain: string) {
@@ -73,8 +102,19 @@ export class DisputeService {
   /**
    * Orchestrate evidence upload and attachment with validation
    */
-  static async provideEvidence(orderIdOnChain: string, file: Express.Multer.File) {
+  static async provideEvidence(orderIdOnChain: string, file: Express.Multer.File, walletAddress: string) {
     const dispute = await this.getDisputeByOrderId(orderIdOnChain);
+
+    const isParticipant =
+      dispute.order.buyerAddress === walletAddress || dispute.order.sellerAddress === walletAddress;
+
+    if (!isParticipant) {
+      throw new ApiError(403, "Forbidden", "Only dispute participants can submit evidence");
+    }
+
+    if (dispute.status === "Resolved" || dispute.status === "Dismissed") {
+      throw new ApiError(409, "Conflict", `Cannot submit evidence to a ${dispute.status.toLowerCase()} dispute`);
+    }
 
     const evidenceHash = await EvidenceStorageService.uploadEvidence(file, orderIdOnChain);
 

--- a/server/src/services/orderService.ts
+++ b/server/src/services/orderService.ts
@@ -23,6 +23,24 @@ export class OrderService {
     }
   }
 
+  static async getAllForWallet(walletAddress: string) {
+    try {
+      return await prisma.order.findMany({
+        where: {
+          OR: [
+            { buyerAddress: walletAddress },
+            { sellerAddress: walletAddress },
+          ],
+        },
+        include: ORDER_INCLUDE,
+        orderBy: ORDER_BY_CREATED_DESC,
+      });
+    } catch (error) {
+      logger.error("Failed to fetch orders for wallet", { error, walletAddress });
+      throw new ApiError(500, "Internal Server Error", "Failed to fetch orders");
+    }
+  }
+
   static async getByOrderId(orderIdOnChain: string) {
     try {
       const order = await prisma.order.findUnique({


### PR DESCRIPTION
## Summary

Fixes #614
Fixes #615
Fixes #616
Fixes #617

---

### Contract Fixes

**#614 — Add MAX_BATCH cap to batch_refund_orders**
- Added `const MAX_BATCH: u32 = 50` with early `EscrowError::InvalidAmount` return, matching the cap already present in `batch_refund_investors`.

**#615 — Fix double-counted totals in batch refund events**
- `batch_refund_investors`: Changed from adding both `contribution` and `payout` to only adding `payout` — the summary now tracks only the actual transferred amount.
- `batch_refund_orders`: Changed from adding both `refund_amount` and `order.amount` to only adding `refund_amount` — `refund_amount` already equals `amount + fee`, so adding `amount` again doubled it.

### Backend Fixes

**#616 — Remove unsigned x-wallet-address header auth bypass**
- `agro-production/server/src/middleware/walletAuth.ts`: Removed the legacy `x-wallet-address` header path that accepted an unauthenticated wallet identity for read operations. All requests now require a valid `Authorization: Bearer <session_token>`.

**#617 — Add auth middleware to order and dispute routes**
- Added `requireWallet` middleware to all order and dispute routes.
- `getOrdersByBuyer` / `getOrdersBySeller` / `getSellerStats` / `getOrderById`: Added wallet ownership checks — users can only access their own orders.
- `getAllOrders`: Scoped to return only orders where the user is buyer or seller.
- Dispute routes: Scoped to disputes where the user is buyer or seller on the related order.
- Evidence submission: Now requires wallet ownership (buyer/seller of the order) and rejects submission once the dispute status is no longer OPEN.