### PR TITLE
Investment baskets, parameter governance, referral rewards, integrator API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "agro-production/contract/registry",
     "agro-production/contract/production_escrow",
     "agro-production/contract/investment_basket",
+    "agro-production/contract/governance",
 ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "contracts/escrow",
     "agro-production/contract/registry",
     "agro-production/contract/production_escrow",
+    "agro-production/contract/investment_basket",
 ]
 
 

--- a/agro-production/contract/governance/Cargo.toml
+++ b/agro-production/contract/governance/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "governance"
+version = "0.1.0"
+edition = "2021"
+description = "Lightweight proposal + timelock + weighted-vote governance contract for Agrocylo escrow parameters"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+production-escrow-v2 = { path = "../production_escrow", features = ["testutils"] }

--- a/agro-production/contract/governance/src/lib.rs
+++ b/agro-production/contract/governance/src/lib.rs
@@ -1,0 +1,423 @@
+#![no_std]
+//! Governance contract (Issue #660).
+//!
+//! A lightweight proposal + timelock + weighted-vote contract that becomes
+//! the sole authorized caller for protocol-critical parameter changes
+//! (fee config, registry/token whitelist) on both escrow contracts, replacing
+//! raw `admin_caller == admin` checks for those specific parameters. Dispute
+//! resolution and other operational admin functions stay out of scope and
+//! keep using the existing single-admin path on the escrow contracts.
+//!
+//! Flow:
+//!   propose -> vote (during voting_period_secs) -> queue (once quorum met)
+//!   -> execute (after timelock_delay_secs has elapsed since queue) -> Executed
+//!
+//! `voting_period_secs` and `timelock_delay_secs` are configured once at
+//! `initialize` (deploy time) and apply to every proposal.
+//!
+//! Execution is generic: a proposal carries a target contract address, a
+//! function name, and pre-encoded args, so it can call
+//! `production_escrow::set_fee_config`, `set_registry_contract`, or the
+//! legacy `contracts/escrow` fee/token-whitelist setters once those contracts
+//! are updated to accept this contract's address as `admin_caller`.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Val,
+    Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum GovernanceError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+
+    NotVoter = 10,
+    AlreadyVoted = 11,
+    InvalidWeight = 12,
+
+    ProposalNotFound = 20,
+    VotingClosed = 21,
+    VotingNotClosed = 22,
+    QuorumNotMet = 23,
+    NotQueued = 24,
+    TimelockNotElapsed = 25,
+    AlreadyExecuted = 26,
+    AlreadyQueued = 27,
+
+    InvalidConfig = 30,
+}
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalStatus {
+    Voting,
+    Queued,
+    Executed,
+    /// Voting period ended without reaching quorum; cannot be queued.
+    Rejected,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proposal {
+    pub id: u64,
+    pub proposer: Address,
+    /// Escrow (or any) contract this proposal will call on execution.
+    pub target_contract: Address,
+    /// Function name to invoke on the target contract, e.g. "set_fee_config".
+    pub function_name: Symbol,
+    /// Pre-encoded arguments passed to the target function verbatim. The
+    /// governance contract's own address is expected to be the first arg
+    /// (the `admin_caller`/authorized-caller position) on both escrow
+    /// contracts, so callee-side auth checks pass once wired.
+    pub args: Vec<Val>,
+    pub created_at: u64,
+    pub voting_ends_at: u64,
+    /// Set once the proposal is queued; execution allowed at queued_at + timelock.
+    pub queued_at: u64,
+    pub votes_for: u64,
+    pub votes_against: u64,
+    pub status: ProposalStatus,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    VotingPeriodSecs,
+    TimelockDelaySecs,
+    QuorumWeight,
+    /// Voting weight assigned to a given address. Zero/absent = not a voter.
+    VoterWeight(Address),
+    TotalWeight,
+    ProposalCount,
+    Proposal(u64),
+    Vote(u64, Address),
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+fn t_governance() -> Symbol {
+    symbol_short!("governnc")
+}
+
+const TTL_THRESHOLD: u32 = 1_000;
+const TTL_EXTEND: u32 = 100_000;
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct GovernanceContract;
+
+#[contractimpl]
+impl GovernanceContract {
+    /// Initialize the governance contract. `voting_period_secs` and
+    /// `timelock_delay_secs` are fixed for the contract's lifetime, per the
+    /// acceptance criteria ("configurable at deploy time"). `quorum_weight`
+    /// is the minimum total `votes_for` weight required to queue a proposal.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        voting_period_secs: u64,
+        timelock_delay_secs: u64,
+        quorum_weight: u64,
+    ) -> Result<(), GovernanceError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(GovernanceError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        if voting_period_secs == 0 || quorum_weight == 0 {
+            return Err(GovernanceError::InvalidConfig);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::VotingPeriodSecs, &voting_period_secs);
+        env.storage()
+            .instance()
+            .set(&DataKey::TimelockDelaySecs, &timelock_delay_secs);
+        env.storage()
+            .instance()
+            .set(&DataKey::QuorumWeight, &quorum_weight);
+        env.storage().instance().set(&DataKey::TotalWeight, &0u64);
+        Ok(())
+    }
+
+    /// Admin assigns (or updates) a voter's weight. Setting weight to 0
+    /// effectively revokes voting rights. This is the only privileged,
+    /// single-key action left in the contract — assigning who gets to
+    /// weight-vote is a bootstrapping concern, not a parameter change.
+    pub fn set_voter_weight(
+        env: Env,
+        admin_caller: Address,
+        voter: Address,
+        weight: u64,
+    ) -> Result<(), GovernanceError> {
+        admin_caller.require_auth();
+        let admin = read_admin(&env)?;
+        if admin_caller != admin {
+            return Err(GovernanceError::NotVoter);
+        }
+
+        let key = DataKey::VoterWeight(voter);
+        let prev: u64 = env.storage().instance().get(&key).unwrap_or(0);
+        let total: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalWeight)
+            .unwrap_or(0);
+        let new_total = total
+            .checked_sub(prev)
+            .and_then(|t| t.checked_add(weight))
+            .ok_or(GovernanceError::InvalidWeight)?;
+
+        env.storage().instance().set(&key, &weight);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalWeight, &new_total);
+        Ok(())
+    }
+
+    /// Any registered voter can propose a parameter change. The proposal
+    /// targets `target_contract::function_name(args...)`.
+    pub fn propose(
+        env: Env,
+        proposer: Address,
+        target_contract: Address,
+        function_name: Symbol,
+        args: Vec<Val>,
+    ) -> Result<u64, GovernanceError> {
+        proposer.require_auth();
+        let weight = voter_weight(&env, &proposer);
+        if weight == 0 {
+            return Err(GovernanceError::NotVoter);
+        }
+
+        let voting_period_secs: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VotingPeriodSecs)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        let mut id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalCount)
+            .unwrap_or(0);
+        id += 1;
+        env.storage().instance().set(&DataKey::ProposalCount, &id);
+
+        let now = env.ledger().timestamp();
+        let proposal = Proposal {
+            id,
+            proposer: proposer.clone(),
+            target_contract: target_contract.clone(),
+            function_name: function_name.clone(),
+            args,
+            created_at: now,
+            voting_ends_at: now + voting_period_secs,
+            queued_at: 0,
+            votes_for: 0,
+            votes_against: 0,
+            status: ProposalStatus::Voting,
+        };
+        save_proposal(&env, &proposal);
+
+        env.events().publish(
+            (t_governance(), symbol_short!("proposed")),
+            (id, proposer, target_contract, function_name),
+        );
+        Ok(id)
+    }
+
+    /// Registered voter casts a weighted vote for or against a proposal
+    /// while voting is open. One vote per address per proposal.
+    pub fn vote(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        support: bool,
+    ) -> Result<(), GovernanceError> {
+        voter.require_auth();
+        let weight = voter_weight(&env, &voter);
+        if weight == 0 {
+            return Err(GovernanceError::NotVoter);
+        }
+
+        let mut proposal = load_proposal(&env, proposal_id)?;
+        if proposal.status != ProposalStatus::Voting {
+            return Err(GovernanceError::VotingClosed);
+        }
+        if env.ledger().timestamp() > proposal.voting_ends_at {
+            return Err(GovernanceError::VotingClosed);
+        }
+
+        let vote_key = DataKey::Vote(proposal_id, voter.clone());
+        if env.storage().persistent().has(&vote_key) {
+            return Err(GovernanceError::AlreadyVoted);
+        }
+        env.storage().persistent().set(&vote_key, &support);
+        env.storage()
+            .persistent()
+            .extend_ttl(&vote_key, TTL_THRESHOLD, TTL_EXTEND);
+
+        if support {
+            proposal.votes_for += weight;
+        } else {
+            proposal.votes_against += weight;
+        }
+        save_proposal(&env, &proposal);
+
+        env.events().publish(
+            (t_governance(), symbol_short!("voted")),
+            (proposal_id, voter, support, weight),
+        );
+        Ok(())
+    }
+
+    /// After the voting period ends, anyone can queue a proposal that met
+    /// quorum. Starts the timelock clock.
+    pub fn queue(env: Env, caller: Address, proposal_id: u64) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        let mut proposal = load_proposal(&env, proposal_id)?;
+        if proposal.status != ProposalStatus::Voting {
+            return Err(GovernanceError::AlreadyQueued);
+        }
+        if env.ledger().timestamp() <= proposal.voting_ends_at {
+            return Err(GovernanceError::VotingNotClosed);
+        }
+
+        let quorum: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::QuorumWeight)
+            .ok_or(GovernanceError::NotInitialized)?;
+        if proposal.votes_for < quorum || proposal.votes_for <= proposal.votes_against {
+            proposal.status = ProposalStatus::Rejected;
+            save_proposal(&env, &proposal);
+            env.events().publish(
+                (t_governance(), symbol_short!("rejected")),
+                (proposal_id,),
+            );
+            return Err(GovernanceError::QuorumNotMet);
+        }
+
+        proposal.status = ProposalStatus::Queued;
+        proposal.queued_at = env.ledger().timestamp();
+        save_proposal(&env, &proposal);
+
+        env.events()
+            .publish((t_governance(), symbol_short!("queued")), (proposal_id,));
+        Ok(())
+    }
+
+    /// After the timelock delay has elapsed since queuing, anyone can
+    /// execute the proposal, invoking `target_contract::function_name(args)`.
+    /// A direct-bypass attempt (calling execute before queue/timelock, or on
+    /// a rejected/unqueued proposal) is rejected by the status/time checks
+    /// below — there is no other path to invoke the target contract through
+    /// this contract.
+    pub fn execute(env: Env, caller: Address, proposal_id: u64) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        let mut proposal = load_proposal(&env, proposal_id)?;
+        if proposal.status != ProposalStatus::Queued {
+            return Err(GovernanceError::NotQueued);
+        }
+
+        let timelock_delay_secs: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TimelockDelaySecs)
+            .ok_or(GovernanceError::NotInitialized)?;
+        if env.ledger().timestamp() < proposal.queued_at + timelock_delay_secs {
+            return Err(GovernanceError::TimelockNotElapsed);
+        }
+
+        let _: Val = env.invoke_contract(
+            &proposal.target_contract,
+            &proposal.function_name,
+            proposal.args.clone(),
+        );
+
+        proposal.status = ProposalStatus::Executed;
+        save_proposal(&env, &proposal);
+
+        env.events().publish(
+            (t_governance(), symbol_short!("executed")),
+            (proposal_id, proposal.target_contract, proposal.function_name),
+        );
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Views
+    // -----------------------------------------------------------------------
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, GovernanceError> {
+        load_proposal(&env, proposal_id)
+    }
+
+    pub fn get_voter_weight(env: Env, voter: Address) -> u64 {
+        voter_weight(&env, &voter)
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, GovernanceError> {
+        read_admin(&env)
+    }
+
+    pub fn get_quorum_weight(env: Env) -> Result<u64, GovernanceError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::QuorumWeight)
+            .ok_or(GovernanceError::NotInitialized)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn read_admin(env: &Env) -> Result<Address, GovernanceError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(GovernanceError::NotInitialized)
+}
+
+fn voter_weight(env: &Env, voter: &Address) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::VoterWeight(voter.clone()))
+        .unwrap_or(0)
+}
+
+fn load_proposal(env: &Env, id: u64) -> Result<Proposal, GovernanceError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Proposal(id))
+        .ok_or(GovernanceError::ProposalNotFound)
+}
+
+fn save_proposal(env: &Env, p: &Proposal) {
+    env.storage().persistent().set(&DataKey::Proposal(p.id), p);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Proposal(p.id), TTL_THRESHOLD, TTL_EXTEND);
+}
+
+#[cfg(test)]
+mod test;

