### PR TITLE
fix(client): authenticate WebSocket connections

### DIFF
--- a/client/src/hooks/useSocket.test.ts
+++ b/client/src/hooks/useSocket.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useSocket } from "./useSocket";
+import { setAccessToken } from "@/lib/authToken";
 
 type MockSocket = {
   send: ReturnType<typeof vi.fn>;
@@ -33,6 +34,7 @@ describe("useSocket Hook", () => {
   });
 
   afterEach(() => {
+    setAccessToken(null);
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
@@ -53,6 +55,33 @@ describe("useSocket Hook", () => {
     });
 
     expect(result.current.isConnected).toBe(true);
+  });
+
+  it("authenticates with the REST access token on every connection", () => {
+    setAccessToken("jwt-access-token");
+    renderHook(() => useSocket());
+
+    act(() => {
+      const socket = webSocketCtor.mock.results[0]?.value as MockSocket;
+      socket.onopen?.(new Event("open"));
+    });
+
+    expect(mockWs.send).toHaveBeenNthCalledWith(
+      1,
+      JSON.stringify({ type: "auth", token: "jwt-access-token" }),
+    );
+
+    act(() => {
+      const socket = webSocketCtor.mock.results[0]?.value as MockSocket;
+      socket.onclose?.(new Event("close"));
+      vi.advanceTimersByTime(1_000);
+    });
+
+    const reconnectedSocket = webSocketCtor.mock.results[1]?.value as MockSocket;
+    act(() => reconnectedSocket.onopen?.(new Event("open")));
+    expect(reconnectedSocket.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "auth", token: "jwt-access-token" }),
+    );
   });
 
   it("should send subscription signals when registering order listeners", () => {

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { API_BASE_URL } from "@/lib/apiConfig";
+import { getAccessToken } from "@/lib/authToken";
 
 const RECONNECT_BASE_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;
@@ -30,6 +31,11 @@ export function useSocket() {
     socket.onopen = () => {
       setIsConnected(true);
       reconnectAttempt.current = 0;
+
+      const token = getAccessToken();
+      if (token) {
+        socket.send(JSON.stringify({ type: "auth", token }));
+      }
       
       // Flush queue
       while (messageQueue.current.length > 0) {

--- a/client/src/lib/apiHelper.ts
+++ b/client/src/lib/apiHelper.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL } from "./apiConfig";
+import { getAccessToken } from "./authToken";
 
 export interface ApiError {
   code: string;
@@ -41,10 +42,12 @@ export async function apiRequest<T>(
   const timer = setTimeout(() => controller.abort(), timeout);
 
   try {
+    const accessToken = getAccessToken();
     const res = await fetch(url, {
       method,
       headers: {
         "Content-Type": "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
         ...headers,
       },
       body: body ? JSON.stringify(body) : undefined,

--- a/client/src/lib/authToken.ts
+++ b/client/src/lib/authToken.ts
@@ -1,0 +1,15 @@
+export const AUTH_TOKEN_STORAGE_KEY = "agrocylo:access-token";
+
+export function getAccessToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+export function setAccessToken(token: string | null): void {
+  if (typeof window === "undefined") return;
+  if (token) {
+    window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+  } else {
+    window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  }
+}


### PR DESCRIPTION
Introduces one access-token store shared by REST and WebSocket clients. useSocket sends the auth handshake first on every open and reconnect, with reconnect coverage in the hook tests.

Validation: git diff --check.

Closes #689