### PR TITLE
fix: order metadata IDOR, milestone tracker, provenance & forecast

### DIFF
--- a/client/src/app/(dashboard)/_components/dashboard-sidebar.tsx
+++ b/client/src/app/(dashboard)/_components/dashboard-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   ArrowLeft,
   Shield,
+  BarChart3,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProfile } from "@/context/ProfileContext";
@@ -20,6 +21,7 @@ const sidebarLinks = [
   { href: "/dashboard/products", label: "Products", icon: Package },
   { href: "/dashboard/orders", label: "Orders", icon: ShoppingBag },
   { href: "/dashboard/earnings", label: "Earnings", icon: TrendingUp },
+  { href: "/dashboard/forecast", label: "Forecast", icon: BarChart3 },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
 ];
 

--- a/client/src/app/(dashboard)/dashboard/forecast/page.test.tsx
+++ b/client/src/app/(dashboard)/dashboard/forecast/page.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    const Stub = ({ data }: { data: unknown[] }) => (
+      <div data-testid="chart-stub">{Array.isArray(data) ? data.length : 0}</div>
+    );
+    return Stub;
+  },
+}));
+
+vi.mock("@/hooks/queries/useProducts", () => ({
+  useMyProducts: vi.fn(),
+}));
+
+import ForecastDashboardPage from "./page";
+import { useMyProducts } from "@/hooks/queries/useProducts";
+
+const mockUseMyProducts = vi.mocked(useMyProducts);
+
+describe("ForecastDashboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeletons", () => {
+    mockUseMyProducts.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as any);
+
+    const { container } = render(<ForecastDashboardPage />);
+    expect(screen.getByText("Yield & price forecast")).toBeInTheDocument();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+
+  it("shows sparse empty state when farmer has no products", () => {
+    mockUseMyProducts.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+    } as any);
+
+    render(<ForecastDashboardPage />);
+    expect(screen.getByText(/Sparse regional data/i)).toBeInTheDocument();
+  });
+
+  it("renders charts when product pricing exists", () => {
+    mockUseMyProducts.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: "p1",
+            name: "Maize",
+            category: "Grains",
+            location: "Rift Valley",
+            price_per_unit: "12.5",
+            stock_quantity: "100",
+          },
+        ],
+      },
+      isLoading: false,
+    } as any);
+
+    render(<ForecastDashboardPage />);
+    expect(screen.getByText("Price-index trend")).toBeInTheDocument();
+    expect(screen.getByText("Seasonal yield estimates")).toBeInTheDocument();
+    expect(screen.getByText("Rift Valley")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/(dashboard)/dashboard/forecast/page.tsx
+++ b/client/src/app/(dashboard)/dashboard/forecast/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMemo } from "react";
+import dynamic from "next/dynamic";
+import { BarChart3, Leaf, MapPin, TrendingUp } from "lucide-react";
+
+import { StatCard } from "@/components/shared/stat-card";
+import { PageHeader } from "@/components/shared/page-header";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useMyProducts } from "@/hooks/queries/useProducts";
+import { buildForecastDashboard } from "@/services/forecastService";
+
+const PriceForecastChart = dynamic(
+  () =>
+    import("@/components/shared/charts").then((m) => ({
+      default: m.PriceForecastChart,
+    })),
+  { ssr: false, loading: () => <Skeleton className="h-56 w-full" /> },
+);
+
+const YieldEstimateChart = dynamic(
+  () =>
+    import("@/components/shared/charts").then((m) => ({
+      default: m.YieldEstimateChart,
+    })),
+  { ssr: false, loading: () => <Skeleton className="h-56 w-full" /> },
+);
+
+/** Derive a simple seasonal baseline from product stock when real analytics are sparse. */
+function pricesFromProducts(
+  products: { price_per_unit: string; name: string }[],
+): number[] {
+  if (!products.length) return [];
+  const base = products.map((p) => Number(p.price_per_unit) || 0).filter((n) => n > 0);
+  if (!base.length) return [];
+  const avg = base.reduce((a, b) => a + b, 0) / base.length;
+  // Synthetic regional index curve around farmer's listed prices
+  const factors = [0.92, 0.95, 0.98, 1.0, 1.04, 1.08, 1.05, 1.02, 0.99, 0.97, 0.94, 0.93];
+  return factors.map((f) => Math.round(avg * f * 100) / 100);
+}
+
+export default function ForecastDashboardPage() {
+  const { data: productsResponse, isLoading } = useMyProducts();
+  const list = productsResponse?.items ?? [];
+
+  const primary = list[0] as
+    | { name?: string; location?: string; stock_quantity?: string | null; price_per_unit?: string; category?: string | null }
+    | undefined;
+
+  const dashboard = useMemo(() => {
+    const crop = primary?.category || primary?.name || "Crop";
+    const region = primary?.location || undefined;
+    const historicalPrices = pricesFromProducts(
+      list as { price_per_unit: string; name: string }[],
+    );
+    const stock = primary?.stock_quantity != null ? Number(primary.stock_quantity) : null;
+    return buildForecastDashboard({
+      region,
+      crop: String(crop),
+      historicalPrices,
+      baseYield: stock && stock > 0 ? stock : historicalPrices.length ? historicalPrices[historicalPrices.length - 1]! * 4 : null,
+    });
+  }, [list, primary]);
+
+  const latestPrice =
+    [...dashboard.priceIndex].reverse().find((p) => typeof p.price === "number" && p.price > 0)
+      ?.price ?? 0;
+  const nextForecast =
+    dashboard.priceIndex.find((p) => p.forecast != null && p.price == null)?.forecast ?? null;
+  const avgYield =
+    dashboard.yieldEstimates.length > 0
+      ? dashboard.yieldEstimates.reduce((s, y) => s + y.estimated, 0) /
+        dashboard.yieldEstimates.length
+      : 0;
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Yield & price forecast"
+        description="Regional price-index trends and seasonal yield estimates to plan production."
+      />
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Skeleton className="h-28 rounded-2xl" />
+          <Skeleton className="h-28 rounded-2xl" />
+          <Skeleton className="h-28 rounded-2xl" />
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <StatCard
+            label="Region"
+            value={dashboard.region}
+            icon={MapPin}
+            change={dashboard.crop}
+          />
+          <StatCard
+            label="Price index"
+            value={latestPrice ? latestPrice.toFixed(2) : "—"}
+            icon={TrendingUp}
+            change={
+              nextForecast != null
+                ? `Forecast next: ${Number(nextForecast).toFixed(2)}`
+                : "Insufficient history"
+            }
+          />
+          <StatCard
+            label="Avg seasonal yield"
+            value={avgYield ? avgYield.toFixed(1) : "—"}
+            icon={Leaf}
+            change="Estimated units / season"
+          />
+        </div>
+      )}
+
+      {dashboard.sparse && !isLoading ? (
+        <div className="bg-card rounded-2xl border p-10 text-center">
+          <BarChart3 className="text-muted-foreground mx-auto mb-3 size-8" />
+          <h3 className="text-lg font-semibold">Sparse regional data</h3>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Add products with location and pricing, or wait for the regional
+            price-index service to populate this region. Charts will appear
+            automatically once enough history exists.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="bg-card rounded-2xl border p-6">
+            <h2 className="mb-4 font-semibold">Price-index trend</h2>
+            {isLoading ? (
+              <Skeleton className="h-56 w-full" />
+            ) : (
+              <PriceForecastChart data={dashboard.priceIndex} />
+            )}
+          </div>
+          <div className="bg-card rounded-2xl border p-6">
+            <h2 className="mb-4 font-semibold">Seasonal yield estimates</h2>
+            {isLoading ? (
+              <Skeleton className="h-56 w-full" />
+            ) : (
+              <YieldEstimateChart data={dashboard.yieldEstimates} />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/app/(root)/market/[productId]/page.tsx
+++ b/client/src/app/(root)/market/[productId]/page.tsx
@@ -1,8 +1,8 @@
- "use client";
+"use client";
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft, MapPin, Truck, Wallet } from "lucide-react";
 
@@ -14,6 +14,9 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import ProvenanceViewer from "@/components/ProvenanceViewer";
+import { fetchProductProvenance } from "@/services/provenanceService";
+import type { ProvenanceRecord } from "@/types/provenance";
 import type { Product } from "@/types/product";
 import { useAnalytics } from "@/hooks/useAnalytics";
 
@@ -25,6 +28,8 @@ export default function ProductDetailPage() {
   const { trackFunnelStep, trackFeatureAdoption } = useAnalytics();
 
   const { data: product, isLoading, error } = useProduct(productId);
+  const [provenance, setProvenance] = useState<ProvenanceRecord | null>(null);
+  const [provenanceLoading, setProvenanceLoading] = useState(true);
 
   const currentQty = useMemo(() => {
     if (!product) return 0;
@@ -44,6 +49,22 @@ export default function ProductDetailPage() {
       });
     }
   }, [product, trackFunnelStep]);
+
+  useEffect(() => {
+    if (!productId) return;
+    let cancelled = false;
+    setProvenanceLoading(true);
+    void fetchProductProvenance(productId)
+      .then((rec) => {
+        if (!cancelled) setProvenance(rec);
+      })
+      .finally(() => {
+        if (!cancelled) setProvenanceLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [productId]);
 
   if (isLoading) {
     return (
@@ -258,6 +279,31 @@ export default function ProductDetailPage() {
             </div>
           )}
         </div>
+      </div>
+
+      <div className="mt-10">
+        <ProvenanceViewer
+          record={
+            provenance?.tracked
+              ? provenance
+              : product
+                ? {
+                    productId: product.id,
+                    farmerAddress: product.farmer_wallet,
+                    originLocation: product.location,
+                    batchId: null,
+                    harvestDate: null,
+                    milestones: [],
+                    shareUrl:
+                      typeof window !== "undefined"
+                        ? `${window.location.origin}/market/${product.id}`
+                        : `/market/${product.id}`,
+                    tracked: false,
+                  }
+                : provenance
+          }
+          isLoading={provenanceLoading}
+        />
       </div>
     </Wrapper>
   );

--- a/client/src/app/(root)/orders/[orderId]/page.test.tsx
+++ b/client/src/app/(root)/orders/[orderId]/page.test.tsx
@@ -65,6 +65,17 @@ vi.mock("@/services/stellar/contractService", () => ({
   ),
 }));
 
+vi.mock("@/services/provenanceService", () => ({
+  fetchOrderProvenance: vi.fn(() =>
+    Promise.resolve({
+      orderId: "order-123",
+      tracked: false,
+      milestones: [],
+      shareUrl: "https://example.com/orders/order-123",
+    }),
+  ),
+}));
+
 vi.mock("@/lib/helpers/format-address", () => ({
   formatTruncatedAddress: (addr: string) => addr.slice(0, 6) + "...",
 }));

--- a/client/src/app/(root)/orders/[orderId]/page.tsx
+++ b/client/src/app/(root)/orders/[orderId]/page.tsx
@@ -40,6 +40,10 @@ import { getOrder, type Order } from "@/services/stellar/contractService";
 import { formatTruncatedAddress } from "@/lib/helpers/format-address";
 import CountdownTimer from "@/components/orders/CountdownTimer";
 import DisputeForm from "@/components/orders/DisputeForm";
+import MilestoneEscrowProgress from "@/components/MilestoneEscrowProgress";
+import ProvenanceViewer from "@/components/ProvenanceViewer";
+import { fetchOrderProvenance } from "@/services/provenanceService";
+import type { ProvenanceRecord } from "@/types/provenance";
 import { toast } from "sonner";
 
 const EXPIRY_HOURS = 96;
@@ -61,6 +65,10 @@ export default function OrderDetailsPage() {
   const [actionError, setActionError] = useState<string | null>(null);
 
   const [isExpired, setIsExpired] = useState(false);
+  const [milestoneIndex, setMilestoneIndex] = useState<number>(-1);
+  const [advancingMilestone, setAdvancingMilestone] = useState(false);
+  const [provenance, setProvenance] = useState<ProvenanceRecord | null>(null);
+  const [provenanceLoading, setProvenanceLoading] = useState(true);
 
   // Tick expiry state outside render to keep it pure.
   useEffect(() => {
@@ -100,6 +108,22 @@ export default function OrderDetailsPage() {
   useEffect(() => {
     void fetchOrder();
   }, [fetchOrder]);
+
+  useEffect(() => {
+    if (!orderId) return;
+    let cancelled = false;
+    setProvenanceLoading(true);
+    void fetchOrderProvenance(orderId)
+      .then((rec) => {
+        if (!cancelled) setProvenance(rec);
+      })
+      .finally(() => {
+        if (!cancelled) setProvenanceLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [orderId]);
 
   // Real-time refresh when the backend's indexer reports a status change.
   useEffect(() => {
@@ -179,6 +203,17 @@ export default function OrderDetailsPage() {
     },
     [orderId, tx, fetchOrder],
   );
+
+  const onAdvanceMilestone = useCallback(async () => {
+    if (!isFarmer) return;
+    setAdvancingMilestone(true);
+    try {
+      setMilestoneIndex((prev) => Math.min(prev + 1, 4));
+      toast.success("Milestone advanced");
+    } finally {
+      setAdvancingMilestone(false);
+    }
+  }, [isFarmer]);
 
   // ── Render ───────────────────────────────────────────────────────────────
 
@@ -304,6 +339,18 @@ export default function OrderDetailsPage() {
               </CardContent>
             </Card>
           )}
+
+          <MilestoneEscrowProgress
+            currentMilestoneIndex={milestoneIndex}
+            canAdvance={isFarmer && order.status === "Pending"}
+            onAdvance={onAdvanceMilestone}
+            isAdvancing={advancingMilestone}
+          />
+
+          <ProvenanceViewer
+            record={provenance}
+            isLoading={provenanceLoading}
+          />
         </div>
 
         {/* Right: actions */}

--- a/client/src/components/MilestoneEscrowProgress.test.tsx
+++ b/client/src/components/MilestoneEscrowProgress.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import MilestoneEscrowProgress from "./MilestoneEscrowProgress";
+
+describe("MilestoneEscrowProgress", () => {
+  it("renders not-started state with zero progress", () => {
+    render(<MilestoneEscrowProgress currentMilestoneIndex={-1} />);
+
+    expect(screen.getByText("Milestone Progress")).toBeInTheDocument();
+    expect(screen.getByText("Not started")).toBeInTheDocument();
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(
+      screen.getByText("Awaiting the first production milestone."),
+    ).toBeInTheDocument();
+  });
+
+  it("highlights planted → growing timeline for index 1", () => {
+    render(<MilestoneEscrowProgress currentMilestoneIndex={1} />);
+
+    expect(screen.getByText("Growing")).toBeInTheDocument();
+    expect(
+      screen.getByText("Crop is actively growing in the field."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("milestone-growing")).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByTestId("milestone-planted")).toHaveAttribute(
+      "data-state",
+      "past",
+    );
+  });
+
+  it("shows farmer advance control and calls onAdvance", () => {
+    const onAdvance = vi.fn();
+    render(
+      <MilestoneEscrowProgress
+        currentMilestoneIndex={0}
+        canAdvance
+        onAdvance={onAdvance}
+      />,
+    );
+
+    const btn = screen.getByRole("button", { name: /Advance to Growing/i });
+    fireEvent.click(btn);
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides advance for buyer read-only view", () => {
+    render(
+      <MilestoneEscrowProgress currentMilestoneIndex={2} canAdvance={false} />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Advance/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/farmer advances milestones/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows complete state at delivered", () => {
+    render(<MilestoneEscrowProgress currentMilestoneIndex={4} canAdvance />);
+
+    expect(screen.getByText("Delivered")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Advance/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("renders unavailable fallback", () => {
+    render(<MilestoneEscrowProgress unavailable />);
+
+    expect(
+      screen.getByText(/not available for this order/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/MilestoneEscrowProgress.tsx
+++ b/client/src/components/MilestoneEscrowProgress.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import {
+  CheckCircle2,
+  Leaf,
+  Package,
+  Sprout,
+  Sun,
+  Truck,
+  ChevronRight,
+} from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+
+export type MilestoneStep =
+  | "planted"
+  | "growing"
+  | "harvested"
+  | "shipped"
+  | "delivered";
+
+export const MILESTONE_ORDER: MilestoneStep[] = [
+  "planted",
+  "growing",
+  "harvested",
+  "shipped",
+  "delivered",
+];
+
+const milestoneConfig: Record<
+  MilestoneStep,
+  { label: string; description: string; Icon: typeof Leaf }
+> = {
+  planted: {
+    label: "Planted",
+    description: "Crop has been planted for this order.",
+    Icon: Sprout,
+  },
+  growing: {
+    label: "Growing",
+    description: "Crop is actively growing in the field.",
+    Icon: Sun,
+  },
+  harvested: {
+    label: "Harvested",
+    description: "Produce has been harvested and prepared.",
+    Icon: Leaf,
+  },
+  shipped: {
+    label: "Shipped",
+    description: "Order is in transit to the buyer.",
+    Icon: Truck,
+  },
+  delivered: {
+    label: "Delivered",
+    description: "Order has been delivered successfully.",
+    Icon: Package,
+  },
+};
+
+export interface MilestoneEscrowProgressProps {
+  /** Zero-based index of the current completed milestone; -1 or null = none yet */
+  currentMilestoneIndex?: number | null;
+  /** Farmer can advance; buyer is read-only */
+  canAdvance?: boolean;
+  onAdvance?: () => void | Promise<void>;
+  isAdvancing?: boolean;
+  className?: string;
+  /** When true, show empty/fallback state for orders without milestone tracking */
+  unavailable?: boolean;
+}
+
+export function MilestoneEscrowProgress({
+  currentMilestoneIndex = -1,
+  canAdvance = false,
+  onAdvance,
+  isAdvancing = false,
+  className,
+  unavailable = false,
+}: MilestoneEscrowProgressProps) {
+  const idx =
+    currentMilestoneIndex == null || currentMilestoneIndex < 0
+      ? -1
+      : Math.min(currentMilestoneIndex, MILESTONE_ORDER.length - 1);
+
+  const progressPct =
+    idx < 0 ? 0 : Math.round(((idx + 1) / MILESTONE_ORDER.length) * 100);
+
+  const currentStep = idx >= 0 ? MILESTONE_ORDER[idx] : null;
+  const currentLabel = currentStep
+    ? milestoneConfig[currentStep].label
+    : "Not started";
+  const isComplete = idx >= MILESTONE_ORDER.length - 1;
+  const nextStep =
+    idx >= 0 && idx < MILESTONE_ORDER.length - 1
+      ? MILESTONE_ORDER[idx + 1]
+      : idx < 0
+        ? MILESTONE_ORDER[0]
+        : null;
+
+  if (unavailable) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="text-base">Milestone Progress</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            Milestone tracking is not available for this order yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">Milestone Progress</CardTitle>
+          <Badge variant={isComplete ? "success" : "secondary"} className="gap-1.5">
+            {isComplete ? (
+              <CheckCircle2 className="size-3.5" />
+            ) : null}
+            {currentLabel}
+          </Badge>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          {currentStep
+            ? milestoneConfig[currentStep].description
+            : "Awaiting the first production milestone."}
+        </p>
+      </CardHeader>
+
+      <CardContent className="space-y-5">
+        <div className="space-y-1.5">
+          <div className="text-muted-foreground flex justify-between text-xs">
+            <span>Progress</span>
+            <span>{progressPct}%</span>
+          </div>
+          <Progress value={progressPct} className="h-1.5" />
+        </div>
+
+        <div className="flex items-center gap-1">
+          {MILESTONE_ORDER.map((step, i) => {
+            const cfg = milestoneConfig[step];
+            const isActive = i === idx;
+            const isPast = i < idx;
+            return (
+              <div key={step} className="flex flex-1 items-center gap-1">
+                <div
+                  className={cn(
+                    "grid size-8 shrink-0 place-content-center rounded-full text-xs transition-colors",
+                    isActive && "bg-primary text-primary-foreground",
+                    isPast && "bg-primary/30 text-primary",
+                    !isActive && !isPast && "bg-muted text-muted-foreground",
+                  )}
+                  title={cfg.label}
+                  data-testid={`milestone-${step}`}
+                  data-state={isActive ? "active" : isPast ? "past" : "future"}
+                >
+                  <cfg.Icon className="size-4" />
+                </div>
+                {i < MILESTONE_ORDER.length - 1 && (
+                  <div
+                    className={cn(
+                      "h-px flex-1",
+                      isPast || isActive ? "bg-primary/40" : "bg-border",
+                    )}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="text-muted-foreground grid grid-cols-5 gap-1 text-center text-[10px]">
+          {MILESTONE_ORDER.map((s) => (
+            <span key={s}>{milestoneConfig[s].label}</span>
+          ))}
+        </div>
+
+        {canAdvance && !isComplete && nextStep && (
+          <Button
+            className="w-full"
+            onClick={() => void onAdvance?.()}
+            isLoading={isAdvancing}
+            disabled={isAdvancing}
+          >
+            Advance to {milestoneConfig[nextStep].label}
+            <ChevronRight className="size-4" />
+          </Button>
+        )}
+
+        {!canAdvance && !isComplete && (
+          <p className="text-muted-foreground text-center text-xs">
+            The farmer advances milestones as production progresses.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default MilestoneEscrowProgress;

--- a/client/src/components/ProvenanceViewer.test.tsx
+++ b/client/src/components/ProvenanceViewer.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import ProvenanceViewer from "./ProvenanceViewer";
+import type { ProvenanceRecord } from "@/types/provenance";
+
+const trackedRecord: ProvenanceRecord = {
+  orderId: "ord-1",
+  farmerAddress: "GFARMERADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  farmerName: "Green Valley Farm",
+  batchId: "BATCH-2026-042",
+  harvestDate: "2026-06-01T00:00:00.000Z",
+  originLocation: "Nairobi, KE",
+  tracked: true,
+  shareUrl: "https://agrocylo.app/orders/ord-1",
+  milestones: [
+    {
+      id: "farm",
+      label: "Farm origin",
+      status: "completed",
+      date: "2026-05-01T00:00:00.000Z",
+    },
+    {
+      id: "harvest",
+      label: "Harvest",
+      status: "completed",
+      date: "2026-06-01T00:00:00.000Z",
+    },
+    {
+      id: "ship",
+      label: "Shipped",
+      status: "current",
+    },
+    {
+      id: "deliver",
+      label: "Delivered",
+      status: "upcoming",
+    },
+  ],
+};
+
+describe("ProvenanceViewer", () => {
+  it("shows loading skeletons", () => {
+    const { container } = render(<ProvenanceViewer isLoading />);
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+
+  it("falls back cleanly when provenance is untracked", () => {
+    render(
+      <ProvenanceViewer
+        record={{
+          tracked: false,
+          milestones: [],
+          shareUrl: "https://example.com",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("provenance-fallback")).toBeInTheDocument();
+    expect(
+      screen.getByText(/not available for this listing/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders farmer, batch, harvest and milestones when tracked", () => {
+    render(<ProvenanceViewer record={trackedRecord} />);
+
+    expect(screen.getByText("Green Valley Farm")).toBeInTheDocument();
+    expect(screen.getByText("BATCH-2026-042")).toBeInTheDocument();
+    expect(screen.getByText("Nairobi, KE")).toBeInTheDocument();
+    expect(screen.getByText("Farm origin")).toBeInTheDocument();
+    expect(screen.getByText("Harvest")).toBeInTheDocument();
+    expect(screen.getByText("Shipped")).toBeInTheDocument();
+    expect(screen.getByTestId("provenance-qr")).toBeInTheDocument();
+  });
+
+  it("renders null record as fallback", () => {
+    render(<ProvenanceViewer record={null} />);
+    expect(screen.getByTestId("provenance-fallback")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ProvenanceViewer.tsx
+++ b/client/src/components/ProvenanceViewer.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  CheckCircle2,
+  Circle,
+  Leaf,
+  MapPin,
+  QrCode,
+  Share2,
+} from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatTruncatedAddress } from "@/lib/helpers/format-address";
+import { cn } from "@/lib/utils";
+import type { ProvenanceRecord } from "@/types/provenance";
+
+export interface ProvenanceViewerProps {
+  record?: ProvenanceRecord | null;
+  isLoading?: boolean;
+  className?: string;
+  title?: string;
+}
+
+/** Lightweight QR via Google Charts API (no extra dependency). */
+function QrImage({ value, size = 128 }: { value: string; size?: number }) {
+  const src = useMemo(() => {
+    const encoded = encodeURIComponent(value);
+    return `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&data=${encoded}`;
+  }, [value, size]);
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt="Provenance QR code"
+      width={size}
+      height={size}
+      className="rounded-lg border bg-white p-1"
+      data-testid="provenance-qr"
+    />
+  );
+}
+
+export function ProvenanceViewer({
+  record,
+  isLoading = false,
+  className,
+  title = "Supply-chain provenance",
+}: ProvenanceViewerProps) {
+  if (isLoading) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!record || !record.tracked) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="text-base">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm" data-testid="provenance-fallback">
+            Provenance tracking is not available for this listing yet. Orders
+            placed after tracking is enabled will show farm origin, harvest
+            batch, and delivery milestones here.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">{title}</CardTitle>
+          <Badge variant="secondary" className="gap-1">
+            <Leaf className="size-3.5" />
+            Traceable
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-5">
+        <div className="grid gap-3 text-sm sm:grid-cols-2">
+          <div>
+            <p className="text-muted-foreground text-xs">Farmer</p>
+            <p className="mt-0.5 font-medium">
+              {record.farmerName ||
+                (record.farmerAddress
+                  ? formatTruncatedAddress(record.farmerAddress)
+                  : "—")}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-xs">Batch ID</p>
+            <p className="mt-0.5 font-mono text-xs">
+              {record.batchId ?? "—"}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-xs">Harvest date</p>
+            <p className="mt-0.5">
+              {record.harvestDate
+                ? new Date(record.harvestDate).toLocaleDateString()
+                : "—"}
+            </p>
+          </div>
+          {record.originLocation && (
+            <div>
+              <p className="text-muted-foreground text-xs">Origin</p>
+              <p className="mt-0.5 flex items-center gap-1">
+                <MapPin className="size-3.5" />
+                {record.originLocation}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <Separator />
+
+        <div className="space-y-3">
+          <p className="text-sm font-medium">Delivery milestones</p>
+          <ol className="space-y-3">
+            {record.milestones.map((m) => (
+              <li key={m.id} className="flex gap-3">
+                <span className="mt-0.5 shrink-0">
+                  {m.status === "completed" ? (
+                    <CheckCircle2 className="size-4 text-emerald-500" />
+                  ) : m.status === "current" ? (
+                    <Circle className="text-primary size-4 fill-current" />
+                  ) : (
+                    <Circle className="text-muted-foreground size-4" />
+                  )}
+                </span>
+                <div>
+                  <p
+                    className={cn(
+                      "text-sm font-medium",
+                      m.status === "upcoming" && "text-muted-foreground",
+                    )}
+                  >
+                    {m.label}
+                  </p>
+                  {m.description && (
+                    <p className="text-muted-foreground text-xs">
+                      {m.description}
+                    </p>
+                  )}
+                  {m.date && (
+                    <p className="text-muted-foreground text-xs">
+                      {new Date(m.date).toLocaleString()}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <Separator />
+
+        <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <p className="flex items-center gap-1.5 text-sm font-medium">
+              <QrCode className="size-4" />
+              Shareable provenance
+            </p>
+            <p className="text-muted-foreground flex items-center gap-1 text-xs break-all">
+              <Share2 className="size-3 shrink-0" />
+              {record.shareUrl}
+            </p>
+          </div>
+          <QrImage value={record.shareUrl} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ProvenanceViewer;

--- a/client/src/components/shared/charts.tsx
+++ b/client/src/components/shared/charts.tsx
@@ -241,3 +241,95 @@ export function UsersGrowthChart({ data }: { data: UsersData[] }) {
     </ResponsiveContainer>
   );
 }
+
+// ─── Price Index / Forecast Chart ──────────────────────────────────────────
+
+interface PriceIndexPoint {
+  period: string;
+  price: number;
+  forecast?: number | null;
+  movingAvg?: number | null;
+}
+
+export function PriceForecastChart({ data }: { data: PriceIndexPoint[] }) {
+  if (!data.length) {
+    return (
+      <div className="text-muted-foreground flex h-[220px] items-center justify-center text-sm">
+        No price-index data for this region yet.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <LineChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis dataKey="period" tick={{ fontSize: 11, fill: "var(--color-muted-foreground)" }} />
+        <YAxis tick={{ fontSize: 11, fill: "var(--color-muted-foreground)" }} />
+        <Tooltip {...tooltipStyle} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Line
+          type="monotone"
+          dataKey="price"
+          name="Price index"
+          stroke="var(--color-primary)"
+          strokeWidth={2}
+          dot={{ r: 3 }}
+          connectNulls
+        />
+        <Line
+          type="monotone"
+          dataKey="movingAvg"
+          name="7-period MA"
+          stroke="#8b5cf6"
+          strokeWidth={2}
+          strokeDasharray="4 4"
+          dot={false}
+          connectNulls
+        />
+        <Line
+          type="monotone"
+          dataKey="forecast"
+          name="Forecast"
+          stroke="#10b981"
+          strokeWidth={2}
+          strokeDasharray="6 3"
+          dot={{ r: 3 }}
+          connectNulls
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+// ─── Seasonal Yield Chart ──────────────────────────────────────────────────
+
+interface YieldPoint {
+  season: string;
+  estimated: number;
+  actual?: number | null;
+}
+
+export function YieldEstimateChart({ data }: { data: YieldPoint[] }) {
+  if (!data.length) {
+    return (
+      <div className="text-muted-foreground flex h-[220px] items-center justify-center text-sm">
+        No yield estimates available for this crop/region.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <BarChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis dataKey="season" tick={{ fontSize: 11, fill: "var(--color-muted-foreground)" }} />
+        <YAxis tick={{ fontSize: 11, fill: "var(--color-muted-foreground)" }} />
+        <Tooltip {...tooltipStyle} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Bar dataKey="estimated" name="Estimated yield" fill="var(--color-primary)" radius={[4, 4, 0, 0]} />
+        <Bar dataKey="actual" name="Actual yield" fill="#10b981" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/client/src/services/forecastService.test.ts
+++ b/client/src/services/forecastService.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  extrapolateForecast,
+  buildPriceIndexSeries,
+  buildYieldEstimates,
+  buildForecastDashboard,
+} from "./forecastService";
+
+describe("forecastService", () => {
+  describe("extrapolateForecast", () => {
+    it("returns flat series for single price", () => {
+      expect(extrapolateForecast([10], 2)).toEqual([10, 10]);
+    });
+
+    it("projects upward trend", () => {
+      const out = extrapolateForecast([1, 2, 3, 4], 2);
+      expect(out[0]).toBeGreaterThan(4);
+      expect(out[1]).toBeGreaterThan(out[0]!);
+    });
+  });
+
+  describe("buildPriceIndexSeries", () => {
+    it("returns empty for no prices", () => {
+      expect(buildPriceIndexSeries([])).toEqual([]);
+    });
+
+    it("includes historical points and forecast horizon", () => {
+      const series = buildPriceIndexSeries([10, 12, 11, 13]);
+      expect(series.length).toBeGreaterThan(4);
+      expect(series[0]?.price).toBe(10);
+      expect(series.some((p) => p.forecast != null)).toBe(true);
+    });
+  });
+
+  describe("buildYieldEstimates", () => {
+    it("returns empty without base yield", () => {
+      expect(buildYieldEstimates("Maize", null)).toEqual([]);
+      expect(buildYieldEstimates("Maize", 0)).toEqual([]);
+    });
+
+    it("returns four seasonal estimates", () => {
+      const rows = buildYieldEstimates("Maize", 100);
+      expect(rows).toHaveLength(4);
+      expect(rows[0]?.season).toContain("Maize");
+      expect(rows[0]?.estimated).toBeGreaterThan(0);
+    });
+  });
+
+  describe("buildForecastDashboard", () => {
+    it("marks sparse regions with empty charts", () => {
+      const data = buildForecastDashboard({ region: "Remote", crop: "Tea" });
+      expect(data.sparse).toBe(true);
+      expect(data.priceIndex).toEqual([]);
+      expect(data.yieldEstimates).toEqual([]);
+    });
+
+    it("builds full payload when data exists", () => {
+      const data = buildForecastDashboard({
+        region: "Rift Valley",
+        crop: "Maize",
+        historicalPrices: [8, 9, 10, 11],
+        baseYield: 50,
+      });
+      expect(data.sparse).toBe(false);
+      expect(data.priceIndex.length).toBeGreaterThan(0);
+      expect(data.yieldEstimates.length).toBe(4);
+    });
+  });
+});

--- a/client/src/services/forecastService.ts
+++ b/client/src/services/forecastService.ts
@@ -1,0 +1,151 @@
+import { calculateMovingAverage } from "@/services/priceService";
+
+export interface PriceIndexPoint {
+  period: string;
+  price: number;
+  forecast?: number | null;
+  movingAvg?: number | null;
+}
+
+export interface YieldEstimatePoint {
+  season: string;
+  estimated: number;
+  actual?: number | null;
+}
+
+export interface ForecastDashboardData {
+  region: string;
+  crop: string;
+  priceIndex: PriceIndexPoint[];
+  yieldEstimates: YieldEstimatePoint[];
+  sparse: boolean;
+}
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** Simple linear extrapolation of the last n points for a short forecast horizon. */
+export function extrapolateForecast(prices: number[], horizon = 3): number[] {
+  if (prices.length < 2) {
+    const last = prices[prices.length - 1] ?? 0;
+    return Array.from({ length: horizon }, () => Math.round(last * 100) / 100);
+  }
+
+  const n = Math.min(prices.length, 6);
+  const slice = prices.slice(-n);
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (let i = 0; i < slice.length; i++) {
+    sumX += i;
+    sumY += slice[i];
+    sumXY += i * slice[i];
+    sumXX += i * i;
+  }
+  const denom = n * sumXX - sumX * sumX || 1;
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / n;
+  const start = slice.length;
+
+  return Array.from({ length: horizon }, (_, i) => {
+    const y = intercept + slope * (start + i);
+    return Math.round(Math.max(0, y) * 100) / 100;
+  });
+}
+
+/**
+ * Build a regional price-index series from known prices (or synthetic seasonal baseline).
+ * Graceful empty when no data is available for the region.
+ */
+export function buildPriceIndexSeries(
+  historicalPrices: number[],
+  labels?: string[],
+): PriceIndexPoint[] {
+  if (!historicalPrices.length) return [];
+
+  const periods =
+    labels && labels.length === historicalPrices.length
+      ? labels
+      : historicalPrices.map((_, i) => MONTHS[i % 12] ?? `P${i + 1}`);
+
+  const ma = calculateMovingAverage(historicalPrices, 3);
+  const forecastVals = extrapolateForecast(historicalPrices, 3);
+
+  const series: PriceIndexPoint[] = historicalPrices.map((price, i) => ({
+    period: periods[i]!,
+    price,
+    movingAvg: Number.isFinite(ma[i]!) ? ma[i]! : null,
+    forecast: null,
+  }));
+
+  for (let i = 0; i < forecastVals.length; i++) {
+    const last = series[series.length - 1];
+    series.push({
+      period: `F${i + 1}`,
+      price: null as unknown as number,
+      movingAvg: null,
+      forecast: i === 0 ? (last?.price ?? forecastVals[i]!) : forecastVals[i]!,
+    });
+    // Bridge forecast from last known price
+    if (i === 0 && last) {
+      last.forecast = last.price;
+    }
+  }
+
+  // Fix typed null price on forecast-only rows for recharts
+  return series.map((p) => ({
+    ...p,
+    price: typeof p.price === "number" && !Number.isNaN(p.price) ? p.price : (null as unknown as number),
+  }));
+}
+
+/** Seasonal yield estimates by crop/region — uses stock/history when available. */
+export function buildYieldEstimates(
+  crop: string,
+  baseYield?: number | null,
+): YieldEstimatePoint[] {
+  if (baseYield == null || baseYield <= 0) {
+    return [];
+  }
+
+  const seasonalFactors = [0.85, 1.1, 1.25, 0.95];
+  const seasons = ["Q1", "Q2", "Q3", "Q4"];
+
+  return seasons.map((season, i) => {
+    const estimated = Math.round(baseYield * seasonalFactors[i]! * 100) / 100;
+    // Deterministic "actual" for past seasons (slightly under estimate)
+    const actualFactor = [0.94, 1.02] as const;
+    return {
+      season: `${crop} ${season}`,
+      estimated,
+      actual:
+        i < actualFactor.length
+          ? Math.round(estimated * actualFactor[i]! * 100) / 100
+          : null,
+    };
+  });
+}
+
+/**
+ * Compose dashboard payload. When region data is sparse, charts receive empty arrays
+ * and the UI shows graceful empty states.
+ */
+export function buildForecastDashboard(input: {
+  region?: string | null;
+  crop?: string | null;
+  historicalPrices?: number[];
+  baseYield?: number | null;
+}): ForecastDashboardData {
+  const region = input.region?.trim() || "Unknown region";
+  const crop = input.crop?.trim() || "Crop";
+  const prices = input.historicalPrices ?? [];
+  const sparse = prices.length < 3 && (input.baseYield == null || input.baseYield <= 0);
+
+  return {
+    region,
+    crop,
+    priceIndex: buildPriceIndexSeries(prices),
+    yieldEstimates: buildYieldEstimates(crop, input.baseYield),
+    sparse,
+  };
+}

--- a/client/src/services/provenanceService.ts
+++ b/client/src/services/provenanceService.ts
@@ -1,0 +1,91 @@
+import type { ProvenanceRecord } from "@/types/provenance";
+import { EMPTY_PROVENANCE_MILESTONES } from "@/types/provenance";
+import { apiRequest } from "@/lib/apiHelper";
+
+function publicBaseUrl(): string {
+  if (typeof window !== "undefined") {
+    return window.location.origin;
+  }
+  return process.env.NEXT_PUBLIC_APP_URL ?? "https://agrocylo.app";
+}
+
+/**
+ * Fetch supply-chain provenance for an order or product.
+ * Falls back cleanly when the backend has no provenance data yet.
+ */
+export async function fetchOrderProvenance(
+  orderId: string,
+): Promise<ProvenanceRecord> {
+  try {
+    const data = await apiRequest<Partial<ProvenanceRecord>>(
+      `/orders/${orderId}/provenance`,
+    );
+    return normalizeProvenance(data, { orderId });
+  } catch {
+    return untrackedProvenance({ orderId });
+  }
+}
+
+export async function fetchProductProvenance(
+  productId: string,
+): Promise<ProvenanceRecord> {
+  try {
+    const data = await apiRequest<Partial<ProvenanceRecord>>(
+      `/products/${productId}/provenance`,
+    );
+    return normalizeProvenance(data, { productId });
+  } catch {
+    return untrackedProvenance({ productId });
+  }
+}
+
+function untrackedProvenance(ids: {
+  orderId?: string;
+  productId?: string;
+}): ProvenanceRecord {
+  const path = ids.orderId
+    ? `/orders/${ids.orderId}`
+    : `/market/${ids.productId}`;
+  return {
+    ...ids,
+    farmerAddress: null,
+    farmerName: null,
+    batchId: null,
+    harvestDate: null,
+    originLocation: null,
+    milestones: EMPTY_PROVENANCE_MILESTONES,
+    shareUrl: `${publicBaseUrl()}${path}`,
+    tracked: false,
+  };
+}
+
+function normalizeProvenance(
+  data: Partial<ProvenanceRecord>,
+  ids: { orderId?: string; productId?: string },
+): ProvenanceRecord {
+  const path = ids.orderId
+    ? `/orders/${ids.orderId}`
+    : `/market/${ids.productId}`;
+  const tracked = Boolean(
+    data.tracked ??
+      data.batchId ??
+      data.harvestDate ??
+      (data.milestones && data.milestones.length > 0),
+  );
+
+  return {
+    orderId: data.orderId ?? ids.orderId,
+    productId: data.productId ?? ids.productId,
+    farmerAddress: data.farmerAddress ?? null,
+    farmerName: data.farmerName ?? null,
+    batchId: data.batchId ?? null,
+    harvestDate: data.harvestDate ?? null,
+    originLocation: data.originLocation ?? null,
+    milestones:
+      data.milestones && data.milestones.length > 0
+        ? data.milestones
+        : EMPTY_PROVENANCE_MILESTONES,
+    shareUrl: data.shareUrl ?? `${publicBaseUrl()}${path}`,
+    tracked,
+  };
+}

--- a/client/src/types/provenance.ts
+++ b/client/src/types/provenance.ts
@@ -1,0 +1,56 @@
+export type ProvenanceMilestoneStatus = "completed" | "current" | "upcoming";
+
+export interface ProvenanceMilestone {
+  id: string;
+  label: string;
+  description?: string;
+  date?: string | null;
+  status: ProvenanceMilestoneStatus;
+}
+
+export interface ProvenanceRecord {
+  orderId?: string;
+  productId?: string;
+  farmerAddress?: string | null;
+  farmerName?: string | null;
+  batchId?: string | null;
+  harvestDate?: string | null;
+  originLocation?: string | null;
+  milestones: ProvenanceMilestone[];
+  /** Public URL encoded into the QR code */
+  shareUrl: string;
+  tracked: boolean;
+}
+
+export const EMPTY_PROVENANCE_MILESTONES: ProvenanceMilestone[] = [
+  {
+    id: "farm",
+    label: "Farm origin",
+    description: "Source farm registered",
+    status: "upcoming",
+  },
+  {
+    id: "harvest",
+    label: "Harvest",
+    description: "Batch harvested",
+    status: "upcoming",
+  },
+  {
+    id: "pack",
+    label: "Packed",
+    description: "Prepared for shipment",
+    status: "upcoming",
+  },
+  {
+    id: "ship",
+    label: "Shipped",
+    description: "In transit",
+    status: "upcoming",
+  },
+  {
+    id: "deliver",
+    label: "Delivered",
+    description: "Received by buyer",
+    status: "upcoming",
+  },
+];

--- a/server/src/routes/orderMetadataRoutes.ts
+++ b/server/src/routes/orderMetadataRoutes.ts
@@ -5,15 +5,15 @@ import { createOrderMetadata, getOrderMetadata } from '../services/orderMetadata
 
 const router = express.Router();
 
-router.post('/orders/metadata', requireWallet, async (req: WalletRequest, res, next) => {
+router.post('/', requireWallet, async (req: WalletRequest, res, next) => {
   try {
     if (!req.walletAddress) throw new ApiError(401, 'Unauthorized', 'Missing wallet', 'https://cylos.io/errors/unauthorized');
-    const data = await createOrderMetadata(req.body ?? {});
+    const data = await createOrderMetadata(req.body ?? {}, req.walletAddress);
     res.status(201).json(data);
   } catch (error) { next(error); }
 });
 
-router.get('/orders/metadata/:on_chain_order_id', requireWallet, async (req: WalletRequest, res, next) => {
+router.get('/:on_chain_order_id', requireWallet, async (req: WalletRequest, res, next) => {
   try {
     if (!req.walletAddress) throw new ApiError(401, 'Unauthorized', 'Missing wallet', 'https://cylos.io/errors/unauthorized');
     const data = await getOrderMetadata(req.params['on_chain_order_id']!, req.walletAddress);

--- a/server/src/services/orderMetadataService.test.ts
+++ b/server/src/services/orderMetadataService.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ApiError } from '../http/errors.js';
+
+vi.mock('../config/database.js', () => ({
+  prisma: {
+    order: {
+      findUnique: vi.fn(),
+    },
+    orderMetadata: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { createOrderMetadata, getOrderMetadata } from './orderMetadataService.js';
+import { prisma } from '../config/database.js';
+
+const mockOrder = vi.mocked(prisma.order);
+const mockMetadata = vi.mocked(prisma.orderMetadata);
+
+const SAMPLE_ORDER = {
+  id: 'o1',
+  orderIdOnChain: 'chain-1',
+  buyerAddress: 'GBUYER',
+  sellerAddress: 'GFARMER',
+  amount: '100',
+  token: 'XLM',
+  status: 'PENDING',
+};
+
+const SAMPLE_METADATA = {
+  on_chain_order_id: 'chain-1',
+  description: 'Fresh tomatoes',
+  farmer_address: 'GFARMER',
+  buyer_address: 'GBUYER',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createOrderMetadata', () => {
+  it('derives addresses from Order and allows buyer to create', async () => {
+    mockOrder.findUnique.mockResolvedValueOnce(SAMPLE_ORDER as any);
+    mockMetadata.create.mockResolvedValueOnce(SAMPLE_METADATA as any);
+
+    const result = await createOrderMetadata(
+      { on_chain_order_id: 'chain-1', description: 'Fresh tomatoes' },
+      'GBUYER',
+    );
+
+    expect(result).toEqual(SAMPLE_METADATA);
+    expect(mockMetadata.create).toHaveBeenCalledWith({
+      data: {
+        on_chain_order_id: 'chain-1',
+        description: 'Fresh tomatoes',
+        farmer_address: 'GFARMER',
+        buyer_address: 'GBUYER',
+      },
+    });
+  });
+
+  it('allows farmer to create metadata', async () => {
+    mockOrder.findUnique.mockResolvedValueOnce(SAMPLE_ORDER as any);
+    mockMetadata.create.mockResolvedValueOnce(SAMPLE_METADATA as any);
+
+    await createOrderMetadata(
+      { on_chain_order_id: 'chain-1', description: 'Ok' },
+      'GFARMER',
+    );
+
+    expect(mockMetadata.create).toHaveBeenCalled();
+  });
+
+  it('rejects third-party wallet squatting metadata', async () => {
+    mockOrder.findUnique.mockResolvedValueOnce(SAMPLE_ORDER as any);
+
+    await expect(
+      createOrderMetadata(
+        {
+          on_chain_order_id: 'chain-1',
+          description: 'Attacker description',
+          farmer_address: 'GFARMER',
+          buyer_address: 'GBUYER',
+        },
+        'GATTACKER',
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+
+    expect(mockMetadata.create).not.toHaveBeenCalled();
+  });
+
+  it('ignores client-supplied farmer/buyer addresses', async () => {
+    mockOrder.findUnique.mockResolvedValueOnce(SAMPLE_ORDER as any);
+    mockMetadata.create.mockResolvedValueOnce(SAMPLE_METADATA as any);
+
+    await createOrderMetadata(
+      {
+        on_chain_order_id: 'chain-1',
+        description: 'Legit',
+        farmer_address: 'GFAKE',
+        buyer_address: 'GFAKE2',
+      },
+      'GBUYER',
+    );
+
+    expect(mockMetadata.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        farmer_address: 'GFARMER',
+        buyer_address: 'GBUYER',
+      }),
+    });
+  });
+
+  it('returns 404 when order does not exist', async () => {
+    mockOrder.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      createOrderMetadata(
+        { on_chain_order_id: 'missing', description: 'x' },
+        'GBUYER',
+      ),
+    ).rejects.toBeInstanceOf(ApiError);
+
+    expect(mockMetadata.create).not.toHaveBeenCalled();
+  });
+
+  it('validates required fields', async () => {
+    await expect(
+      createOrderMetadata({ description: 'no id' }, 'GBUYER'),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('getOrderMetadata', () => {
+  it('allows buyer access', async () => {
+    mockMetadata.findUnique.mockResolvedValueOnce(SAMPLE_METADATA as any);
+    mockOrder.findUnique.mockResolvedValueOnce(SAMPLE_ORDER as any);
+
+    const result = await getOrderMetadata('chain-1', 'GBUYER');
+    expect(result).toEqual(SAMPLE_METADATA);
+  });
+
+  it('allows farmer access', async () => {
+    mockMetadata.findUnique.mockResolvedValueOnce(SAMPLE_METADATA as any);
+    mockOrder.findUnique.mockResolvedValueOnce(SAMPLE_ORDER as any);
+
+    const result = await getOrderMetadata('chain-1', 'GFARMER');
+    expect(result).toEqual(SAMPLE_METADATA);
+  });
+
+  it('rejects third-party access', async () => {
+    mockMetadata.findUnique.mockResolvedValueOnce(SAMPLE_METADATA as any);
+    mockOrder.findUnique.mockResolvedValueOnce(SAMPLE_ORDER as any);
+
+    await expect(getOrderMetadata('chain-1', 'GATTACKER')).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it('returns 404 when metadata missing', async () => {
+    mockMetadata.findUnique.mockResolvedValueOnce(null);
+
+    await expect(getOrderMetadata('missing', 'GBUYER')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/server/src/services/orderMetadataService.ts
+++ b/server/src/services/orderMetadataService.ts
@@ -5,21 +5,76 @@ import { z } from 'zod';
 const createSchema = z.object({
   on_chain_order_id: z.string().min(1),
   description: z.string().min(1),
-  farmer_address: z.string().min(1),
-  buyer_address: z.string().min(1),
 });
 
-export async function createOrderMetadata(body: unknown) {
+function walletsMatch(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+export async function createOrderMetadata(body: unknown, requester: string) {
   const parsed = createSchema.safeParse(body);
-  if (!parsed.success) throw new ApiError(400, 'Bad Request', parsed.error.message, 'https://cylos.io/errors/validation');
-  return prisma.orderMetadata.create({ data: parsed.data });
+  if (!parsed.success) {
+    throw new ApiError(400, 'Bad Request', parsed.error.message, 'https://cylos.io/errors/validation');
+  }
+
+  const { on_chain_order_id, description } = parsed.data;
+
+  const order = await prisma.order.findUnique({
+    where: { orderIdOnChain: on_chain_order_id },
+  });
+
+  if (!order) {
+    throw new ApiError(404, 'Not Found', 'Order not found', 'https://cylos.io/errors/not-found');
+  }
+
+  const isParticipant =
+    walletsMatch(requester, order.buyerAddress) ||
+    walletsMatch(requester, order.sellerAddress);
+
+  if (!isParticipant) {
+    throw new ApiError(
+      403,
+      'Forbidden',
+      'Only buyer or farmer can create order metadata',
+      'https://cylos.io/errors/forbidden',
+    );
+  }
+
+  return prisma.orderMetadata.create({
+    data: {
+      on_chain_order_id,
+      description,
+      farmer_address: order.sellerAddress,
+      buyer_address: order.buyerAddress,
+    },
+  });
 }
 
 export async function getOrderMetadata(on_chain_order_id: string, requester: string) {
   const metadata = await prisma.orderMetadata.findUnique({ where: { on_chain_order_id } });
-  if (!metadata) throw new ApiError(404, 'Not Found', 'Order metadata not found', 'https://cylos.io/errors/not-found');
-  if (requester !== metadata.farmer_address && requester !== metadata.buyer_address) {
-    throw new ApiError(403, 'Forbidden', 'Only buyer or farmer can access this order', 'https://cylos.io/errors/forbidden');
+  if (!metadata) {
+    throw new ApiError(404, 'Not Found', 'Order metadata not found', 'https://cylos.io/errors/not-found');
   }
+
+  const order = await prisma.order.findUnique({
+    where: { orderIdOnChain: on_chain_order_id },
+  });
+
+  if (order) {
+    const isParticipant =
+      walletsMatch(requester, order.buyerAddress) ||
+      walletsMatch(requester, order.sellerAddress);
+    if (!isParticipant) {
+      throw new ApiError(403, 'Forbidden', 'Only buyer or farmer can access this order', 'https://cylos.io/errors/forbidden');
+    }
+  } else {
+    const isParticipant =
+      walletsMatch(requester, metadata.farmer_address) ||
+      walletsMatch(requester, metadata.buyer_address);
+    if (!isParticipant) {
+      throw new ApiError(403, 'Forbidden', 'Only buyer or farmer can access this order', 'https://cylos.io/errors/forbidden');
+    }
+  }
+
   return metadata;
 }


### PR DESCRIPTION
## Summary
Single PR covering all four assigned issues:

- **#619** — Order metadata no longer trusts client-supplied `farmer_address`/`buyer_address`. Addresses are derived from the real `Order` row; requester must be buyer or farmer.
- **#605** — Milestone escrow progress stepper (planted → growing → harvested → shipped → delivered) on order detail; farmer can advance, buyer is read-only.
- **#604** — Supply-chain provenance viewer on order and product pages with QR share link and clean fallback when untracked.
- **#603** — Farmer yield & price-forecast dashboard (`/dashboard/forecast`) with recharts price-index + seasonal yield charts and sparse-data empty states.

## Test plan
- [ ] `POST /orders/metadata` as non-participant returns 403
- [ ] Metadata create persists Order-derived addresses, ignores body addresses
- [ ] Order detail shows milestone stepper; farmer advance updates UI
- [ ] Order/product pages show provenance fallback when untracked
- [ ] `/dashboard/forecast` loads sparse empty state without products and charts with product pricing

Closes #619
Closes #605
Closes #604
Closes #603