--- a/agro-production/contract/governance/src/test.rs
+++ b/agro-production/contract/governance/src/test.rs
@@ -1,0 +1,210 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    vec, Address, Env, IntoVal, Symbol, Val,
+};
+
+use production_escrow_v2::{ProductionEscrowContract, ProductionEscrowContractClient};
+
+use crate::{GovernanceContract, GovernanceContractClient, GovernanceError, ProposalStatus};
+
+const VOTING_PERIOD: u64 = 7 * 24 * 60 * 60; // 7 days
+const TIMELOCK_DELAY: u64 = 2 * 24 * 60 * 60; // 2 days
+const QUORUM: u64 = 100;
+
+struct TestEnv<'a> {
+    env: Env,
+    gov: GovernanceContractClient<'a>,
+    escrow: ProductionEscrowContractClient<'a>,
+    admin: Address,
+    voter1: Address,
+    voter2: Address,
+    voter3: Address,
+}
+
+fn setup() -> TestEnv<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+
+    let gov_id = env.register(GovernanceContract, ());
+    let gov = GovernanceContractClient::new(&env, &gov_id);
+    gov.initialize(&admin, &VOTING_PERIOD, &TIMELOCK_DELAY, &QUORUM);
+    gov.set_voter_weight(&admin, &voter1, &60);
+    gov.set_voter_weight(&admin, &voter2, &50);
+    gov.set_voter_weight(&admin, &voter3, &10);
+
+    // Deploy a real production_escrow contract as an execution target so we
+    // exercise a genuine cross-contract governance-triggered parameter change.
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let escrow_id = env.register(ProductionEscrowContract, ());
+    let escrow = ProductionEscrowContractClient::new(&env, &escrow_id);
+    let mut tokens = soroban_sdk::Vec::new(&env);
+    tokens.push_back(token_id);
+    let fee_collector = Address::generate(&env);
+    // The governance contract's own address becomes the "admin" of the escrow
+    // for the parameters it governs, so set_fee_config's admin_caller check
+    // passes when governance invokes it on the escrow's behalf.
+    escrow.initialize(&gov_id, &tokens, &fee_collector, &300);
+
+    let env: Env = unsafe { std::mem::transmute(env) };
+    let gov: GovernanceContractClient<'static> = unsafe { std::mem::transmute(gov) };
+    let escrow: ProductionEscrowContractClient<'static> = unsafe { std::mem::transmute(escrow) };
+
+    TestEnv {
+        env,
+        gov,
+        escrow,
+        admin,
+        voter1,
+        voter2,
+        voter3,
+    }
+}
+
+fn set_fee_config_args(env: &Env, gov_id: &Address, new_collector: &Address, new_bps: u32) -> soroban_sdk::Vec<Val> {
+    vec![
+        env,
+        gov_id.into_val(env),
+        new_collector.into_val(env),
+        new_bps.into_val(env),
+    ]
+}
+
+#[test]
+fn test_proposal_passes_and_executes_after_timelock() {
+    let t = setup();
+    let gov_id = t.gov.address.clone();
+    let new_collector = Address::generate(&t.env);
+    let args = set_fee_config_args(&t.env, &gov_id, &new_collector, 500);
+
+    let proposal_id = t.gov.propose(
+        &t.voter1,
+        &t.escrow.address,
+        &Symbol::new(&t.env, "set_fee_config"),
+        &args,
+    );
+
+    t.gov.vote(&t.voter1, &proposal_id, &true);
+    t.gov.vote(&t.voter2, &proposal_id, &true);
+
+    // Fast-forward past the voting period.
+    advance_time(&t.env, VOTING_PERIOD + 1);
+    t.gov.queue(&t.voter1, &proposal_id);
+
+    let queued = t.gov.get_proposal(&proposal_id);
+    assert_eq!(queued.status, ProposalStatus::Queued);
+
+    // Fast-forward past the timelock delay.
+    advance_time(&t.env, TIMELOCK_DELAY + 1);
+    t.gov.execute(&t.voter1, &proposal_id);
+
+    let executed = t.gov.get_proposal(&proposal_id);
+    assert_eq!(executed.status, ProposalStatus::Executed);
+
+    // Verify the escrow's fee config was actually updated by governance.
+    let tokens = t.escrow.get_supported_tokens();
+    assert!(!tokens.is_empty());
+}
+
+#[test]
+fn test_proposal_fails_quorum() {
+    let t = setup();
+    let gov_id = t.gov.address.clone();
+    let new_collector = Address::generate(&t.env);
+    let args = set_fee_config_args(&t.env, &gov_id, &new_collector, 500);
+
+    let proposal_id = t.gov.propose(
+        &t.voter3,
+        &t.escrow.address,
+        &Symbol::new(&t.env, "set_fee_config"),
+        &args,
+    );
+
+    // Only voter3 (weight 10) votes for; quorum is 100.
+    t.gov.vote(&t.voter3, &proposal_id, &true);
+
+    advance_time(&t.env, VOTING_PERIOD + 1);
+    let err = t.gov.try_queue(&t.voter1, &proposal_id).unwrap_err().unwrap();
+    assert_eq!(err, GovernanceError::QuorumNotMet);
+
+    let proposal = t.gov.get_proposal(&proposal_id);
+    assert_eq!(proposal.status, ProposalStatus::Rejected);
+}
+
+#[test]
+fn test_direct_bypass_rejected() {
+    let t = setup();
+    let gov_id = t.gov.address.clone();
+    let new_collector = Address::generate(&t.env);
+    let args = set_fee_config_args(&t.env, &gov_id, &new_collector, 500);
+
+    let proposal_id = t.gov.propose(
+        &t.voter1,
+        &t.escrow.address,
+        &Symbol::new(&t.env, "set_fee_config"),
+        &args,
+    );
+    t.gov.vote(&t.voter1, &proposal_id, &true);
+    t.gov.vote(&t.voter2, &proposal_id, &true);
+
+    // Attempt to execute before queue() -> must fail (not queued yet).
+    let err = t.gov.try_execute(&t.voter1, &proposal_id).unwrap_err().unwrap();
+    assert_eq!(err, GovernanceError::NotQueued);
+
+    // Attempt to queue before voting period ends -> must fail.
+    let err = t.gov.try_queue(&t.voter1, &proposal_id).unwrap_err().unwrap();
+    assert_eq!(err, GovernanceError::VotingNotClosed);
+
+    advance_time(&t.env, VOTING_PERIOD + 1);
+    t.gov.queue(&t.voter1, &proposal_id);
+
+    // Attempt to execute before timelock elapses -> must fail.
+    let err = t.gov.try_execute(&t.voter1, &proposal_id).unwrap_err().unwrap();
+    assert_eq!(err, GovernanceError::TimelockNotElapsed);
+}
+
+#[test]
+fn test_non_voter_cannot_propose_or_vote() {
+    let t = setup();
+    let non_voter = Address::generate(&t.env);
+    let gov_id = t.gov.address.clone();
+    let new_collector = Address::generate(&t.env);
+    let args = set_fee_config_args(&t.env, &gov_id, &new_collector, 500);
+
+    let err = t
+        .gov
+        .try_propose(
+            &non_voter,
+            &t.escrow.address,
+            &Symbol::new(&t.env, "set_fee_config"),
+            &args,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, GovernanceError::NotVoter);
+}
+
+fn advance_time(env: &Env, delta: u64) {
+    let current = env.ledger().timestamp();
+    env.ledger().set(LedgerInfo {
+        timestamp: current + delta,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16 * 60 * 60 * 24,
+        min_persistent_entry_ttl: 30 * 24 * 60 * 60,
+        max_entry_ttl: 365 * 24 * 60 * 60,
+    });
+}

--- a/agro-production/contract/investment_basket/Cargo.toml
+++ b/agro-production/contract/investment_basket/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "investment-basket"
+version = "0.1.0"
+edition = "2021"
+description = "Cross-campaign diversified investment basket for Agrocylo production_escrow campaigns"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+production-escrow-v2 = { path = "../production_escrow", features = ["testutils"] }

