### PR TITLE
fix: require auth on equipment/crop-plan mutating routes, derive wallet from session, require owner sign-off for deposit refund

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -119,11 +119,12 @@ model Product {
   createdAt     DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt     DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  farmer       Profile        @relation(fields: [farmerWallet], references: [wallet_address], onDelete: Cascade)
+  farmer       Profile             @relation(fields: [farmerWallet], references: [wallet_address], onDelete: Cascade)
   cartItems    CartItem[]
   orders       Order[]
   priceHistory PriceHistory[]
   groupOrders  GroupOrder[]
+  priceTiers   ProductPriceTier[]
 
   @@index([farmerWallet, isAvailable])
   @@map("products")

--- a/server/src/routes/cropPlanRoutes.test.ts
+++ b/server/src/routes/cropPlanRoutes.test.ts
@@ -17,6 +17,18 @@ vi.mock("../config/database.js", () => ({
   },
 }));
 
+vi.mock("../middleware/walletAuth.js", () => ({
+  requireWallet: (req: any, res: any, next: any) => {
+    const wallet = req.headers["x-wallet-address"];
+    if (!wallet) {
+      res.status(401).json({ message: "Missing wallet" });
+      return;
+    }
+    req.walletAddress = wallet;
+    next();
+  },
+}));
+
 describe("CropPlan routes (Issue #658)", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -41,8 +53,8 @@ describe("CropPlan routes (Issue #658)", () => {
 
     const res = await request(app)
       .post("/crop-plans")
+      .set("x-wallet-address", "G1234567890")
       .send({
-        farmerWallet: "G1234567890",
         cropName: "Cassava",
         plantedDate: "2026-01-01",
         expectedHarvestStart: "2026-06-01",
@@ -57,11 +69,50 @@ describe("CropPlan routes (Issue #658)", () => {
     expect(res.body.cropName).toBe("Cassava");
   });
 
-  it("POST /crop-plans returns 400 when plantedDate is after expectedHarvestStart", async () => {
+  it("POST /crop-plans rejects unauthenticated requests", async () => {
     const res = await request(app)
       .post("/crop-plans")
       .send({
-        farmerWallet: "G1234567890",
+        cropName: "Maize",
+        plantedDate: "2026-01-01",
+        expectedHarvestStart: "2026-06-01",
+        expectedHarvestEnd: "2026-06-30",
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /crop-plans rejects cross-wallet spoofing (farmerWallet in body ignored)", async () => {
+    vi.mocked(prisma.cropPlan.create).mockResolvedValue({} as any);
+
+    await request(app)
+      .post("/crop-plans")
+      .set("x-wallet-address", "G1234567890")
+      .send({
+        farmerWallet: "GEVILFARMER", // spoofed – must be ignored
+        cropName: "Maize",
+        plantedDate: "2026-01-01",
+        expectedHarvestStart: "2026-06-01",
+        expectedHarvestEnd: "2026-06-30",
+      });
+
+    expect(prisma.cropPlan.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ farmerWallet: "G1234567890" }),
+      }),
+    );
+    expect(prisma.cropPlan.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ farmerWallet: "GEVILFARMER" }),
+      }),
+    );
+  });
+
+  it("POST /crop-plans returns 400 when plantedDate is after expectedHarvestStart", async () => {
+    const res = await request(app)
+      .post("/crop-plans")
+      .set("x-wallet-address", "G1234567890")
+      .send({
         cropName: "Maize",
         plantedDate: "2026-07-01",
         expectedHarvestStart: "2026-06-01",

--- a/server/src/routes/cropPlanRoutes.ts
+++ b/server/src/routes/cropPlanRoutes.ts
@@ -2,14 +2,16 @@ import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 import { prisma } from "../config/database.js";
 import { ApiError } from "../http/errors.js";
+import { requireWallet, type WalletRequest } from "../middleware/walletAuth.js";
 
 const router = Router();
 
 // Create a new CropPlan
-router.post("/crop-plans", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/crop-plans", requireWallet, async (req: WalletRequest, res: Response, next: NextFunction) => {
   try {
+    const farmerWallet = req.walletAddress;
+
     const {
-      farmerWallet,
       cropName,
       plantedDate,
       expectedHarvestStart,
@@ -22,7 +24,7 @@ router.post("/crop-plans", async (req: Request, res: Response, next: NextFunctio
     } = req.body;
 
     if (!farmerWallet || !cropName || !plantedDate || !expectedHarvestStart || !expectedHarvestEnd) {
-      throw new ApiError(400, "Validation Error", "farmerWallet, cropName, plantedDate, expectedHarvestStart, and expectedHarvestEnd are required");
+      throw new ApiError(400, "Validation Error", "cropName, plantedDate, expectedHarvestStart, and expectedHarvestEnd are required");
     }
 
     const pDate = new Date(plantedDate);

--- a/server/src/routes/equipmentRoutes.test.ts
+++ b/server/src/routes/equipmentRoutes.test.ts
@@ -18,6 +18,18 @@ vi.mock("../config/database.js", () => ({
   },
 }));
 
+vi.mock("../middleware/walletAuth.js", () => ({
+  requireWallet: (req: any, res: any, next: any) => {
+    const wallet = req.headers["x-wallet-address"];
+    if (!wallet) {
+      res.status(401).json({ message: "Missing wallet" });
+      return;
+    }
+    req.walletAddress = wallet;
+    next();
+  },
+}));
+
 describe("Equipment Marketplace routes (Issue #657)", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -40,8 +52,8 @@ describe("Equipment Marketplace routes (Issue #657)", () => {
 
     const res = await request(app)
       .post("/equipment/listings")
+      .set("x-wallet-address", "G999999999")
       .send({
-        ownerWallet: "G999999999",
         title: "Tractor Rental",
         listingType: "EQUIPMENT_RENTAL",
         pricePerUnit: 50.0,
@@ -53,11 +65,70 @@ describe("Equipment Marketplace routes (Issue #657)", () => {
     expect(res.status).toBe(201);
     expect(res.body.id).toBe("el-1");
     expect(res.body.listingType).toBe("EQUIPMENT_RENTAL");
+    expect(prisma.equipmentListing.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ownerWallet: "G999999999" }),
+      }),
+    );
+  });
+
+  it("POST /equipment/listings rejects unauthenticated requests", async () => {
+    const res = await request(app)
+      .post("/equipment/listings")
+      .send({
+        title: "Tractor",
+        listingType: "TOOL",
+        pricePerUnit: 50.0,
+        currency: "XLM",
+        unit: "day",
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /equipment/listings rejects cross-wallet spoofing (ownerWallet in body ignored)", async () => {
+    const mockListing = {
+      id: "el-1",
+      ownerWallet: "G999999999",
+      title: "Tractor",
+      listingType: "TOOL",
+      pricePerUnit: "50.00",
+      currency: "XLM",
+      unit: "day",
+      isAvailable: true,
+    };
+
+    vi.mocked(prisma.equipmentListing.create).mockResolvedValue(mockListing as any);
+
+    await request(app)
+      .post("/equipment/listings")
+      .set("x-wallet-address", "G999999999")
+      .send({
+        ownerWallet: "GEVILHACKER", // spoofed – must be ignored
+        title: "Tractor",
+        listingType: "TOOL",
+        pricePerUnit: 50.0,
+        currency: "XLM",
+        unit: "day",
+      });
+
+    // The ownerWallet used in create must be the authenticated one, not the spoofed body value
+    expect(prisma.equipmentListing.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ownerWallet: "G999999999" }),
+      }),
+    );
+    expect(prisma.equipmentListing.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ownerWallet: "GEVILHACKER" }),
+      }),
+    );
   });
 
   it("POST /equipment/rent creates rental with deposit step", async () => {
     vi.mocked(prisma.equipmentListing.findUnique).mockResolvedValue({
       id: "el-1",
+      ownerWallet: "G999999999",
       isAvailable: true,
       depositAmount: 100.0,
     } as any);
@@ -77,9 +148,9 @@ describe("Equipment Marketplace routes (Issue #657)", () => {
 
     const res = await request(app)
       .post("/equipment/rent")
+      .set("x-wallet-address", "G888888888")
       .send({
         listingId: "el-1",
-        renterWallet: "G888888888",
         startDate: "2026-08-01",
         endDate: "2026-08-05",
       });
@@ -89,12 +160,68 @@ describe("Equipment Marketplace routes (Issue #657)", () => {
     expect(res.body.depositAmount).toBe(100.0);
   });
 
-  it("POST /equipment/rentals/:id/return confirms return and triggers deposit refund", async () => {
+  it("POST /equipment/rent rejects unauthenticated requests", async () => {
+    const res = await request(app)
+      .post("/equipment/rent")
+      .send({
+        listingId: "el-1",
+        startDate: "2026-08-01",
+        endDate: "2026-08-05",
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /equipment/rent rejects cross-wallet spoofing (renterWallet in body ignored)", async () => {
+    vi.mocked(prisma.equipmentListing.findUnique).mockResolvedValue({
+      id: "el-1",
+      ownerWallet: "G999999999",
+      isAvailable: true,
+      depositAmount: 100.0,
+    } as any);
+
+    const mockRental = {
+      id: "er-1",
+      listingId: "el-1",
+      renterWallet: "G888888888",
+      startDate: new Date("2026-08-01"),
+      endDate: new Date("2026-08-05"),
+      status: "ACTIVE",
+      depositAmount: 100.0,
+      depositRefunded: false,
+    };
+
+    vi.mocked(prisma.equipmentRental.create).mockResolvedValue(mockRental as any);
+
+    await request(app)
+      .post("/equipment/rent")
+      .set("x-wallet-address", "G888888888")
+      .send({
+        listingId: "el-1",
+        renterWallet: "GEVILHACKER", // spoofed – must be ignored
+        startDate: "2026-08-01",
+        endDate: "2026-08-05",
+      });
+
+    expect(prisma.equipmentRental.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ renterWallet: "G888888888" }),
+      }),
+    );
+    expect(prisma.equipmentRental.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ renterWallet: "GEVILHACKER" }),
+      }),
+    );
+  });
+
+  it("POST /equipment/rentals/:id/return - owner can confirm return and refund deposit", async () => {
     vi.mocked(prisma.equipmentRental.findUnique).mockResolvedValue({
       id: "er-1",
       status: "ACTIVE",
+      renterWallet: "G888888888",
       depositAmount: 100.0,
-      listing: { currency: "XLM" },
+      listing: { ownerWallet: "G999999999", currency: "XLM" },
     } as any);
 
     vi.mocked(prisma.equipmentRental.update).mockResolvedValue({
@@ -105,11 +232,63 @@ describe("Equipment Marketplace routes (Issue #657)", () => {
 
     const res = await request(app)
       .post("/equipment/rentals/er-1/return")
+      .set("x-wallet-address", "G999999999")
       .send({ confirmCondition: true });
 
     expect(res.status).toBe(200);
     expect(res.body.rental.status).toBe("RETURNED");
     expect(res.body.rental.depositRefunded).toBe(true);
     expect(res.body.message).toContain("refunded");
+  });
+
+  it("POST /equipment/rentals/:id/return - renter can return but cannot refund deposit", async () => {
+    vi.mocked(prisma.equipmentRental.findUnique).mockResolvedValue({
+      id: "er-1",
+      status: "ACTIVE",
+      renterWallet: "G888888888",
+      depositAmount: 100.0,
+      listing: { ownerWallet: "G999999999", currency: "XLM" },
+    } as any);
+
+    vi.mocked(prisma.equipmentRental.update).mockResolvedValue({
+      id: "er-1",
+      status: "RETURNED",
+      depositRefunded: false,
+    } as any);
+
+    const res = await request(app)
+      .post("/equipment/rentals/er-1/return")
+      .set("x-wallet-address", "G888888888")
+      .send({ confirmCondition: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.rental.status).toBe("RETURNED");
+    expect(res.body.rental.depositRefunded).toBe(false);
+    expect(res.body.message).toContain("pending owner inspection");
+  });
+
+  it("POST /equipment/rentals/:id/return rejects unauthenticated requests", async () => {
+    const res = await request(app)
+      .post("/equipment/rentals/er-1/return")
+      .send({ confirmCondition: true });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /equipment/rentals/:id/return rejects unauthorised caller (neither renter nor owner)", async () => {
+    vi.mocked(prisma.equipmentRental.findUnique).mockResolvedValue({
+      id: "er-1",
+      status: "ACTIVE",
+      renterWallet: "G888888888",
+      depositAmount: 100.0,
+      listing: { ownerWallet: "G999999999", currency: "XLM" },
+    } as any);
+
+    const res = await request(app)
+      .post("/equipment/rentals/er-1/return")
+      .set("x-wallet-address", "GSTRANGER")
+      .send({ confirmCondition: true });
+
+    expect(res.status).toBe(403);
   });
 });

--- a/server/src/routes/equipmentRoutes.ts
+++ b/server/src/routes/equipmentRoutes.ts
@@ -2,14 +2,16 @@ import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 import { prisma } from "../config/database.js";
 import { ApiError } from "../http/errors.js";
+import { requireWallet, type WalletRequest } from "../middleware/walletAuth.js";
 
 const router = Router();
 
 // Create new Equipment/Input/Tool listing
-router.post("/equipment/listings", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/equipment/listings", requireWallet, async (req: WalletRequest, res: Response, next: NextFunction) => {
   try {
+    const ownerWallet = req.walletAddress;
+
     const {
-      ownerWallet,
       title,
       description,
       listingType,
@@ -21,7 +23,7 @@ router.post("/equipment/listings", async (req: Request, res: Response, next: Nex
     } = req.body;
 
     if (!ownerWallet || !title || !listingType || pricePerUnit === undefined || !currency || !unit) {
-      throw new ApiError(400, "Validation Error", "ownerWallet, title, listingType, pricePerUnit, currency, and unit are required");
+      throw new ApiError(400, "Validation Error", "title, listingType, pricePerUnit, currency, and unit are required");
     }
 
     if (!["SEED", "TOOL", "EQUIPMENT_RENTAL"].includes(listingType)) {
@@ -70,12 +72,13 @@ router.get("/equipment/listings", async (req: Request, res: Response, next: Next
 });
 
 // Rent equipment / tools with deposit
-router.post("/equipment/rent", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/equipment/rent", requireWallet, async (req: WalletRequest, res: Response, next: NextFunction) => {
   try {
-    const { listingId, renterWallet, startDate, endDate } = req.body;
+    const renterWallet = req.walletAddress;
+    const { listingId, startDate, endDate } = req.body;
 
     if (!listingId || !renterWallet || !startDate || !endDate) {
-      throw new ApiError(400, "Validation Error", "listingId, renterWallet, startDate, and endDate are required");
+      throw new ApiError(400, "Validation Error", "listingId, startDate, and endDate are required");
     }
 
     const listing = await prisma.equipmentListing.findUnique({ where: { id: listingId } });
@@ -113,10 +116,11 @@ router.post("/equipment/rent", async (req: Request, res: Response, next: NextFun
 });
 
 // Return equipment and trigger deposit refund
-router.post("/equipment/rentals/:id/return", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/equipment/rentals/:id/return", requireWallet, async (req: WalletRequest, res: Response, next: NextFunction) => {
   try {
+    const caller = req.walletAddress;
     const { id } = req.params;
-    const { confirmCondition = true } = req.body;
+    const { confirmCondition } = req.body;
 
     const rental = await prisma.equipmentRental.findUnique({
       where: { id },
@@ -131,19 +135,29 @@ router.post("/equipment/rentals/:id/return", async (req: Request, res: Response,
       throw new ApiError(400, "Already Returned", "This rental has already been returned");
     }
 
+    const isOwner = rental.listing.ownerWallet === caller;
+    const isRenter = rental.renterWallet === caller;
+
+    if (!isOwner && !isRenter) {
+      throw new ApiError(403, "Forbidden", "Only the renter or listing owner can confirm return");
+    }
+
+    // Only the listing owner can authorise a deposit refund
+    const depositRefunded = confirmCondition === true && isOwner;
+    const status = "RETURNED";
+
     const updatedRental = await prisma.equipmentRental.update({
       where: { id },
-      data: {
-        status: "RETURNED",
-        depositRefunded: confirmCondition,
-      },
+      data: { status, depositRefunded },
     });
 
     res.json({
       rental: updatedRental,
-      message: confirmCondition
+      message: depositRefunded
         ? `Equipment returned successfully. Deposit of ${rental.depositAmount} ${rental.listing.currency} refunded.`
-        : `Equipment returned. Deposit withheld pending damage inspection.`,
+        : isOwner
+          ? `Deposit withheld. Confirmed by owner.`
+          : `Equipment returned. Deposit withheld pending owner inspection.`,
     });
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary

Closes auth vulnerability in equipment and crop-plan routes. All mutating endpoints now use requireWallet middleware and derive wallet addresses from the authenticated JWT session instead of accepting them from the request body.
Closes #685 
Closes #687 
Closes #714 
## Changes

### equipmentRoutes.ts
- POST /equipment/listings: requireWallet, ownerWallet from session
- POST /equipment/rent: requireWallet, renterWallet from session
- POST /equipment/rentals/:id/return: requireWallet, only owner can set depositRefunded: true

### cropPlanRoutes.ts
- POST /crop-plans: requireWallet, farmerWallet from session

### schema.prisma
- Fixed missing ProductPriceTier reverse relation on Product model

### Tests added
- Cross-wallet spoofing tests for all three mutation flows
- Unauthenticated rejection tests (401)
- Owner vs. renter deposit refund authorization test
- Unauthorized caller rejection test (403)