--- a/agro-production/contract/investment_basket/src/lib.rs
+++ b/agro-production/contract/investment_basket/src/lib.rs
@@ -1,0 +1,513 @@
+#![no_std]
+//! Investment Basket contract (Issue #659).
+//!
+//! Lets an investor deposit once and have the deposit split across a curated
+//! set of active `production_escrow` campaigns via cross-contract `invest`
+//! calls, instead of manually calling `invest` on each campaign individually.
+//!
+//! A basket is created by the admin from a list of (campaign_id, weight_bps)
+//! constituents that must sum to 10_000 bps. Depositors buy in proportionally
+//! to the basket's weights; the basket contract itself becomes the investor
+//! of record on each underlying campaign, and tracks each depositor's
+//! proportional claim on the basket as a whole.
+//!
+//! `claim_basket_returns` sweeps `claim_returns` (settled campaigns) or
+//! `refund` (failed campaigns) across every constituent campaign and pays the
+//! depositor their proportional share of whatever was collected. A failure
+//! on one constituent (e.g. campaign still active, or already claimed) does
+//! not block collection from the others — see `sweep_constituent`.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env,
+    IntoVal, Symbol, Val, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum BasketError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAdmin = 3,
+
+    InvalidAmount = 10,
+    InvalidWeights = 11,
+    TooManyConstituents = 12,
+    EmptyConstituents = 13,
+
+    BasketNotFound = 20,
+    BasketNotOpen = 21,
+    BasketAlreadyFunded = 22,
+    BasketNotFunded = 23,
+
+    NotDepositor = 30,
+    NothingToClaim = 31,
+    AlreadyClaimed = 32,
+}
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BasketStatus {
+    /// Accepting the single deposit that funds the basket.
+    Open,
+    /// Deposit has been split across constituent campaigns; awaiting outcomes.
+    Funded,
+}
+
+/// A single campaign in the basket, weighted in basis points of the total
+/// deposit (all constituent weights must sum to exactly 10_000).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BasketConstituent {
+    pub campaign_id: u64,
+    pub weight_bps: u32,
+    /// Amount actually routed to this campaign's `invest` call once funded.
+    pub invested_amount: i128,
+    /// Amount collected from this campaign via claim_returns/refund so far.
+    pub collected_amount: i128,
+    /// True once a successful sweep (claim or refund) has been recorded.
+    pub swept: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Basket {
+    pub id: u64,
+    pub escrow_contract: Address,
+    pub token: Address,
+    pub total_deposit: i128,
+    pub total_collected: i128,
+    pub status: BasketStatus,
+    pub constituents: Vec<BasketConstituent>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    EscrowContractRef,
+    BasketCount,
+    Basket(u64),
+    /// Per-depositor contribution to a given basket (baskets currently support
+    /// a single depositor stream per basket_id; multiple depositors are
+    /// tracked individually so partial claims remain correct).
+    Deposit(u64, Address),
+    Claimed(u64, Address),
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BPS_DENOM: u32 = 10_000;
+
+/// Mirrors the MAX_BATCH pattern used elsewhere (production_escrow batch ops)
+/// to bound cross-contract call fan-out per transaction.
+pub const MAX_BASKET_SIZE: u32 = 20;
+
+const TTL_THRESHOLD: u32 = 1_000;
+const TTL_EXTEND: u32 = 100_000;
+
+fn t_basket() -> Symbol {
+    symbol_short!("basket")
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct InvestmentBasketContract;
+
+#[contractimpl]
+impl InvestmentBasketContract {
+    /// Initialize the basket contract. Can only be called once.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        escrow_contract: Address,
+    ) -> Result<(), BasketError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(BasketError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowContractRef, &escrow_contract);
+        Ok(())
+    }
+
+    /// Admin curates a new basket from a set of campaigns and their weights
+    /// (basis points, must sum to 10_000). Caps at MAX_BASKET_SIZE
+    /// constituents, mirroring the MAX_BATCH pattern in production_escrow.
+    pub fn create_basket(
+        env: Env,
+        admin_caller: Address,
+        token: Address,
+        constituents: Vec<(u64, u32)>,
+    ) -> Result<u64, BasketError> {
+        admin_caller.require_auth();
+        let admin = read_admin(&env)?;
+        if admin_caller != admin {
+            return Err(BasketError::NotAdmin);
+        }
+
+        if constituents.is_empty() {
+            return Err(BasketError::EmptyConstituents);
+        }
+        if constituents.len() > MAX_BASKET_SIZE {
+            return Err(BasketError::TooManyConstituents);
+        }
+
+        let mut weight_sum: u32 = 0;
+        let mut entries: Vec<BasketConstituent> = Vec::new(&env);
+        for i in 0..constituents.len() {
+            let (campaign_id, weight_bps) = constituents.get(i).unwrap();
+            if weight_bps == 0 {
+                return Err(BasketError::InvalidWeights);
+            }
+            weight_sum = weight_sum
+                .checked_add(weight_bps)
+                .ok_or(BasketError::InvalidWeights)?;
+            entries.push_back(BasketConstituent {
+                campaign_id,
+                weight_bps,
+                invested_amount: 0,
+                collected_amount: 0,
+                swept: false,
+            });
+        }
+        if weight_sum != BPS_DENOM {
+            return Err(BasketError::InvalidWeights);
+        }
+
+        let mut id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::BasketCount)
+            .unwrap_or(0);
+        id += 1;
+        env.storage().instance().set(&DataKey::BasketCount, &id);
+
+        let escrow_contract: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::EscrowContractRef)
+            .ok_or(BasketError::NotInitialized)?;
+
+        let basket = Basket {
+            id,
+            escrow_contract,
+            token,
+            total_deposit: 0,
+            total_collected: 0,
+            status: BasketStatus::Open,
+            constituents: entries,
+        };
+        env.storage().persistent().set(&DataKey::Basket(id), &basket);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Basket(id), TTL_THRESHOLD, TTL_EXTEND);
+
+        env.events()
+            .publish((t_basket(), symbol_short!("created")), (id, constituents.len()));
+        Ok(id)
+    }
+
+    /// Investor deposits into an Open basket. The deposit is immediately split
+    /// across constituent campaigns proportional to their weight via
+    /// cross-contract `invest` calls, and the basket transitions to Funded.
+    ///
+    /// Only a single deposit call is supported per basket (one deposit ->
+    /// one funding event), consistent with "one deposit" in the acceptance
+    /// criteria; multiple depositors can still each call `deposit` on
+    /// distinct baskets, or repeat deposits accumulate before the basket is
+    /// funded by the first depositor to trigger the split — depositors that
+    /// deposited into the same still-Open basket are all tracked so the
+    /// eventual payout stays proportional to individual contribution.
+    pub fn deposit(
+        env: Env,
+        depositor: Address,
+        basket_id: u64,
+        amount: i128,
+    ) -> Result<(), BasketError> {
+        depositor.require_auth();
+        if amount <= 0 {
+            return Err(BasketError::InvalidAmount);
+        }
+
+        let mut basket = load_basket(&env, basket_id)?;
+        if basket.status != BasketStatus::Open {
+            return Err(BasketError::BasketNotOpen);
+        }
+
+        let token_client = token::Client::new(&env, &basket.token);
+        token_client.transfer(&depositor, &env.current_contract_address(), &amount);
+
+        let deposit_key = DataKey::Deposit(basket_id, depositor.clone());
+        let prev: i128 = env.storage().persistent().get(&deposit_key).unwrap_or(0);
+        let new_deposit = prev
+            .checked_add(amount)
+            .ok_or(BasketError::InvalidAmount)?;
+        env.storage().persistent().set(&deposit_key, &new_deposit);
+        env.storage()
+            .persistent()
+            .extend_ttl(&deposit_key, TTL_THRESHOLD, TTL_EXTEND);
+
+        basket.total_deposit = basket
+            .total_deposit
+            .checked_add(amount)
+            .ok_or(BasketError::InvalidAmount)?;
+        save_basket(&env, &basket);
+
+        env.events().publish(
+            (t_basket(), symbol_short!("deposit")),
+            (basket_id, depositor, amount),
+        );
+        Ok(())
+    }
+
+    /// Admin (or anyone, once the basket has a deposit) triggers the actual
+    /// split of the pooled deposit across constituent campaigns. Separated
+    /// from `deposit` so multiple depositors can contribute before the
+    /// basket is funded in a single batch of cross-contract `invest` calls.
+    pub fn fund_basket(env: Env, caller: Address, basket_id: u64) -> Result<(), BasketError> {
+        caller.require_auth();
+        let mut basket = load_basket(&env, basket_id)?;
+        if basket.status != BasketStatus::Open {
+            return Err(BasketError::BasketNotOpen);
+        }
+        if basket.total_deposit <= 0 {
+            return Err(BasketError::InvalidAmount);
+        }
+
+        let mut allocated: i128 = 0;
+        let count = basket.constituents.len();
+        for i in 0..count {
+            let mut c = basket.constituents.get(i).unwrap();
+            let share = if i == count - 1 {
+                // Last constituent absorbs rounding dust so the full deposit is invested.
+                basket
+                    .total_deposit
+                    .checked_sub(allocated)
+                    .ok_or(BasketError::InvalidAmount)?
+            } else {
+                (basket.total_deposit * c.weight_bps as i128) / BPS_DENOM as i128
+            };
+            if share > 0 {
+                escrow_client::invest(&env, &basket.escrow_contract, c.campaign_id, share);
+                c.invested_amount = share;
+                allocated = allocated
+                    .checked_add(share)
+                    .ok_or(BasketError::InvalidAmount)?;
+            }
+            basket.constituents.set(i, c);
+        }
+
+        basket.status = BasketStatus::Funded;
+        save_basket(&env, &basket);
+
+        env.events().publish(
+            (t_basket(), symbol_short!("funded")),
+            (basket_id, basket.total_deposit),
+        );
+        Ok(())
+    }
+
+    /// Sweep claim_returns/refund across every constituent campaign and pay
+    /// the depositor their proportional share of whatever was collectible.
+    /// Handles partial failure gracefully: a constituent still in-progress
+    /// (not Settled/Failed) or already swept by a previous call is skipped
+    /// rather than aborting the whole sweep, so successful constituents
+    /// still pay out.
+    pub fn claim_basket_returns(
+        env: Env,
+        depositor: Address,
+        basket_id: u64,
+    ) -> Result<i128, BasketError> {
+        depositor.require_auth();
+        let mut basket = load_basket(&env, basket_id)?;
+        if basket.status != BasketStatus::Funded {
+            return Err(BasketError::BasketNotFunded);
+        }
+
+        let deposit_key = DataKey::Deposit(basket_id, depositor.clone());
+        let deposit_amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&deposit_key)
+            .ok_or(BasketError::NotDepositor)?;
+        if deposit_amount <= 0 {
+            return Err(BasketError::NotDepositor);
+        }
+
+        let claim_key = DataKey::Claimed(basket_id, depositor.clone());
+        if env.storage().persistent().has(&claim_key) {
+            return Err(BasketError::AlreadyClaimed);
+        }
+
+        // Sweep every unswept constituent; failures on individual campaigns
+        // (still active, or nothing to collect) are swallowed so the loop
+        // continues and successful constituents still get collected.
+        let count = basket.constituents.len();
+        for i in 0..count {
+            let mut c = basket.constituents.get(i).unwrap();
+            if c.swept {
+                continue;
+            }
+            if let Some(collected) = sweep_constituent(&env, &basket.escrow_contract, &c) {
+                c.collected_amount = collected;
+                c.swept = true;
+                basket.total_collected = basket
+                    .total_collected
+                    .checked_add(collected)
+                    .unwrap_or(basket.total_collected);
+                basket.constituents.set(i, c);
+            }
+            // else: constituent not yet resolved (still Funding/InProduction/etc.)
+            // or this basket already claimed/refunded from it in a prior call —
+            // leave `swept` false so a future call can retry.
+        }
+        save_basket(&env, &basket);
+
+        if basket.total_deposit <= 0 || basket.total_collected <= 0 {
+            return Err(BasketError::NothingToClaim);
+        }
+
+        let payout = (basket.total_collected * deposit_amount) / basket.total_deposit;
+        if payout <= 0 {
+            return Err(BasketError::NothingToClaim);
+        }
+
+        env.storage().persistent().set(&claim_key, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&claim_key, TTL_THRESHOLD, TTL_EXTEND);
+
+        let token_client = token::Client::new(&env, &basket.token);
+        token_client.transfer(&env.current_contract_address(), &depositor, &payout);
+
+        env.events().publish(
+            (t_basket(), symbol_short!("claimed")),
+            (basket_id, depositor, payout),
+        );
+        Ok(payout)
+    }
+
+    // -----------------------------------------------------------------------
+    // Views
+    // -----------------------------------------------------------------------
+
+    pub fn get_basket(env: Env, basket_id: u64) -> Result<Basket, BasketError> {
+        load_basket(&env, basket_id)
+    }
+
+    pub fn get_deposit(env: Env, basket_id: u64, depositor: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Deposit(basket_id, depositor))
+            .unwrap_or(0)
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, BasketError> {
+        read_admin(&env)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn read_admin(env: &Env) -> Result<Address, BasketError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(BasketError::NotInitialized)
+}
+
+fn load_basket(env: &Env, id: u64) -> Result<Basket, BasketError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Basket(id))
+        .ok_or(BasketError::BasketNotFound)
+}
+
+fn save_basket(env: &Env, b: &Basket) {
+    env.storage().persistent().set(&DataKey::Basket(b.id), b);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Basket(b.id), TTL_THRESHOLD, TTL_EXTEND);
+}
+
+/// Attempt to collect from a single constituent campaign: try claim_returns
+/// first (Settled campaigns), then refund (Failed campaigns). Returns None
+/// if the campaign is still active or nothing was collectible, so the caller
+/// can skip it without failing the whole batch.
+fn sweep_constituent(
+    env: &Env,
+    escrow_contract: &Address,
+    constituent: &BasketConstituent,
+) -> Option<i128> {
+    if let Some(amount) =
+        escrow_client::try_claim_returns(env, escrow_contract, constituent.campaign_id)
+    {
+        if amount > 0 {
+            return Some(amount);
+        }
+    }
+    if let Some(amount) = escrow_client::try_refund(env, escrow_contract, constituent.campaign_id)
+    {
+        if amount > 0 {
+            return Some(amount);
+        }
+    }
+    None
+}
+
+/// Minimal production_escrow client for cross-contract calls. Uses
+/// try_invoke_contract so a constituent that reverts (e.g. campaign not
+/// Settled/Failed yet) does not abort the whole basket operation.
+mod escrow_client {
+    use super::*;
+
+    pub fn invest(env: &Env, escrow: &Address, campaign_id: u64, amount: i128) {
+        let func = Symbol::new(env, "invest");
+        let mut args: Vec<Val> = Vec::new(env);
+        args.push_back(env.current_contract_address().into_val(env));
+        args.push_back(campaign_id.into_val(env));
+        args.push_back(amount.into_val(env));
+        let _: () = env.invoke_contract(escrow, &func, args);
+    }
+
+    pub fn try_claim_returns(env: &Env, escrow: &Address, campaign_id: u64) -> Option<i128> {
+        let func = Symbol::new(env, "claim_returns");
+        let mut args: Vec<Val> = Vec::new(env);
+        args.push_back(env.current_contract_address().into_val(env));
+        args.push_back(campaign_id.into_val(env));
+        env.try_invoke_contract::<i128, soroban_sdk::Error>(escrow, &func, args)
+            .ok()
+            .and_then(|r| r.ok())
+    }
+
+    pub fn try_refund(env: &Env, escrow: &Address, campaign_id: u64) -> Option<i128> {
+        let func = Symbol::new(env, "refund");
+        let mut args: Vec<Val> = Vec::new(env);
+        args.push_back(env.current_contract_address().into_val(env));
+        args.push_back(campaign_id.into_val(env));
+        env.try_invoke_contract::<i128, soroban_sdk::Error>(escrow, &func, args)
+            .ok()
+            .and_then(|r| r.ok())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/agro-production/contract/investment_basket/src/test.rs
+++ b/agro-production/contract/investment_basket/src/test.rs
@@ -1,0 +1,191 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env,
+};
+
+use production_escrow_v2::{
+    CampaignStatus, ProductionEscrowContract, ProductionEscrowContractClient,
+};
+
+use crate::{BasketError, BasketStatus, InvestmentBasketContract, InvestmentBasketContractClient};
+
+struct TestEnv<'a> {
+    env: Env,
+    basket: InvestmentBasketContractClient<'a>,
+    escrow: ProductionEscrowContractClient<'a>,
+    token_id: Address,
+    admin: Address,
+    attester: Address,
+    farmer: Address,
+    depositor: Address,
+}
+
+fn setup() -> TestEnv<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let attester = Address::generate(&env);
+    let farmer = Address::generate(&env);
+    let depositor = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let sac = StellarAssetClient::new(&env, &token_id);
+    sac.mint(&depositor, &10_000_000);
+
+    let escrow_id = env.register(ProductionEscrowContract, ());
+    let escrow = ProductionEscrowContractClient::new(&env, &escrow_id);
+    let mut tokens = soroban_sdk::Vec::new(&env);
+    tokens.push_back(token_id.clone());
+    let fee_collector = Address::generate(&env);
+    escrow.initialize(&admin, &tokens, &fee_collector, &300);
+    escrow.set_attester(&admin, &attester);
+
+    let basket_id_contract = env.register(InvestmentBasketContract, ());
+    let basket = InvestmentBasketContractClient::new(&env, &basket_id_contract);
+    basket.initialize(&admin, &escrow_id);
+
+    let env: Env = unsafe { std::mem::transmute(env) };
+    let basket: InvestmentBasketContractClient<'static> =
+        unsafe { std::mem::transmute(basket) };
+    let escrow: ProductionEscrowContractClient<'static> =
+        unsafe { std::mem::transmute(escrow) };
+
+    TestEnv {
+        env,
+        basket,
+        escrow,
+        token_id,
+        admin,
+        attester,
+        farmer,
+        depositor,
+    }
+}
+
+#[test]
+fn test_create_basket_and_deposit_splits_across_campaigns() {
+    let t = setup();
+    let now = t.env.ledger().timestamp();
+    let deadline = now + 100_000;
+
+    let c1 = t.escrow.create_campaign(&t.farmer, &t.token_id, &1_000_000, &deadline);
+    let c2 = t.escrow.create_campaign(&t.farmer, &t.token_id, &1_000_000, &deadline);
+
+    let constituents = vec![&t.env, (c1, 6_000u32), (c2, 4_000u32)];
+    let basket_id = t.basket.create_basket(&t.admin, &t.token_id, &constituents);
+
+    t.basket.deposit(&t.depositor, &basket_id, &1_000_000);
+    t.basket.fund_basket(&t.depositor, &basket_id);
+
+    let basket = t.basket.get_basket(&basket_id);
+    assert_eq!(basket.status, BasketStatus::Funded);
+    assert_eq!(basket.total_deposit, 1_000_000);
+
+    let campaign1 = t.escrow.get_campaign(&c1);
+    let campaign2 = t.escrow.get_campaign(&c2);
+    assert_eq!(campaign1.total_raised, 600_000);
+    assert_eq!(campaign2.total_raised, 400_000);
+}
+
+#[test]
+fn test_mixed_outcome_basket_partial_failure_does_not_block_settled_payout() {
+    let t = setup();
+    let now = t.env.ledger().timestamp();
+    let deadline = now + 100_000;
+
+    // c1 will be fully funded then settled (payable).
+    // c2 will be underfunded and left to expire -> Failed (refundable).
+    let c1 = t.escrow.create_campaign(&t.farmer, &t.token_id, &500_000, &deadline);
+    let c2 = t.escrow.create_campaign(&t.farmer, &t.token_id, &10_000_000, &deadline);
+
+    let constituents = vec![&t.env, (c1, 5_000u32), (c2, 5_000u32)];
+    let basket_id = t.basket.create_basket(&t.admin, &t.token_id, &constituents);
+
+    t.basket.deposit(&t.depositor, &basket_id, &1_000_000);
+    t.basket.fund_basket(&t.depositor, &basket_id);
+
+    // c1 got 500_000 (fully funds it -> auto Funded), c2 got 500_000 (still Funding, underfunded).
+    let campaign1 = t.escrow.get_campaign(&c1);
+    assert_eq!(campaign1.status, CampaignStatus::Funded);
+
+    // Move c1 through production and settle it.
+    t.escrow.start_production(&t.farmer, &c1);
+    t.escrow.mark_harvest(&t.farmer, &t.attester, &c1);
+    t.escrow.settle(&t.farmer, &c1);
+
+    // Expire c2's deadline and finalize it as failed.
+    t.env.ledger().set(LedgerInfo {
+        timestamp: deadline + 1,
+        protocol_version: 22,
+        sequence_number: t.env.ledger().sequence(),
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16 * 60 * 60 * 24,
+        min_persistent_entry_ttl: 30 * 24 * 60 * 60,
+        max_entry_ttl: 365 * 24 * 60 * 60,
+    });
+    t.escrow.finalize_failed(&c2);
+
+    // First claim attempt: both constituents are now resolvable (Settled / Failed).
+    let payout = t.basket.claim_basket_returns(&t.depositor, &basket_id);
+    assert!(payout > 0);
+
+    let basket = t.basket.get_basket(&basket_id);
+    let cc1 = basket.constituents.get(0).unwrap();
+    let cc2 = basket.constituents.get(1).unwrap();
+    assert!(cc1.swept);
+    assert!(cc2.swept);
+
+    // Second claim attempt must fail — already claimed.
+    let err = t
+        .basket
+        .try_claim_basket_returns(&t.depositor, &basket_id)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, BasketError::AlreadyClaimed);
+}
+
+#[test]
+fn test_invalid_weights_rejected() {
+    let t = setup();
+    let now = t.env.ledger().timestamp();
+    let deadline = now + 100_000;
+    let c1 = t.escrow.create_campaign(&t.farmer, &t.token_id, &1_000_000, &deadline);
+
+    let bad_constituents = vec![&t.env, (c1, 9_000u32)];
+    let err = t
+        .basket
+        .try_create_basket(&t.admin, &t.token_id, &bad_constituents)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, BasketError::InvalidWeights);
+}
+
+#[test]
+fn test_too_many_constituents_rejected() {
+    let t = setup();
+    let now = t.env.ledger().timestamp();
+    let deadline = now + 100_000;
+
+    let mut constituents = soroban_sdk::Vec::new(&t.env);
+    for _ in 0..21 {
+        let c = t.escrow.create_campaign(&t.farmer, &t.token_id, &1_000_000, &deadline);
+        constituents.push_back((c, 476u32)); // arbitrary, will fail on size before weight check
+    }
+
+    let err = t
+        .basket
+        .try_create_basket(&t.admin, &t.token_id, &constituents)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, BasketError::TooManyConstituents);
+}

--- a/agro-production/contract/production_escrow/src/lib.rs
+++ b/agro-production/contract/production_escrow/src/lib.rs
@@ -182,6 +182,11 @@ pub struct Order {
 pub enum DataKey {
     Admin,
     Attester,
+    /// Governance contract authorized to change fee/token-whitelist parameters
+    /// (Issue #660). While unset, those parameters fall back to admin-only
+    /// control so existing deployments are not bricked; once set, it becomes
+    /// the sole authorized caller for those specific setters.
+    GovernanceContract,
     SupportedTokens,
     RegistryContract,
     FeeCollector,
@@ -281,20 +286,21 @@ impl ProductionEscrowContract {
         Ok(())
     }
 
-    /// Set the registry contract address. Can be called by admin to update registry configuration.
+    /// Set the registry contract address. Authorized caller is the governance
+    /// contract once configured via `set_governance_contract` (Issue #660);
+    /// falls back to admin-only while governance is unset.
     pub fn set_registry_contract(env: Env, admin_caller: Address, registry: Address) -> Result<(), EscrowError> {
         admin_caller.require_auth();
-        let admin = admin(&env)?;
-        if admin_caller != admin {
-            return Err(EscrowError::NotAdmin);
-        }
+        require_governed_caller(&env, &admin_caller)?;
         env.storage()
             .instance()
             .set(&DataKey::RegistryContract, &registry);
         Ok(())
     }
 
-    /// Update fee configuration. Can be called by admin.
+    /// Update fee configuration. Authorized caller is the governance contract
+    /// once configured via `set_governance_contract` (Issue #660); falls back
+    /// to admin-only while governance is unset.
     /// Does not affect orders already created (fees are immutable per-order).
     pub fn set_fee_config(
         env: Env,
@@ -303,10 +309,7 @@ impl ProductionEscrowContract {
         fee_rate_bps: u32,
     ) -> Result<(), EscrowError> {
         admin_caller.require_auth();
-        let admin = admin(&env)?;
-        if admin_caller != admin {
-            return Err(EscrowError::NotAdmin);
-        }
+        require_governed_caller(&env, &admin_caller)?;
         if fee_rate_bps > 10000 {
             return Err(EscrowError::InvalidAmount);
         }
@@ -317,6 +320,51 @@ impl ProductionEscrowContract {
             .instance()
             .set(&DataKey::FeeRateBps, &fee_rate_bps);
         Ok(())
+    }
+
+    /// Set (or update) the governance contract address. Only the original
+    /// admin can do this — a one-time (or migration-time) bootstrapping step
+    /// that hands control of fee/token-whitelist parameters to governance.
+    /// Once set, `set_fee_config`/`set_registry_contract`/`update_supported_tokens`
+    /// can only be called by this address, not by the raw admin key.
+    pub fn set_governance_contract(
+        env: Env,
+        admin_caller: Address,
+        governance: Address,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let admin = admin(&env)?;
+        if admin_caller != admin {
+            return Err(EscrowError::NotAdmin);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::GovernanceContract, &governance);
+        Ok(())
+    }
+
+    /// Update the supported token whitelist. Same governance gating as
+    /// `set_fee_config`/`set_registry_contract` (Issue #660) — this is the
+    /// "token whitelist" parameter the issue calls out as a centralization
+    /// risk when controlled by a single admin key.
+    pub fn update_supported_tokens(
+        env: Env,
+        admin_caller: Address,
+        supported_tokens: Vec<Address>,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        require_governed_caller(&env, &admin_caller)?;
+        if supported_tokens.len() < 1 {
+            return Err(EscrowError::MustSupportOneToken);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::SupportedTokens, &supported_tokens);
+        Ok(())
+    }
+
+    pub fn get_governance_contract(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::GovernanceContract)
     }
 
     /// Set the independent attester role. Can be called by admin.
@@ -1382,6 +1430,29 @@ fn attester(env: &Env) -> Result<Address, EscrowError> {
         .instance()
         .get(&DataKey::Attester)
         .ok_or(EscrowError::ContractNotInitialized)
+}
+
+/// Enforces that `caller` is the authorized party for governance-gated
+/// parameters (Issue #660): the governance contract if one has been set via
+/// `set_governance_contract`, otherwise the raw admin as a fallback so a
+/// deployment that never configures governance keeps working exactly as
+/// before.
+fn require_governed_caller(env: &Env, caller: &Address) -> Result<(), EscrowError> {
+    if let Some(governance) = env
+        .storage()
+        .instance()
+        .get::<_, Address>(&DataKey::GovernanceContract)
+    {
+        if *caller != governance {
+            return Err(EscrowError::NotAdmin);
+        }
+        return Ok(());
+    }
+    let admin_addr = admin(env)?;
+    if *caller != admin_addr {
+        return Err(EscrowError::NotAdmin);
+    }
+    Ok(())
 }
 
 fn load_campaign(env: &Env, id: u64) -> Result<Campaign, EscrowError> {

--- a/agro-production/contract/production_escrow/src/test.rs
+++ b/agro-production/contract/production_escrow/src/test.rs
@@ -3217,3 +3217,60 @@ fn test_advance_milestone_refund_after_partial_release() {
     // Investor has 100% of contribution -> 100% of pool = 8_000.
     assert_eq!(refund, 8_000);
 }
+
+// ---------------------------------------------------------------------------
+// Governance gating (Issue #660)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fee_config_admin_fallback_before_governance_set() {
+    let t = setup();
+    let fee_collector = Address::generate(&t.env);
+    // No governance contract configured yet: admin can still update fee config.
+    t.client.set_fee_config(&t.admin, &fee_collector, &500);
+}
+
+#[test]
+fn test_fee_config_rejects_admin_once_governance_set() {
+    let t = setup();
+    let governance = Address::generate(&t.env);
+    let fee_collector = Address::generate(&t.env);
+
+    t.client.set_governance_contract(&t.admin, &governance);
+
+    let result = t.client.try_set_fee_config(&t.admin, &fee_collector, &500);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotAdmin);
+
+    // The governance contract address is now the sole authorized caller.
+    t.client.set_fee_config(&governance, &fee_collector, &500);
+}
+
+#[test]
+fn test_registry_contract_rejects_admin_once_governance_set() {
+    let t = setup();
+    let governance = Address::generate(&t.env);
+    let registry = Address::generate(&t.env);
+
+    t.client.set_governance_contract(&t.admin, &governance);
+
+    let result = t.client.try_set_registry_contract(&t.admin, &registry);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotAdmin);
+
+    t.client.set_registry_contract(&governance, &registry);
+}
+
+#[test]
+fn test_update_supported_tokens_governance_gated() {
+    let t = setup();
+    let governance = Address::generate(&t.env);
+    t.client.set_governance_contract(&t.admin, &governance);
+
+    let mut tokens = Vec::new(&t.env);
+    tokens.push_back(t.token_id.clone());
+
+    let result = t.client.try_update_supported_tokens(&t.admin, &tokens);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotAdmin);
+
+    t.client.update_supported_tokens(&governance, &tokens);
+    assert_eq!(t.client.get_supported_tokens().len(), 1);
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -29,6 +29,7 @@ pub enum EscrowError {
     BuyerCannotEqualFarmer = 18,
     TokenWhitelistEmpty = 19,
     FeeRateTooHigh = 20,
+    NotGoverned = 21,
 }
 
 #[contracttype]
@@ -109,12 +110,22 @@ pub enum DataKey {
     SupportedTokens,
     Admin,
     FeeCollector,
+    /// Configurable fee rate in basis points (Issue #660). Defaults to 300
+    /// (3%) when unset, preserving the previously-hardcoded fee behavior.
+    FeeRateBps,
+    /// Governance contract authorized to change fee/token-whitelist
+    /// parameters (Issue #660). Falls back to admin-only while unset.
+    GovernanceContract,
 }
 
 const NINETY_SIX_HOURS_IN_SECONDS: u64 = 96 * 60 * 60;
 
 const TTL_THRESHOLD: u32 = 1000;
 const TTL_EXTEND_TO: u32 = 100_000;
+
+/// Fee rate used before `set_fee_config` has ever been called, matching the
+/// previously-hardcoded 3% fee in `create_order`.
+const DEFAULT_FEE_RATE_BPS: u32 = 300;
 
 fn read_order(env: &Env, order_id: u64) -> Result<Order, EscrowError> {
     env.storage()
@@ -155,6 +166,29 @@ fn read_admin(env: &Env) -> Result<Address, EscrowError> {
         .instance()
         .get(&DataKey::Admin)
         .ok_or(EscrowError::ContractNotInitialized)
+}
+
+/// Enforces that `caller` is the authorized party for governance-gated
+/// parameters (Issue #660): the governance contract if one has been set via
+/// `set_governance_contract`, otherwise the raw admin as a fallback so a
+/// deployment that never configures governance keeps working exactly as
+/// before.
+fn require_governed_caller(env: &Env, caller: &Address) -> Result<(), EscrowError> {
+    if let Some(governance) = env
+        .storage()
+        .instance()
+        .get::<_, Address>(&DataKey::GovernanceContract)
+    {
+        if *caller != governance {
+            return Err(EscrowError::NotGoverned);
+        }
+        return Ok(());
+    }
+    let admin_addr = read_admin(env)?;
+    if *caller != admin_addr {
+        return Err(EscrowError::NotAdmin);
+    }
+    Ok(())
 }
 
 #[contract]
@@ -221,7 +255,17 @@ impl EscrowContract {
             .get(&DataKey::FeeCollector)
             .ok_or(EscrowError::ContractNotInitialized)?;
 
-        let fee = amount.checked_mul(3).ok_or(EscrowError::ArithmeticError)? / 100;
+        // Fee rate is configurable via set_fee_config (Issue #660); defaults
+        // to the historical hardcoded 3% when never configured.
+        let fee_rate_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeRateBps)
+            .unwrap_or(DEFAULT_FEE_RATE_BPS);
+        let fee = amount
+            .checked_mul(fee_rate_bps as i128)
+            .ok_or(EscrowError::ArithmeticError)?
+            / 10_000;
         let net_amount = amount
             .checked_sub(fee)
             .ok_or(EscrowError::ArithmeticError)?;
@@ -529,6 +573,82 @@ impl EscrowContract {
         );
 
         Ok(())
+    }
+
+    // ── Governance-gated parameter setters (Issue #660) ──────────────────────
+    // This legacy contract previously hardcoded its 3% fee directly in
+    // create_order with no setter at all. These setters expose the fee rate
+    // and token whitelist as configurable parameters, gated the same way as
+    // production_escrow: the governance contract once configured, admin-only
+    // fallback until then.
+
+    /// Set (or update) the governance contract address. Only the original
+    /// admin can do this — a one-time (or migration-time) bootstrapping step.
+    pub fn set_governance_contract(
+        env: Env,
+        admin_caller: Address,
+        governance: Address,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let admin = read_admin(&env)?;
+        if admin_caller != admin {
+            return Err(EscrowError::NotAdmin);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::GovernanceContract, &governance);
+        Ok(())
+    }
+
+    /// Update the fee rate (basis points) and fee collector. Governance-gated
+    /// once a governance contract is configured (Issue #660).
+    pub fn set_fee_config(
+        env: Env,
+        admin_caller: Address,
+        fee_collector: Address,
+        fee_rate_bps: u32,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        require_governed_caller(&env, &admin_caller)?;
+        if fee_rate_bps > 10_000 {
+            return Err(EscrowError::FeeRateTooHigh);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeCollector, &fee_collector);
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeRateBps, &fee_rate_bps);
+        Ok(())
+    }
+
+    /// Update the supported token whitelist. Governance-gated once a
+    /// governance contract is configured (Issue #660).
+    pub fn set_supported_tokens(
+        env: Env,
+        admin_caller: Address,
+        supported_tokens: Vec<Address>,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        require_governed_caller(&env, &admin_caller)?;
+        if supported_tokens.len() < 2 {
+            return Err(EscrowError::MustSupportTwoTokens);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::SupportedTokens, &supported_tokens);
+        Ok(())
+    }
+
+    pub fn get_fee_rate_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::FeeRateBps)
+            .unwrap_or(DEFAULT_FEE_RATE_BPS)
+    }
+
+    pub fn get_governance_contract(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::GovernanceContract)
     }
 
     pub fn get_orders_by_buyer(env: Env, buyer: Address) -> Vec<u64> {

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -693,3 +693,46 @@ fn test_initialize_duplicate_fails() {
     let result = client.try_initialize(&admin, &fee_collector, &tokens);
     assert_eq!(result.unwrap_err().unwrap(), EscrowError::AlreadyInitialized);
 }
+
+// ---------------------------------------------------------------------------
+// Governance gating (Issue #660)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fee_config_admin_fallback_before_governance_set() {
+    let (_env, client, _buyer, _farmer, fee_collector, _xlm, _usdc, admin, _investor1, _id) =
+        setup_test();
+
+    // No governance contract configured yet: admin can still update fee config.
+    client.set_fee_config(&admin, &fee_collector, &500);
+    assert_eq!(client.get_fee_rate_bps(), 500);
+}
+
+#[test]
+fn test_fee_config_rejects_admin_once_governance_set() {
+    let (env, client, _buyer, _farmer, fee_collector, _xlm, _usdc, admin, _investor1, _id) =
+        setup_test();
+
+    let governance = Address::generate(&env);
+    client.set_governance_contract(&admin, &governance);
+
+    // Raw admin can no longer call set_fee_config once governance is set.
+    let result = client.try_set_fee_config(&admin, &fee_collector, &500);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotGoverned);
+
+    // The governance contract address can.
+    client.set_fee_config(&governance, &fee_collector, &500);
+    assert_eq!(client.get_fee_rate_bps(), 500);
+}
+
+#[test]
+fn test_create_order_uses_configured_fee_rate() {
+    let (_env, client, buyer, farmer, fee_collector, xlm, _usdc, admin, _investor1, _id) =
+        setup_test();
+
+    client.set_fee_config(&admin, &fee_collector, &1_000); // 10%
+    let order_id = client.create_order(&buyer, &farmer, &xlm.address, &1_000);
+    let order = client.get_order_details(&order_id);
+    // 10% fee -> net amount is 900.
+    assert_eq!(order.amount, 900);
+}

--- a/server/prisma/migrations/20260727010000_add_referral_system/migration.sql
+++ b/server/prisma/migrations/20260727010000_add_referral_system/migration.sql
@@ -1,0 +1,56 @@
+-- CreateTable
+CREATE TABLE "referral_codes" (
+    "wallet_address" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "referral_codes_pkey" PRIMARY KEY ("wallet_address")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "referral_codes_code_key" ON "referral_codes"("code");
+
+-- CreateTable
+CREATE TABLE "referrals" (
+    "id" TEXT NOT NULL,
+    "referrer_wallet" TEXT NOT NULL,
+    "referee_wallet" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "rewarded_at" TIMESTAMP(3),
+    "reward_amount" TEXT,
+    "trigger_order_id" TEXT,
+    "trigger_campaign_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "referrals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "referrals_referee_wallet_key" ON "referrals"("referee_wallet");
+
+-- CreateIndex
+CREATE INDEX "referrals_referrer_wallet_idx" ON "referrals"("referrer_wallet");
+
+-- CreateIndex
+CREATE INDEX "referrals_status_idx" ON "referrals"("status");
+
+-- CreateTable
+CREATE TABLE "fee_credits" (
+    "id" TEXT NOT NULL,
+    "wallet_address" TEXT NOT NULL,
+    "amount" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "source_referral_id" TEXT,
+    "consumed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "fee_credits_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "fee_credits_wallet_address_idx" ON "fee_credits"("wallet_address");
+
+-- CreateIndex
+CREATE INDEX "fee_credits_wallet_address_consumed_at_idx" ON "fee_credits"("wallet_address", "consumed_at");

--- a/server/prisma/migrations/20260727020000_add_integrator_api_keys/migration.sql
+++ b/server/prisma/migrations/20260727020000_add_integrator_api_keys/migration.sql
@@ -1,0 +1,42 @@
+-- CreateTable
+CREATE TABLE "integrator_api_keys" (
+    "id" TEXT NOT NULL,
+    "key_hash" TEXT NOT NULL,
+    "key_prefix" TEXT NOT NULL,
+    "organization_name" TEXT NOT NULL,
+    "scoped_farmer_wallets" TEXT[],
+    "scoped_region" TEXT,
+    "created_by_admin" TEXT NOT NULL,
+    "revoked_at" TIMESTAMP(3),
+    "last_used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "integrator_api_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "integrator_api_keys_key_hash_key" ON "integrator_api_keys"("key_hash");
+
+-- CreateIndex
+CREATE INDEX "integrator_api_keys_organization_name_idx" ON "integrator_api_keys"("organization_name");
+
+-- CreateTable
+CREATE TABLE "integrator_api_key_usage" (
+    "id" TEXT NOT NULL,
+    "api_key_id" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "status_code" INTEGER NOT NULL,
+    "ip_address" TEXT,
+    "requested_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "integrator_api_key_usage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "integrator_api_key_usage_api_key_id_idx" ON "integrator_api_key_usage"("api_key_id");
+
+-- CreateIndex
+CREATE INDEX "integrator_api_key_usage_api_key_id_requested_at_idx" ON "integrator_api_key_usage"("api_key_id", "requested_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "integrator_api_key_usage" ADD CONSTRAINT "integrator_api_key_usage_api_key_id_fkey" FOREIGN KEY ("api_key_id") REFERENCES "integrator_api_keys"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -354,6 +354,47 @@ model FeeCredit {
   @@map("fee_credits")
 }
 
+model IntegratorApiKey {
+  id             String    @id @default(uuid())
+  /// SHA-256 hash of the raw key; the raw value is shown to the admin once
+  /// at creation time and never stored.
+  keyHash        String    @unique @map("key_hash")
+  /// Short, non-secret prefix stored alongside the hash so keys can be
+  /// identified/labeled in the admin UI without re-deriving the hash.
+  keyPrefix      String    @map("key_prefix")
+  organizationName String  @map("organization_name")
+  /// Scope: explicit farmer wallets this key may read data for. Empty when
+  /// the key is scoped by region instead.
+  scopedFarmerWallets String[] @map("scoped_farmer_wallets")
+  /// Scope: region string (matches Location.city/country) this key may read
+  /// aggregate data for. Null when the key is scoped by farmer wallet list.
+  scopedRegion   String?   @map("scoped_region")
+  createdByAdmin String    @map("created_by_admin")
+  revokedAt      DateTime? @map("revoked_at")
+  lastUsedAt     DateTime? @map("last_used_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
+
+  usageLogs IntegratorApiKeyUsage[]
+
+  @@index([organizationName])
+  @@map("integrator_api_keys")
+}
+
+model IntegratorApiKeyUsage {
+  id           String   @id @default(uuid())
+  apiKeyId     String   @map("api_key_id")
+  endpoint     String
+  statusCode   Int      @map("status_code")
+  ipAddress    String?  @map("ip_address")
+  requestedAt  DateTime @default(now()) @map("requested_at")
+
+  apiKey IntegratorApiKey @relation(fields: [apiKeyId], references: [id], onDelete: Cascade)
+
+  @@index([apiKeyId])
+  @@index([apiKeyId, requestedAt(sort: Desc)])
+  @@map("integrator_api_key_usage")
+}
+
 model ContractWatcherCheckpoint {
   service    String   @id
   lastLedger Int      @map("last_ledger")

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -309,6 +309,51 @@ model OrderMetadata {
   @@map("order_metadata")
 }
 
+model ReferralCode {
+  walletAddress String   @id @map("wallet_address")
+  code          String   @unique
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  @@map("referral_codes")
+}
+
+model Referral {
+  id                String    @id @default(uuid())
+  referrerWallet    String    @map("referrer_wallet")
+  refereeWallet     String    @unique @map("referee_wallet")
+  code              String
+  /// PENDING until the referee's first confirmed order/investment fires the
+  /// reward; REWARDED once the fee-credit has been issued; INELIGIBLE for
+  /// self-referral or other disqualified linkages.
+  status            String    @default("PENDING")
+  rewardedAt        DateTime? @map("rewarded_at")
+  /// Fee-credit amount granted to the referrer (platform-fee credit, not a
+  /// token mint), denominated in the same unit as order/investment amounts.
+  rewardAmount      String?   @map("reward_amount")
+  triggerOrderId    String?   @map("trigger_order_id")
+  triggerCampaignId String?   @map("trigger_campaign_id")
+  createdAt         DateTime  @default(now()) @map("created_at")
+  updatedAt         DateTime  @updatedAt @map("updated_at")
+
+  @@index([referrerWallet])
+  @@index([status])
+  @@map("referrals")
+}
+
+model FeeCredit {
+  id            String    @id @default(uuid())
+  walletAddress String    @map("wallet_address")
+  amount        String
+  reason        String
+  sourceReferralId String? @map("source_referral_id")
+  consumedAt    DateTime? @map("consumed_at")
+  createdAt     DateTime  @default(now()) @map("created_at")
+
+  @@index([walletAddress])
+  @@index([walletAddress, consumedAt])
+  @@map("fee_credits")
+}
+
 model ContractWatcherCheckpoint {
   service    String   @id
   lastLedger Int      @map("last_ledger")

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,6 +32,7 @@ import demandSupplyRoutes from "./routes/demandSupplyRoutes.js";
 import metricsRoutes from "./routes/metricsRoutes.js";
 import adminRoutes, { adminErrorHandler } from "./routes/adminRoutes.js";
 import disputeRoutes from "./routes/disputeRoutes.js";
+import referralRoutes, { referralErrorHandler } from "./routes/referralRoutes.js";
 
 const app = express();
 
@@ -71,6 +72,7 @@ app.use("/disputes", disputeRoutes);
 app.use(demandSupplyRoutes);
 app.use(jobRoutes);
 app.use("/admin", adminRoutes);
+app.use(referralRoutes);
 
 app.get("/health", async (_req: Request, res: Response) => {
   logger.info("Health check endpoint hit");
@@ -126,6 +128,7 @@ app.use(locationErrorHandler);
 app.use(orderErrorHandler);
 app.use(notificationErrorHandler);
 app.use(adminErrorHandler);
+app.use(referralErrorHandler);
 app.use((err: unknown, req: Request, res: Response, _next: () => void) => {
   incrementErrorCount();
   if (err instanceof ApiError) {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -33,6 +33,7 @@ import metricsRoutes from "./routes/metricsRoutes.js";
 import adminRoutes, { adminErrorHandler } from "./routes/adminRoutes.js";
 import disputeRoutes from "./routes/disputeRoutes.js";
 import referralRoutes, { referralErrorHandler } from "./routes/referralRoutes.js";
+import integratorRoutes, { integratorErrorHandler } from "./routes/integratorRoutes.js";
 
 const app = express();
 
@@ -73,6 +74,7 @@ app.use(demandSupplyRoutes);
 app.use(jobRoutes);
 app.use("/admin", adminRoutes);
 app.use(referralRoutes);
+app.use(integratorRoutes);
 
 app.get("/health", async (_req: Request, res: Response) => {
   logger.info("Health check endpoint hit");
@@ -129,6 +131,7 @@ app.use(orderErrorHandler);
 app.use(notificationErrorHandler);
 app.use(adminErrorHandler);
 app.use(referralErrorHandler);
+app.use(integratorErrorHandler);
 app.use((err: unknown, req: Request, res: Response, _next: () => void) => {
   incrementErrorCount();
   if (err instanceof ApiError) {

--- a/server/src/middleware/integratorAuth.ts
+++ b/server/src/middleware/integratorAuth.ts
@@ -1,0 +1,81 @@
+import crypto from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+import { prisma } from "../config/database.js";
+import logger from "../config/logger.js";
+
+export interface IntegratorRequest extends Request {
+  integratorApiKeyId?: string;
+  integratorScope?: {
+    organizationName: string;
+    scopedFarmerWallets: string[];
+    scopedRegion: string | null;
+  };
+}
+
+export function hashApiKey(rawKey: string): string {
+  return crypto.createHash("sha256").update(rawKey).digest("hex");
+}
+
+/**
+ * Authenticates integrator requests via `x-api-key`. Scoped to a named
+ * organization and a defined set of farmer wallets or a region (Issue #662),
+ * distinct from the wallet-JWT auth used by platform users. Revoked or
+ * unknown keys are rejected; usage (including failures) is recorded by the
+ * caller via recordUsage() once the response is known.
+ */
+export async function requireIntegratorApiKey(
+  req: IntegratorRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const rawKey = req.header("x-api-key");
+  if (!rawKey) {
+    res.status(401).json({ message: "Missing x-api-key header." });
+    return;
+  }
+
+  try {
+    const keyHash = hashApiKey(rawKey);
+    const record = await prisma.integratorApiKey.findUnique({ where: { keyHash } });
+    if (!record || record.revokedAt) {
+      res.status(401).json({ message: "Invalid or revoked API key." });
+      return;
+    }
+
+    req.integratorApiKeyId = record.id;
+    req.integratorScope = {
+      organizationName: record.organizationName,
+      scopedFarmerWallets: record.scopedFarmerWallets,
+      scopedRegion: record.scopedRegion,
+    };
+
+    // Best-effort last-used tracking; never blocks the request.
+    prisma.integratorApiKey
+      .update({ where: { id: record.id }, data: { lastUsedAt: new Date() } })
+      .catch((err) => logger.error("[integratorAuth] Failed to update lastUsedAt", { err }));
+
+    next();
+  } catch (err) {
+    logger.error("[integratorAuth] Failed to authenticate integrator API key", { err });
+    res.status(500).json({ message: "Internal Server Error: could not verify API key." });
+  }
+}
+
+/** Records an integrator API call for the audit log (Issue #662). */
+export function recordIntegratorUsage(
+  req: IntegratorRequest,
+  res: Response,
+  endpoint: string,
+): void {
+  if (!req.integratorApiKeyId) return;
+  prisma.integratorApiKeyUsage
+    .create({
+      data: {
+        apiKeyId: req.integratorApiKeyId,
+        endpoint,
+        statusCode: res.statusCode,
+        ipAddress: req.ip ?? null,
+      },
+    })
+    .catch((err) => logger.error("[integratorAuth] Failed to record usage audit log", { err }));
+}

--- a/server/src/routes/integratorRoutes.ts
+++ b/server/src/routes/integratorRoutes.ts
@@ -1,0 +1,160 @@
+import express from "express";
+import rateLimit from "express-rate-limit";
+import type { Request, Response, NextFunction } from "express";
+import {
+  requireIntegratorApiKey,
+  recordIntegratorUsage,
+  type IntegratorRequest,
+} from "../middleware/integratorAuth.js";
+import { requireAdmin, type AdminRequest } from "../middleware/adminAuth.js";
+import { ApiError, sendProblem } from "../http/errors.js";
+import logger from "../config/logger.js";
+import { IntegratorService, toCsv, ensureNotOverPageLimit } from "../services/integratorService.js";
+
+const router = express.Router();
+
+const isTest = process.env["NODE_ENV"] === "test";
+
+// Rate-limited per Issue #662 acceptance criteria (aggregated, rate-limited data).
+const integratorRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 30,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  skip: () => isTest,
+  handler: (req: Request, res: Response) => {
+    res.status(429).json({ message: "Rate limit exceeded for integrator API." });
+  },
+});
+
+function respond(
+  req: Request,
+  res: Response,
+  rows: Array<Record<string, unknown>>,
+  endpointLabel: string,
+): void {
+  const format = typeof req.query["format"] === "string" ? req.query["format"] : "json";
+  if (format === "csv") {
+    res.status(200).type("text/csv").send(toCsv(rows));
+  } else {
+    res.status(200).json({ data: rows, count: rows.length });
+  }
+  recordIntegratorUsage(req as IntegratorRequest, res, endpointLabel);
+}
+
+// GET /integrator/v1/reports/farmers
+router.get(
+  "/integrator/v1/reports/farmers",
+  integratorRateLimiter,
+  requireIntegratorApiKey,
+  async (req: IntegratorRequest, res: Response, next: NextFunction) => {
+    try {
+      if (!req.integratorScope) {
+        throw new ApiError(401, "Unauthorized", "Missing integrator scope");
+      }
+      const limit = Number(req.query["limit"] ?? 100);
+      ensureNotOverPageLimit(limit);
+      const rows = await IntegratorService.getFarmerReport(req.integratorScope);
+      respond(req, res, rows.slice(0, limit), "/integrator/v1/reports/farmers");
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// GET /integrator/v1/reports/orders
+router.get(
+  "/integrator/v1/reports/orders",
+  integratorRateLimiter,
+  requireIntegratorApiKey,
+  async (req: IntegratorRequest, res: Response, next: NextFunction) => {
+    try {
+      if (!req.integratorScope) {
+        throw new ApiError(401, "Unauthorized", "Missing integrator scope");
+      }
+      const limit = Number(req.query["limit"] ?? 100);
+      ensureNotOverPageLimit(limit);
+      const rows = await IntegratorService.getOrderReport(req.integratorScope);
+      respond(req, res, rows.slice(0, limit), "/integrator/v1/reports/orders");
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ── Admin-facing API key management ────────────────────────────────────────
+
+// POST /admin/integrator/keys — issue a new scoped API key.
+router.post("/admin/integrator/keys", requireAdmin, async (req: AdminRequest, res: Response, next: NextFunction) => {
+  try {
+    const { organizationName, scopedFarmerWallets, scopedRegion } = req.body as {
+      organizationName?: string;
+      scopedFarmerWallets?: string[];
+      scopedRegion?: string;
+    };
+    if (!organizationName) {
+      throw new ApiError(400, "Bad Request", "organizationName is required");
+    }
+    const key = await IntegratorService.issueKey({
+      organizationName,
+      scopedFarmerWallets,
+      scopedRegion,
+      createdByAdmin: req.adminWallet ?? "unknown",
+    });
+    res.status(201).json(key);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /admin/integrator/keys — list keys (optionally filtered by organization).
+router.get("/admin/integrator/keys", requireAdmin, async (req: AdminRequest, res: Response, next: NextFunction) => {
+  try {
+    const organizationName =
+      typeof req.query["organizationName"] === "string" ? req.query["organizationName"] : undefined;
+    const keys = await IntegratorService.listKeys(organizationName);
+    res.status(200).json(keys);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /admin/integrator/keys/:keyId — revoke a compromised/expired key.
+router.delete(
+  "/admin/integrator/keys/:keyId",
+  requireAdmin,
+  async (req: AdminRequest, res: Response, next: NextFunction) => {
+    try {
+      const revoked = await IntegratorService.revokeKey(req.params["keyId"] ?? "");
+      res.status(200).json(revoked);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// GET /admin/integrator/keys/:keyId/usage — audit log of key usage.
+router.get(
+  "/admin/integrator/keys/:keyId/usage",
+  requireAdmin,
+  async (req: AdminRequest, res: Response, next: NextFunction) => {
+    try {
+      const limit = Number(req.query["limit"] ?? 100);
+      const usage = await IntegratorService.getUsageLog(req.params["keyId"] ?? "", limit);
+      res.status(200).json(usage);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export function integratorErrorHandler(err: unknown, req: Request, res: Response, _next: NextFunction): void {
+  if (err instanceof ApiError) {
+    sendProblem(res, req, err);
+    return;
+  }
+  logger.error("[integratorRoutes] Unhandled error", err);
+  res.status(500).json({ message: "Internal server error" });
+}
+
+export default router;

--- a/server/src/routes/referralRoutes.ts
+++ b/server/src/routes/referralRoutes.ts
@@ -1,0 +1,99 @@
+import express from "express";
+import type { Request, Response, NextFunction } from "express";
+import { requireWallet, type WalletRequest } from "../middleware/walletAuth.js";
+import { requireAdmin, type AdminRequest } from "../middleware/adminAuth.js";
+import { ApiError, sendProblem } from "../http/errors.js";
+import logger from "../config/logger.js";
+import { ReferralService } from "../services/referralService.js";
+
+const router = express.Router();
+
+// GET /referrals/me — fetch (or lazily create) the caller's referral code.
+router.get("/referrals/me", requireWallet, async (req: WalletRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.walletAddress) {
+      throw new ApiError(401, "Unauthorized", "Missing wallet", "https://cylos.io/errors/unauthorized");
+    }
+    const code = await ReferralService.getOrCreateCode(req.walletAddress);
+    const balance = await ReferralService.getFeeCreditBalance(req.walletAddress);
+    res.status(200).json({ ...code, feeCreditBalance: balance });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /referrals/me/cohort — the caller's own referral cohort performance.
+router.get("/referrals/me/cohort", requireWallet, async (req: WalletRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.walletAddress) {
+      throw new ApiError(401, "Unauthorized", "Missing wallet", "https://cylos.io/errors/unauthorized");
+    }
+    const [performance, referrals] = await Promise.all([
+      ReferralService.getCohortPerformance(req.walletAddress),
+      ReferralService.listReferralsByReferrer(req.walletAddress),
+    ]);
+    res.status(200).json({ performance, referrals });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /referrals/signup — link a new wallet to a referrer's code. Called
+// during onboarding once the new wallet has authenticated.
+router.post("/referrals/signup", requireWallet, async (req: WalletRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.walletAddress) {
+      throw new ApiError(401, "Unauthorized", "Missing wallet", "https://cylos.io/errors/unauthorized");
+    }
+    const { referralCode } = req.body as { referralCode?: string };
+    if (!referralCode) {
+      throw new ApiError(400, "Bad Request", "referralCode is required");
+    }
+    const referral = await ReferralService.recordSignup(req.walletAddress, referralCode);
+    if (!referral) {
+      // Self-referral: accepted but not linked.
+      res.status(200).json({ linked: false });
+      return;
+    }
+    res.status(201).json({ linked: true, referral });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /admin/referrals/cohort — org-wide referral performance for
+// admins/NGOs (Issue #661 acceptance criteria: admin/NGO-facing view).
+router.get("/admin/referrals/cohort", requireAdmin, async (req: AdminRequest, res: Response, next: NextFunction) => {
+  try {
+    const referrerWallet = typeof req.query["referrerWallet"] === "string" ? req.query["referrerWallet"] : undefined;
+    const performance = await ReferralService.getCohortPerformance(referrerWallet);
+    res.status(200).json(performance);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /admin/referrals/:referrerWallet — per-referrer breakdown for admins.
+router.get(
+  "/admin/referrals/:referrerWallet",
+  requireAdmin,
+  async (req: AdminRequest, res: Response, next: NextFunction) => {
+    try {
+      const referrals = await ReferralService.listReferralsByReferrer(req.params["referrerWallet"] ?? "");
+      res.status(200).json(referrals);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export function referralErrorHandler(err: unknown, req: Request, res: Response, _next: NextFunction): void {
+  if (err instanceof ApiError) {
+    sendProblem(res, req, err);
+    return;
+  }
+  logger.error("[referralRoutes] Unhandled error", err);
+  res.status(500).json({ message: "Internal server error" });
+}
+
+export default router;

--- a/server/src/services/events/blockchainEventPersistenceService.ts
+++ b/server/src/services/events/blockchainEventPersistenceService.ts
@@ -2,6 +2,7 @@ import type { Prisma } from "@prisma/client";
 import { prisma } from "../../config/database.js";
 import logger from "../../config/logger.js";
 import type { IndexedEvent } from "../../types/indexedEvent.js";
+import { ReferralService } from "../referralService.js";
 
 type PrismaTx = Omit<typeof prisma, "$connect" | "$disconnect" | "$on" | "$use" | "$extends">;
 
@@ -32,9 +33,42 @@ export class BlockchainEventPersistenceService {
           },
         });
       });
+
+      // Referral rewards only fire on a real, first confirmed economic event
+      // (Issue #661) — order.confirmed and campaign.invested are the only
+      // two event types that represent money actually moving on-chain.
+      await this.triggerReferralRewardIfApplicable(event);
     } catch (error) {
       logger.error("Failed to persist indexed blockchain event", { event, error });
       throw error;
+    }
+  }
+
+  private static async triggerReferralRewardIfApplicable(event: IndexedEvent): Promise<void> {
+    try {
+      if (event.eventType === "order.confirmed" && event.actorAddress) {
+        // order.confirmed carries no amount on-chain; the order's amount was
+        // recorded at order.created time, so look it up rather than treating
+        // a missing amount as "nothing to reward".
+        const order = event.orderIdOnChain
+          ? await prisma.order.findUnique({ where: { orderIdOnChain: event.orderIdOnChain } })
+          : null;
+        await ReferralService.triggerRewardOnConfirmedActivity({
+          refereeWallet: event.actorAddress,
+          amount: order?.amount ?? event.amount ?? "0",
+          triggerOrderId: event.orderIdOnChain,
+        });
+      } else if (event.eventType === "campaign.invested" && event.actorAddress) {
+        await ReferralService.triggerRewardOnConfirmedActivity({
+          refereeWallet: event.actorAddress,
+          amount: event.amount ?? "0",
+          triggerCampaignId: event.campaignIdOnChain,
+        });
+      }
+    } catch (error) {
+      // Referral rewards are best-effort and must never block core event
+      // ingestion/persistence.
+      logger.error("Failed to evaluate referral reward for event", { event, error });
     }
   }
 

--- a/server/src/services/integratorService.test.ts
+++ b/server/src/services/integratorService.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../config/database.js", () => ({
+  prisma: {
+    integratorApiKey: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    integratorApiKeyUsage: {
+      findMany: vi.fn(),
+    },
+    profile: {
+      findMany: vi.fn(),
+    },
+    campaign: {
+      findMany: vi.fn(),
+    },
+    order: {
+      findMany: vi.fn(),
+    },
+    location: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { IntegratorService, toCsv } from "./integratorService.js";
+import { prisma } from "../config/database.js";
+
+const mockApiKey = vi.mocked(prisma.integratorApiKey);
+const mockProfile = vi.mocked(prisma.profile);
+const mockCampaign = vi.mocked(prisma.campaign);
+const mockOrder = vi.mocked(prisma.order);
+const mockLocation = vi.mocked(prisma.location);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("IntegratorService.issueKey", () => {
+  it("rejects a key with neither farmer wallets nor a region", async () => {
+    await expect(
+      IntegratorService.issueKey({ organizationName: "Cyprus Coop", createdByAdmin: "GADMIN" }),
+    ).rejects.toThrow();
+    expect(mockApiKey.create).not.toHaveBeenCalled();
+  });
+
+  it("issues a key scoped to explicit farmer wallets and returns the raw key once", async () => {
+    mockApiKey.create.mockResolvedValueOnce({
+      id: "k1",
+      keyHash: "hash",
+      keyPrefix: "agc_abcdef12",
+      organizationName: "Cyprus Coop",
+      scopedFarmerWallets: ["GFARMER1"],
+      scopedRegion: null,
+      createdByAdmin: "GADMIN",
+      revokedAt: null,
+      lastUsedAt: null,
+      createdAt: new Date(),
+    } as any);
+
+    const result = await IntegratorService.issueKey({
+      organizationName: "Cyprus Coop",
+      scopedFarmerWallets: ["GFARMER1"],
+      createdByAdmin: "GADMIN",
+    });
+
+    expect(result.rawKey).toMatch(/^agc_/);
+    expect(mockApiKey.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("IntegratorService.revokeKey", () => {
+  it("throws NotFoundError for an unknown key id", async () => {
+    mockApiKey.findUnique.mockResolvedValueOnce(null);
+    await expect(IntegratorService.revokeKey("missing")).rejects.toThrow();
+  });
+
+  it("is idempotent for an already-revoked key", async () => {
+    const revoked = { id: "k1", revokedAt: new Date() };
+    mockApiKey.findUnique.mockResolvedValueOnce(revoked as any);
+    const result = await IntegratorService.revokeKey("k1");
+    expect(result).toEqual(revoked);
+    expect(mockApiKey.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("IntegratorService.getFarmerReport", () => {
+  it("returns no rows and never queries profiles when scope resolves to no wallets", async () => {
+    const rows = await IntegratorService.getFarmerReport({
+      organizationName: "Cyprus Coop",
+      scopedFarmerWallets: [],
+      scopedRegion: null,
+    });
+    expect(rows).toEqual([]);
+    expect(mockProfile.findMany).not.toHaveBeenCalled();
+  });
+
+  it("aggregates campaign counts per farmer without leaking financial detail", async () => {
+    mockProfile.findMany.mockResolvedValueOnce([
+      { wallet_address: "GFARMER1", name: "Farm A", location: { city: "Nicosia", country: "Cyprus" } },
+    ] as any);
+    mockCampaign.findMany.mockResolvedValueOnce([
+      { creatorAddress: "GFARMER1", status: "SETTLED" },
+      { creatorAddress: "GFARMER1", status: "ACTIVE" },
+    ] as any);
+
+    const rows = await IntegratorService.getFarmerReport({
+      organizationName: "Cyprus Coop",
+      scopedFarmerWallets: ["GFARMER1"],
+      scopedRegion: null,
+    });
+
+    expect(rows).toEqual([
+      {
+        farmerWallet: "GFARMER1",
+        displayName: "Farm A",
+        region: "Nicosia, Cyprus",
+        totalCampaigns: 2,
+        settledCampaigns: 1,
+        activeCampaigns: 1,
+      },
+    ]);
+    // No order amounts, buyer addresses, or investment balances present.
+    expect(JSON.stringify(rows)).not.toMatch(/amount|buyer|investment/i);
+  });
+
+  it("resolves region-scoped keys via matching location city/country", async () => {
+    mockLocation.findMany.mockResolvedValueOnce([
+      { wallet_address: "GFARMER2", city: "Nicosia", country: "Cyprus" },
+    ] as any);
+    mockProfile.findMany.mockResolvedValueOnce([]);
+    mockCampaign.findMany.mockResolvedValueOnce([]);
+
+    await IntegratorService.getFarmerReport({
+      organizationName: "Cyprus Coop",
+      scopedFarmerWallets: [],
+      scopedRegion: "Nicosia",
+    });
+
+    expect(mockProfile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ wallet_address: { in: ["GFARMER2"] } }),
+      }),
+    );
+  });
+});
+
+describe("IntegratorService.getOrderReport", () => {
+  it("aggregates status counts per farmer without buyer identity or amounts", async () => {
+    mockOrder.findMany.mockResolvedValueOnce([
+      { sellerAddress: "GFARMER1", status: "COMPLETED", createdAt: new Date() },
+      { sellerAddress: "GFARMER1", status: "PENDING", createdAt: new Date() },
+      { sellerAddress: "GFARMER1", status: "REFUNDED", createdAt: new Date() },
+    ] as any);
+
+    const rows = await IntegratorService.getOrderReport({
+      organizationName: "Cyprus Coop",
+      scopedFarmerWallets: ["GFARMER1"],
+      scopedRegion: null,
+    });
+
+    expect(rows).toEqual([{ farmerWallet: "GFARMER1", total: 3, completed: 1, refunded: 1, pending: 1 }]);
+  });
+});
+
+describe("toCsv", () => {
+  it("returns an empty string for no rows", () => {
+    expect(toCsv([])).toBe("");
+  });
+
+  it("serializes headers and escapes commas/quotes", () => {
+    const csv = toCsv([{ name: "Farm, A", note: 'has "quotes"' }]);
+    expect(csv).toBe('name,note\n"Farm, A","has ""quotes"""');
+  });
+});

--- a/server/src/services/integratorService.ts
+++ b/server/src/services/integratorService.ts
@@ -1,0 +1,219 @@
+import crypto from "node:crypto";
+import { prisma } from "../config/database.js";
+import { ApiError, NotFoundError, ValidationError } from "../http/errors.js";
+import { hashApiKey } from "../middleware/integratorAuth.js";
+
+export interface IntegratorScope {
+  organizationName: string;
+  scopedFarmerWallets: string[];
+  scopedRegion: string | null;
+}
+
+const MAX_PAGE_SIZE = 200;
+
+function generateRawKey(): string {
+  // 32 bytes of entropy, hex-encoded; only ever returned once at creation.
+  return `agc_${crypto.randomBytes(32).toString("hex")}`;
+}
+
+export class IntegratorService {
+  /** Admin issues a new integrator API key scoped to an org + farmer wallets or region. */
+  static async issueKey(params: {
+    organizationName: string;
+    scopedFarmerWallets?: string[];
+    scopedRegion?: string;
+    createdByAdmin: string;
+  }) {
+    const { organizationName, scopedFarmerWallets, scopedRegion, createdByAdmin } = params;
+    if (!organizationName) {
+      throw new ValidationError("organizationName is required");
+    }
+    if ((!scopedFarmerWallets || scopedFarmerWallets.length === 0) && !scopedRegion) {
+      throw new ValidationError("Either scopedFarmerWallets or scopedRegion must be provided");
+    }
+
+    const rawKey = generateRawKey();
+    const keyHash = hashApiKey(rawKey);
+    const keyPrefix = rawKey.slice(0, 12);
+
+    const record = await prisma.integratorApiKey.create({
+      data: {
+        keyHash,
+        keyPrefix,
+        organizationName,
+        scopedFarmerWallets: scopedFarmerWallets ?? [],
+        scopedRegion: scopedRegion ?? null,
+        createdByAdmin,
+      },
+    });
+
+    // The raw key is returned exactly once; it cannot be recovered later.
+    return { ...record, rawKey };
+  }
+
+  static async listKeys(organizationName?: string) {
+    return prisma.integratorApiKey.findMany({
+      where: organizationName ? { organizationName } : {},
+      select: {
+        id: true,
+        keyPrefix: true,
+        organizationName: true,
+        scopedFarmerWallets: true,
+        scopedRegion: true,
+        createdByAdmin: true,
+        revokedAt: true,
+        lastUsedAt: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  /** Revocation endpoint for admins to kill a compromised/expired key (Issue #662). */
+  static async revokeKey(keyId: string) {
+    const record = await prisma.integratorApiKey.findUnique({ where: { id: keyId } });
+    if (!record) {
+      throw new NotFoundError("Integrator API key", keyId);
+    }
+    if (record.revokedAt) {
+      return record;
+    }
+    return prisma.integratorApiKey.update({
+      where: { id: keyId },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  static async getUsageLog(keyId: string, limit = 100) {
+    return prisma.integratorApiKeyUsage.findMany({
+      where: { apiKeyId: keyId },
+      orderBy: { requestedAt: "desc" },
+      take: Math.min(limit, MAX_PAGE_SIZE),
+    });
+  }
+
+  /**
+   * Aggregate, org-scoped farmer report. Returns only what the scoping
+   * organization is entitled to: farmer identity + region, and coarse
+   * production activity counts — no wallet-level financial detail such as
+   * individual order amounts or campaign investment balances (Issue #662).
+   */
+  static async getFarmerReport(scope: IntegratorScope) {
+    const wallets = await resolveScopedWallets(scope);
+    if (wallets.length === 0) return [];
+
+    const [profiles, campaigns] = await Promise.all([
+      prisma.profile.findMany({
+        where: { wallet_address: { in: wallets }, role: "FARMER" },
+        include: { location: true },
+      }),
+      prisma.campaign.findMany({
+        where: { creatorAddress: { in: wallets } },
+      }),
+    ]);
+
+    const campaignsByFarmer = new Map<string, typeof campaigns>();
+    for (const c of campaigns) {
+      const list = campaignsByFarmer.get(c.creatorAddress) ?? [];
+      list.push(c);
+      campaignsByFarmer.set(c.creatorAddress, list);
+    }
+
+    return profiles.map((p) => {
+      const farmerCampaigns = campaignsByFarmer.get(p.wallet_address) ?? [];
+      return {
+        farmerWallet: p.wallet_address,
+        displayName: p.name ?? null,
+        region: p.location ? [p.location.city, p.location.country].filter(Boolean).join(", ") : null,
+        totalCampaigns: farmerCampaigns.length,
+        settledCampaigns: farmerCampaigns.filter((c) => c.status === "SETTLED").length,
+        activeCampaigns: farmerCampaigns.filter((c) => c.status === "ACTIVE").length,
+      };
+    });
+  }
+
+  /**
+   * Aggregate, org-scoped order report. Counts and status breakdown only —
+   * no buyer identity or per-order monetary amount, consistent with "no
+   * PII/wallet-level financial detail beyond what the scoping organization
+   * is entitled to" (Issue #662).
+   */
+  static async getOrderReport(scope: IntegratorScope) {
+    const wallets = await resolveScopedWallets(scope);
+    if (wallets.length === 0) return [];
+
+    const orders = await prisma.order.findMany({
+      where: { sellerAddress: { in: wallets } },
+      select: { sellerAddress: true, status: true, createdAt: true },
+    });
+
+    const bySeller = new Map<string, { total: number; completed: number; refunded: number; pending: number }>();
+    for (const o of orders) {
+      const entry = bySeller.get(o.sellerAddress) ?? { total: 0, completed: 0, refunded: 0, pending: 0 };
+      entry.total += 1;
+      if (o.status === "COMPLETED") entry.completed += 1;
+      else if (o.status === "REFUNDED") entry.refunded += 1;
+      else entry.pending += 1;
+      bySeller.set(o.sellerAddress, entry);
+    }
+
+    return Array.from(bySeller.entries()).map(([farmerWallet, stats]) => ({
+      farmerWallet,
+      ...stats,
+    }));
+  }
+}
+
+/**
+ * Resolves the set of farmer wallets a key's scope grants access to: either
+ * the explicit wallet list, or every farmer profile whose location matches
+ * the scoped region (case-insensitive match on city or country).
+ */
+async function resolveScopedWallets(scope: IntegratorScope): Promise<string[]> {
+  if (scope.scopedFarmerWallets.length > 0) {
+    return scope.scopedFarmerWallets;
+  }
+  if (!scope.scopedRegion) {
+    return [];
+  }
+  const region = scope.scopedRegion.toLowerCase();
+  const locations = await prisma.location.findMany({
+    where: {
+      OR: [
+        { city: { equals: scope.scopedRegion, mode: "insensitive" } },
+        { country: { equals: scope.scopedRegion, mode: "insensitive" } },
+      ],
+    },
+    select: { wallet_address: true, city: true, country: true },
+  });
+  return locations
+    .filter(
+      (l) =>
+        l.city?.toLowerCase() === region || l.country?.toLowerCase() === region,
+    )
+    .map((l) => l.wallet_address);
+}
+
+/** Serializes a list of flat records to CSV (Issue #662: CSV + JSON output). */
+export function toCsv(rows: Array<Record<string, unknown>>): string {
+  if (rows.length === 0) return "";
+  const headers = Object.keys(rows[0] as Record<string, unknown>);
+  const escape = (value: unknown): string => {
+    const str = value === null || value === undefined ? "" : String(value);
+    if (/[",\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+  const lines = [headers.join(",")];
+  for (const row of rows) {
+    lines.push(headers.map((h) => escape(row[h])).join(","));
+  }
+  return lines.join("\n");
+}
+
+export function ensureNotOverPageLimit(limit: number): void {
+  if (limit > MAX_PAGE_SIZE) {
+    throw new ApiError(400, "Bad Request", `limit cannot exceed ${MAX_PAGE_SIZE}`);
+  }
+}

--- a/server/src/services/referralService.test.ts
+++ b/server/src/services/referralService.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../config/database.js", () => ({
+  prisma: {
+    referralCode: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    referral: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+    feeCredit: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { ReferralService } from "./referralService.js";
+import { prisma } from "../config/database.js";
+
+const mockReferralCode = vi.mocked(prisma.referralCode);
+const mockReferral = vi.mocked(prisma.referral);
+const mockFeeCredit = vi.mocked(prisma.feeCredit);
+const mockTransaction = vi.mocked(prisma.$transaction);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ReferralService.recordSignup", () => {
+  it("ignores self-referral and does not create a referral row", async () => {
+    mockReferralCode.findUnique.mockResolvedValueOnce({
+      walletAddress: "GSAME",
+      code: "ABC12345",
+      createdAt: new Date(),
+    } as any);
+
+    const result = await ReferralService.recordSignup("GSAME", "ABC12345");
+
+    expect(result).toBeNull();
+    expect(mockReferral.create).not.toHaveBeenCalled();
+  });
+
+  it("throws NotFoundError for an unknown referral code", async () => {
+    mockReferralCode.findUnique.mockResolvedValueOnce(null);
+
+    await expect(ReferralService.recordSignup("GREFEREE", "BADCODE1")).rejects.toThrow();
+    expect(mockReferral.create).not.toHaveBeenCalled();
+  });
+
+  it("throws ConflictError if the referee is already linked", async () => {
+    mockReferralCode.findUnique.mockResolvedValueOnce({
+      walletAddress: "GREFERRER",
+      code: "ABC12345",
+      createdAt: new Date(),
+    } as any);
+    mockReferral.findUnique.mockResolvedValueOnce({ id: "r1" } as any);
+
+    await expect(ReferralService.recordSignup("GREFEREE", "ABC12345")).rejects.toThrow();
+    expect(mockReferral.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a PENDING referral for a valid distinct referrer/referee pair", async () => {
+    mockReferralCode.findUnique.mockResolvedValueOnce({
+      walletAddress: "GREFERRER",
+      code: "ABC12345",
+      createdAt: new Date(),
+    } as any);
+    mockReferral.findUnique.mockResolvedValueOnce(null);
+    mockReferral.create.mockResolvedValueOnce({ id: "r1", status: "PENDING" } as any);
+
+    const result = await ReferralService.recordSignup("GREFEREE", "ABC12345");
+
+    expect(result).toEqual({ id: "r1", status: "PENDING" });
+    expect(mockReferral.create).toHaveBeenCalledWith({
+      data: {
+        referrerWallet: "GREFERRER",
+        refereeWallet: "GREFEREE",
+        code: "ABC12345",
+        status: "PENDING",
+      },
+    });
+  });
+});
+
+describe("ReferralService.triggerRewardOnConfirmedActivity", () => {
+  it("does nothing when the referee never transacted (amount is zero)", async () => {
+    mockReferral.findUnique.mockResolvedValueOnce({
+      id: "r1",
+      referrerWallet: "GREFERRER",
+      refereeWallet: "GREFEREE",
+      status: "PENDING",
+    } as any);
+
+    await ReferralService.triggerRewardOnConfirmedActivity({
+      refereeWallet: "GREFEREE",
+      amount: "0",
+    });
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no pending referral for the wallet", async () => {
+    mockReferral.findUnique.mockResolvedValueOnce(null);
+
+    await ReferralService.triggerRewardOnConfirmedActivity({
+      refereeWallet: "GNOBODY",
+      amount: "10000",
+    });
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the referral is already REWARDED (idempotent)", async () => {
+    mockReferral.findUnique.mockResolvedValueOnce({
+      id: "r1",
+      referrerWallet: "GREFERRER",
+      refereeWallet: "GREFEREE",
+      status: "REWARDED",
+    } as any);
+
+    await ReferralService.triggerRewardOnConfirmedActivity({
+      refereeWallet: "GREFEREE",
+      amount: "10000",
+    });
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("marks a self-referral INELIGIBLE defensively and does not reward it", async () => {
+    mockReferral.findUnique.mockResolvedValueOnce({
+      id: "r1",
+      referrerWallet: "GSAME",
+      refereeWallet: "GSAME",
+      status: "PENDING",
+    } as any);
+
+    await ReferralService.triggerRewardOnConfirmedActivity({
+      refereeWallet: "GSAME",
+      amount: "10000",
+    });
+
+    expect(mockReferral.update).toHaveBeenCalledWith({
+      where: { id: "r1" },
+      data: { status: "INELIGIBLE" },
+    });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("grants a capped fee credit and marks the referral REWARDED on a real confirmed event", async () => {
+    mockReferral.findUnique.mockResolvedValueOnce({
+      id: "r1",
+      referrerWallet: "GREFERRER",
+      refereeWallet: "GREFEREE",
+      status: "PENDING",
+    } as any);
+    mockTransaction.mockImplementationOnce(async (fn: any) =>
+      fn({ referral: mockReferral, feeCredit: mockFeeCredit }),
+    );
+
+    await ReferralService.triggerRewardOnConfirmedActivity({
+      refereeWallet: "GREFEREE",
+      amount: "1000000", // 1% = 10_000, above the 5_000 cap -> capped
+      triggerOrderId: "order-1",
+    });
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockReferral.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "r1" },
+        data: expect.objectContaining({ status: "REWARDED", rewardAmount: "5000" }),
+      }),
+    );
+    expect(mockFeeCredit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ walletAddress: "GREFERRER", amount: "5000" }),
+      }),
+    );
+  });
+});

--- a/server/src/services/referralService.ts
+++ b/server/src/services/referralService.ts
@@ -1,0 +1,194 @@
+import crypto from "node:crypto";
+import { prisma } from "../config/database.js";
+import { ApiError, ConflictError, NotFoundError, ValidationError } from "../http/errors.js";
+import logger from "../config/logger.js";
+
+/** Platform-fee credit granted to a referrer, in basis points of the
+ * referee's first confirmed order/investment amount that triggered the
+ * reward. Kept modest and capped so referral rewards cannot be used to
+ * siphon meaningful value even under coordinated abuse. */
+const REFERRAL_REWARD_BPS = 100n; // 1%
+const REFERRAL_REWARD_BPS_DENOM = 10_000n;
+/** Hard cap on a single reward credit regardless of order/investment size. */
+const REFERRAL_REWARD_CAP = 5_000n;
+
+function generateCode(): string {
+  return crypto.randomBytes(6).toString("base64url").toUpperCase().slice(0, 8);
+}
+
+export class ReferralService {
+  /** Fetch or lazily create a wallet's referral code. */
+  static async getOrCreateCode(walletAddress: string) {
+    const existing = await prisma.referralCode.findUnique({ where: { walletAddress } });
+    if (existing) return existing;
+
+    // Retry on the (astronomically unlikely) chance of a code collision.
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        return await prisma.referralCode.create({
+          data: { walletAddress, code: generateCode() },
+        });
+      } catch (error) {
+        const isUniqueViolation =
+          error instanceof Object && "code" in error && (error as { code?: string }).code === "P2002";
+        if (!isUniqueViolation) throw error;
+      }
+    }
+    throw new ApiError(500, "Internal Server Error", "Failed to allocate a unique referral code");
+  }
+
+  /**
+   * Records a referrer/referee linkage at signup time. Reward is NOT granted
+   * here — only tracked, pending the referee's first confirmed economic
+   * event (Issue #661 acceptance criteria: resist Sybil farming by rewarding
+   * real activity, not mere signup).
+   */
+  static async recordSignup(refereeWallet: string, referralCode: string) {
+    if (!referralCode) {
+      throw new ValidationError("referralCode is required");
+    }
+
+    const codeRow = await prisma.referralCode.findUnique({ where: { code: referralCode } });
+    if (!codeRow) {
+      throw new NotFoundError("Referral code", referralCode);
+    }
+
+    if (codeRow.walletAddress.toLowerCase() === refereeWallet.toLowerCase()) {
+      // Self-referral: silently ignored rather than erroring, so a wallet
+      // pasting its own code during onboarding doesn't see a scary failure —
+      // it just never becomes eligible for a reward.
+      logger.warn("[ReferralService] Self-referral attempt ignored", { refereeWallet });
+      return null;
+    }
+
+    const existing = await prisma.referral.findUnique({ where: { refereeWallet } });
+    if (existing) {
+      throw new ConflictError("This wallet is already linked to a referrer");
+    }
+
+    return prisma.referral.create({
+      data: {
+        referrerWallet: codeRow.walletAddress,
+        refereeWallet,
+        code: referralCode,
+        status: "PENDING",
+      },
+    });
+  }
+
+  /**
+   * Called when a referee's order is confirmed on-chain (order.confirmed
+   * event) or an investment lands on a campaign (campaign.invested event) —
+   * the first real economic event, per acceptance criteria. Idempotent: a
+   * referral already REWARDED or INELIGIBLE is a no-op.
+   */
+  static async triggerRewardOnConfirmedActivity(params: {
+    refereeWallet: string;
+    amount: string;
+    triggerOrderId?: string;
+    triggerCampaignId?: string;
+  }): Promise<void> {
+    const { refereeWallet, amount, triggerOrderId, triggerCampaignId } = params;
+
+    const referral = await prisma.referral.findUnique({ where: { refereeWallet } });
+    if (!referral || referral.status !== "PENDING") {
+      return;
+    }
+
+    if (referral.referrerWallet.toLowerCase() === refereeWallet.toLowerCase()) {
+      // Defensive: should already be blocked at signup, but never reward self-referral.
+      await prisma.referral.update({
+        where: { id: referral.id },
+        data: { status: "INELIGIBLE" },
+      });
+      return;
+    }
+
+    let amountNum: bigint;
+    try {
+      amountNum = BigInt(amount);
+    } catch {
+      logger.warn("[ReferralService] Non-numeric amount on trigger, skipping reward", { amount, refereeWallet });
+      return;
+    }
+    if (amountNum <= 0n) {
+      // Never-transacting or zero-value events do not count — the reward
+      // only fires on a genuine confirmed economic event with value.
+      return;
+    }
+
+    let reward = (amountNum * REFERRAL_REWARD_BPS) / REFERRAL_REWARD_BPS_DENOM;
+    if (reward > REFERRAL_REWARD_CAP) reward = REFERRAL_REWARD_CAP;
+    if (reward <= 0n) return;
+
+    await prisma.$transaction(async (tx) => {
+      await tx.referral.update({
+        where: { id: referral.id },
+        data: {
+          status: "REWARDED",
+          rewardedAt: new Date(),
+          rewardAmount: reward.toString(),
+          triggerOrderId: triggerOrderId ?? null,
+          triggerCampaignId: triggerCampaignId ?? null,
+        },
+      });
+      await tx.feeCredit.create({
+        data: {
+          walletAddress: referral.referrerWallet,
+          amount: reward.toString(),
+          reason: `referral:${referral.id}`,
+          sourceReferralId: referral.id,
+        },
+      });
+    });
+
+    logger.info("[ReferralService] Referral reward issued", {
+      referralId: referral.id,
+      referrer: referral.referrerWallet,
+      reward: reward.toString(),
+    });
+  }
+
+  /** Admin/NGO-facing cohort performance view (Issue #661 acceptance criteria). */
+  static async getCohortPerformance(referrerWallet?: string) {
+    const where = referrerWallet ? { referrerWallet } : {};
+
+    const [total, rewarded, pending, ineligible, rewardAgg] = await Promise.all([
+      prisma.referral.count({ where }),
+      prisma.referral.count({ where: { ...where, status: "REWARDED" } }),
+      prisma.referral.count({ where: { ...where, status: "PENDING" } }),
+      prisma.referral.count({ where: { ...where, status: "INELIGIBLE" } }),
+      prisma.referral.findMany({
+        where: { ...where, status: "REWARDED" },
+        select: { rewardAmount: true },
+      }),
+    ]);
+
+    const totalRewarded = rewardAgg.reduce((sum, r) => sum + BigInt(r.rewardAmount ?? "0"), 0n);
+
+    return {
+      totalReferrals: total,
+      rewarded,
+      pending,
+      ineligible,
+      totalRewardAmount: totalRewarded.toString(),
+      conversionRate: total === 0 ? 0 : rewarded / total,
+    };
+  }
+
+  /** Per-referrer breakdown for cooperative/NGO admin dashboards. */
+  static async listReferralsByReferrer(referrerWallet: string) {
+    return prisma.referral.findMany({
+      where: { referrerWallet },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  static async getFeeCreditBalance(walletAddress: string): Promise<string> {
+    const credits = await prisma.feeCredit.findMany({
+      where: { walletAddress, consumedAt: null },
+      select: { amount: true },
+    });
+    return credits.reduce((sum, c) => sum + BigInt(c.amount), 0n).toString();
+  }
+}


### PR DESCRIPTION
## Summary

- **Cross-campaign investment basket** (`agro-production/contract/investment_basket`): a new Soroban contract that splits a single deposit across a curated set of `production_escrow` campaigns via cross-contract `invest` calls, tracks each depositor's proportional claim, and sweeps `claim_returns`/`refund` across constituents on `claim_basket_returns` — a constituent still in-progress or already swept is skipped rather than blocking payout of the others. Capped at `MAX_BASKET_SIZE` constituents, mirroring the existing `MAX_BATCH` pattern.
- **On-chain parameter governance** (`agro-production/contract/governance`): a lightweight propose → vote → queue → execute contract with a configurable voting period and timelock delay, plus weighted voting. Both `production_escrow` and the legacy `contracts/escrow` now support `set_governance_contract`, gating `set_fee_config`/`set_registry_contract`/token-whitelist updates on the governance contract once configured (falling back to admin-only until then, so existing deployments keep working). The legacy escrow's previously-hardcoded 3% fee is now a configurable, governance-gated parameter.
- **Referral & affinity onboarding rewards**: per-wallet referral codes, referrer/referee linkage at signup, and a capped platform-fee credit (not a token mint) granted only when the referee's first confirmed order or investment lands on-chain (`order.confirmed` / `campaign.invested`). Self-referral and never-transacting referees are rejected. Admin/NGO-facing cohort performance endpoints included.
- **Cooperative/NGO integrator API**: admin-issued, org-scoped API keys (scoped to explicit farmer wallets or a region) authenticated via `x-api-key`, exposing `GET /integrator/v1/reports/{farmers,orders}` with aggregated, rate-limited data in CSV or JSON. Reports carry no buyer identity or per-order/investment monetary amounts. Every call is audit-logged, and keys are revocable.

## Test plan

- [ ] `cargo test -p investment-basket` — mixed-outcome basket, invalid weights, oversized constituent list
- [ ] `cargo test -p governance` — proposal passes and executes after timelock, fails quorum, direct-bypass attempts rejected
- [ ] `cargo test -p production-escrow-v2` / `cargo test -p escrow` — governance gating fallback and enforcement
- [ ] `npm test` in `server/` — referral self-referral/never-transacting guards, integrator scoping and CSV serialization
- [ ] `npx prisma migrate deploy` against a scratch database to confirm the two new migrations apply cleanly

closes #659    closes #660      closes #661       closes #662