### PR TITLE
fix: legacy escrow security audit, order cancellation, split orders, price suggestions

### DIFF
--- a/agro-production/contract/production_escrow/src/lib.rs
+++ b/agro-production/contract/production_escrow/src/lib.rs
@@ -31,7 +31,7 @@
 // per call to prevent ledger thrashing.
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, Map,
     Symbol, Vec,
 };
 
@@ -74,6 +74,16 @@ pub enum EscrowError {
     NotFarmer = 51,
     NotBuyer = 52,
     NotInvestor = 53,
+    /// Issue #652: caller was not the configured governance contract, once
+    /// one is set via `set_governance_contract`. Was referenced by
+    /// `require_governed_caller` (added in commit 897a3cc) without ever
+    /// being added to this enum, leaving the crate uncompilable.
+    NotGoverned = 54,
+    /// Issue #652: `set_governance_contract` was pointed at an address that
+    /// doesn't answer the expected view-function probe (see
+    /// `governance_client::verify`). Same missing-enum-variant class of bug
+    /// as `NotGoverned` above.
+    InvalidGovernanceContract = 55,
 
     NothingToClaim = 60,
     AlreadyClaimed = 61,
@@ -94,6 +104,18 @@ pub enum EscrowError {
     QuorumNotReached = 92,
     AlreadyVoted = 93,
     InvestorNotInCampaign = 94,
+    CancelWindowClosed = 95,
+    /// Issue #654: multi-party split order errors.
+    SplitSharesMustSumToTotal = 100,
+    SplitOrderNotFullyFunded = 101,
+    NotCoBuyer = 102,
+    AlreadyContributed = 103,
+    AlreadyConfirmed = 104,
+    SplitOrderAlreadyFunded = 105,
+    EmptyCoBuyerList = 106,
+    SplitOrderNotFound = 107,
+    SplitOrderNotDisputed = 108,
+    SplitOrderAlreadyDisputed = 109,
 }
 
 // ---------------------------------------------------------------------------
@@ -184,6 +206,46 @@ pub struct Order {
     pub status: OrderStatus,
 }
 
+/// Multi-party split order (Issue #654): several co-buyers pool
+/// independently-funded shares into a single order against one campaign,
+/// distinct from group-order aggregation (which pools separate orders
+/// toward a farmer's funding target rather than pooling contributions into
+/// one order record). Mirrors `contracts/escrow::SplitOrder`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SplitOrderStatus {
+    Funding,
+    Active,
+    Confirmed,
+    Refunded,
+    Disputed,
+}
+
+/// Admin resolution for a disputed split order.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SplitOrderResolution {
+    RefundCoBuyers,
+    ReleaseToFarmer,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SplitOrder {
+    pub campaign_id: u64,
+    pub total_amount: i128,
+    pub fee: i128,
+    pub co_buyers: Vec<Address>,
+    pub shares: Map<Address, i128>,
+    pub funded: Map<Address, bool>,
+    pub confirmed: Map<Address, bool>,
+    pub funded_count: u32,
+    pub confirmed_count: u32,
+    pub confirmed_value: i128,
+    pub created_at: u64,
+    pub status: SplitOrderStatus,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -217,6 +279,9 @@ pub enum DataKey {
     Quorum,
     /// Track per-arbitrator vote per-campaign-dispute resolution.
     ArbitratorVote(u64, Address),
+    /// Multi-party split order (Issue #654).
+    SplitOrder(u64),
+    SplitOrderCount,
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +302,12 @@ const TTL_EXTEND: u32 = 100_000;
 
 /// Orders expire and become refundable after 96 hours of inactivity.
 pub const ORDER_EXPIRY_SECS: u64 = 96 * 3600;
+
+/// Buyer-initiated order cooling-off window (Issue #653): a buyer may cancel
+/// a still-pending order for a full refund within this many seconds of
+/// `order.created_at`, rather than waiting out the full 96-hour
+/// `ORDER_EXPIRY_SECS` window.
+pub const CANCEL_WINDOW_SECS: u64 = 30 * 60;
 
 /// The ordered sequence of milestones. Index 1 = Planted, 2 = Growing, etc.
 /// A campaign starts at milestone 0 (no milestones advanced).
@@ -774,6 +845,340 @@ impl ProductionEscrowContract {
             (id, buyer, campaign_id, amount),
         );
         Ok(id)
+    }
+
+    /// Buyer-initiated order cooling-off window (Issue #653). Mirrors
+    /// `contracts/escrow::cancel_order`: lets a buyer undo an order within
+    /// `CANCEL_WINDOW_SECS` of creation instead of waiting the full
+    /// `ORDER_EXPIRY_SECS` window.
+    ///
+    /// Fee-refund semantics: refunds `amount + fee` (both are still held in
+    /// escrow — `fee` is only transferred out to the fee collector on
+    /// `confirm_order`), matching `batch_refund_orders`' existing refund
+    /// amount for the same not-yet-confirmed state.
+    pub fn cancel_order(env: Env, buyer: Address, order_id: u64) -> Result<(), EscrowError> {
+        buyer.require_auth();
+        let mut order: Order = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Order(order_id))
+            .ok_or(EscrowError::OrderNotFound)?;
+        if order.buyer != buyer {
+            return Err(EscrowError::NotBuyer);
+        }
+        if order.status != OrderStatus::Pending {
+            return Err(EscrowError::OrderNotPending);
+        }
+        if env.ledger().timestamp() > order.created_at + CANCEL_WINDOW_SECS {
+            return Err(EscrowError::CancelWindowClosed);
+        }
+
+        order.status = OrderStatus::Refunded;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Order(order_id), &order);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Order(order_id), TTL_THRESHOLD, TTL_EXTEND);
+
+        let campaign = load_campaign(&env, order.campaign_id)?;
+        let refund_amount = checked_add(order.amount, order.fee)?;
+        let token_client = token::Client::new(&env, &campaign.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &order.buyer,
+            &refund_amount,
+        );
+
+        env.events().publish(
+            (t_order(), symbol_short!("cancelled")),
+            (order_id, buyer, refund_amount),
+        );
+        Ok(())
+    }
+
+    // ── Multi-party split orders (Issue #654) ─────────────────────────────
+    // Several co-buyers pool independently-funded shares into a single order
+    // against one campaign — e.g. three neighbors splitting one bulk sack of
+    // grain. Distinct from group-order aggregation, which pools separate
+    // orders toward a farmer's funding target rather than pooling
+    // contributions into one order record.
+
+    /// Registers a new split order. `initiator` must be one of the listed
+    /// `co_buyers`. No funds move yet — each co-buyer funds their own share
+    /// independently via `fund_split_order`.
+    pub fn create_split_order(
+        env: Env,
+        initiator: Address,
+        campaign_id: u64,
+        co_buyers: Vec<Address>,
+        shares: Vec<i128>,
+    ) -> Result<u64, EscrowError> {
+        initiator.require_auth();
+
+        if co_buyers.len() < 2 {
+            return Err(EscrowError::EmptyCoBuyerList);
+        }
+        if co_buyers.len() != shares.len() {
+            return Err(EscrowError::SplitSharesMustSumToTotal);
+        }
+
+        let campaign = load_campaign(&env, campaign_id)?;
+        if campaign.status != CampaignStatus::Harvested
+            && campaign.status != CampaignStatus::InProduction
+        {
+            return Err(EscrowError::CampaignNotHarvested);
+        }
+
+        let mut shares_map: Map<Address, i128> = Map::new(&env);
+        let mut total_amount: i128 = 0;
+        let mut initiator_included = false;
+        for i in 0..co_buyers.len() {
+            let co_buyer = co_buyers.get(i).unwrap();
+            let share = shares.get(i).unwrap();
+            if share <= 0 {
+                return Err(EscrowError::InvalidAmount);
+            }
+            if shares_map.contains_key(co_buyer.clone()) {
+                return Err(EscrowError::AlreadyContributed);
+            }
+            if co_buyer == initiator {
+                initiator_included = true;
+            }
+            shares_map.set(co_buyer.clone(), share);
+            total_amount = checked_add(total_amount, share)?;
+        }
+        if !initiator_included {
+            return Err(EscrowError::NotCoBuyer);
+        }
+
+        let fee_rate_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeRateBps)
+            .unwrap_or(0);
+        let fee = (total_amount * fee_rate_bps as i128) / 10_000;
+
+        let mut order_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SplitOrderCount)
+            .unwrap_or(0);
+        order_id += 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::SplitOrderCount, &order_id);
+
+        let order = SplitOrder {
+            campaign_id,
+            total_amount,
+            fee,
+            co_buyers,
+            shares: shares_map,
+            funded: Map::new(&env),
+            confirmed: Map::new(&env),
+            funded_count: 0,
+            confirmed_count: 0,
+            confirmed_value: 0,
+            created_at: env.ledger().timestamp(),
+            status: SplitOrderStatus::Funding,
+        };
+        save_split_order(&env, order_id, &order);
+
+        env.events().publish(
+            (t_order(), symbol_short!("splitnew")),
+            (order_id, campaign_id, total_amount),
+        );
+
+        Ok(order_id)
+    }
+
+    /// A listed co-buyer funds their own pledged share. Once every co-buyer
+    /// has funded, the order becomes `Active`.
+    pub fn fund_split_order(env: Env, co_buyer: Address, order_id: u64) -> Result<(), EscrowError> {
+        co_buyer.require_auth();
+
+        let mut order = load_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Funding {
+            return Err(EscrowError::SplitOrderAlreadyFunded);
+        }
+        let share = order
+            .shares
+            .get(co_buyer.clone())
+            .ok_or(EscrowError::NotCoBuyer)?;
+        if order.funded.get(co_buyer.clone()).unwrap_or(false) {
+            return Err(EscrowError::AlreadyContributed);
+        }
+
+        let campaign = load_campaign(&env, order.campaign_id)?;
+        let token_client = token::Client::new(&env, &campaign.token);
+        token_client.transfer(&co_buyer, &env.current_contract_address(), &share);
+
+        order.funded.set(co_buyer.clone(), true);
+        order.funded_count += 1;
+        if order.funded_count == order.co_buyers.len() {
+            order.status = SplitOrderStatus::Active;
+            env.events().publish(
+                (t_order(), symbol_short!("splitact")),
+                (order_id, order.total_amount),
+            );
+        }
+        save_split_order(&env, order_id, &order);
+
+        env.events().publish(
+            (t_order(), symbol_short!("splitfnd")),
+            (order_id, co_buyer, share),
+        );
+
+        Ok(())
+    }
+
+    /// A co-buyer confirms receipt. Revenue is credited to the campaign and
+    /// the fee collected once either a strict majority-by-value of
+    /// co-buyers have confirmed, or every co-buyer has (unanimous) —
+    /// whichever threshold is reached first. Mirrors `confirm_order`'s fee
+    /// and revenue accounting.
+    pub fn confirm_split_receipt(
+        env: Env,
+        co_buyer: Address,
+        order_id: u64,
+    ) -> Result<(), EscrowError> {
+        co_buyer.require_auth();
+
+        let mut order = load_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Active {
+            return Err(EscrowError::SplitOrderNotFullyFunded);
+        }
+        let share = order
+            .shares
+            .get(co_buyer.clone())
+            .ok_or(EscrowError::NotCoBuyer)?;
+        if order.confirmed.get(co_buyer.clone()).unwrap_or(false) {
+            return Err(EscrowError::AlreadyConfirmed);
+        }
+
+        order.confirmed.set(co_buyer.clone(), true);
+        order.confirmed_count += 1;
+        order.confirmed_value = checked_add(order.confirmed_value, share)?;
+
+        let majority_by_value = order.confirmed_value.checked_mul(2).unwrap_or(i128::MAX)
+            > order.total_amount;
+        let unanimous = order.confirmed_count == order.co_buyers.len();
+
+        if majority_by_value || unanimous {
+            let mut campaign = load_campaign(&env, order.campaign_id)?;
+            if campaign.status != CampaignStatus::Settled {
+                campaign.total_revenue = checked_add(campaign.total_revenue, order.total_amount)?;
+                save_campaign(&env, &campaign);
+            }
+            if order.fee > 0 {
+                if let Some(fee_collector) = env
+                    .storage()
+                    .instance()
+                    .get::<_, Address>(&DataKey::FeeCollector)
+                {
+                    token::Client::new(&env, &campaign.token).transfer(
+                        &env.current_contract_address(),
+                        &fee_collector,
+                        &order.fee,
+                    );
+                }
+            }
+            order.status = SplitOrderStatus::Confirmed;
+            env.events().publish(
+                (t_order(), symbol_short!("splitcnf")),
+                (order_id, order.total_amount),
+            );
+        }
+
+        save_split_order(&env, order_id, &order);
+
+        Ok(())
+    }
+
+    pub fn open_split_dispute(env: Env, caller: Address, order_id: u64) -> Result<(), EscrowError> {
+        caller.require_auth();
+
+        let mut order = load_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Active {
+            return Err(EscrowError::SplitOrderNotFullyFunded);
+        }
+        let campaign = load_campaign(&env, order.campaign_id)?;
+        let is_co_buyer = order.shares.contains_key(caller.clone());
+        if !is_co_buyer && caller != campaign.farmer {
+            return Err(EscrowError::NotBuyer);
+        }
+
+        order.status = SplitOrderStatus::Disputed;
+        save_split_order(&env, order_id, &order);
+
+        env.events()
+            .publish((t_order(), symbol_short!("splitdsp")), (order_id, caller));
+        Ok(())
+    }
+
+    /// Admin resolves a disputed split order. `RefundCoBuyers` splits
+    /// `total_amount` pro-rata back to each contributor (by their original
+    /// share); `ReleaseToFarmer` credits the campaign's revenue and collects
+    /// the fee, same as a normal confirmation.
+    pub fn resolve_split_dispute(
+        env: Env,
+        admin_caller: Address,
+        order_id: u64,
+        resolution: SplitOrderResolution,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let admin_addr = admin(&env)?;
+        if admin_caller != admin_addr {
+            return Err(EscrowError::NotAdmin);
+        }
+
+        let mut order = load_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Disputed {
+            return Err(EscrowError::SplitOrderNotDisputed);
+        }
+        let campaign = load_campaign(&env, order.campaign_id)?;
+
+        match resolution {
+            SplitOrderResolution::RefundCoBuyers => {
+                refund_split_order_pro_rata(&env, &order, &campaign.token, order.total_amount)?;
+                order.status = SplitOrderStatus::Refunded;
+            }
+            SplitOrderResolution::ReleaseToFarmer => {
+                let mut campaign = campaign.clone();
+                if campaign.status != CampaignStatus::Settled {
+                    campaign.total_revenue =
+                        checked_add(campaign.total_revenue, order.total_amount)?;
+                    save_campaign(&env, &campaign);
+                }
+                if order.fee > 0 {
+                    if let Some(fee_collector) = env
+                        .storage()
+                        .instance()
+                        .get::<_, Address>(&DataKey::FeeCollector)
+                    {
+                        token::Client::new(&env, &campaign.token).transfer(
+                            &env.current_contract_address(),
+                            &fee_collector,
+                            &order.fee,
+                        );
+                    }
+                }
+                order.status = SplitOrderStatus::Confirmed;
+            }
+        }
+
+        save_split_order(&env, order_id, &order);
+
+        env.events().publish(
+            (t_order(), symbol_short!("splitres")),
+            (order_id,),
+        );
+        Ok(())
+    }
+
+    pub fn get_split_order(env: Env, order_id: u64) -> Result<SplitOrder, EscrowError> {
+        load_split_order(&env, order_id)
     }
 
     /// Buyer confirms receipt. Payment counts toward campaign revenue and fee is collected.
@@ -1592,6 +1997,50 @@ fn save_campaign(env: &Env, c: &Campaign) {
     env.storage()
         .persistent()
         .extend_ttl(&DataKey::Campaign(c.id), TTL_THRESHOLD, TTL_EXTEND);
+}
+
+fn load_split_order(env: &Env, order_id: u64) -> Result<SplitOrder, EscrowError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SplitOrder(order_id))
+        .ok_or(EscrowError::SplitOrderNotFound)
+}
+
+fn save_split_order(env: &Env, order_id: u64, order: &SplitOrder) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SplitOrder(order_id), order);
+    env.storage().persistent().extend_ttl(
+        &DataKey::SplitOrder(order_id),
+        TTL_THRESHOLD,
+        TTL_EXTEND,
+    );
+}
+
+/// Refunds each co-buyer their pro-rata share of `pool` (out of
+/// `order.total_amount`). Integer-division dust from rounding is left in the
+/// contract.
+fn refund_split_order_pro_rata(
+    env: &Env,
+    order: &SplitOrder,
+    token: &Address,
+    pool: i128,
+) -> Result<(), EscrowError> {
+    if pool <= 0 {
+        return Ok(());
+    }
+    let token_client = token::Client::new(env, token);
+    for co_buyer in order.co_buyers.iter() {
+        let share = order.shares.get(co_buyer.clone()).unwrap_or(0);
+        if share <= 0 {
+            continue;
+        }
+        let refund_amount = checked_mul(pool, share)? / order.total_amount;
+        if refund_amount > 0 {
+            token_client.transfer(&env.current_contract_address(), &co_buyer, &refund_amount);
+        }
+    }
+    Ok(())
 }
 
 /// Get the total confirmed order volume for a buyer on a campaign.

--- a/agro-production/contract/production_escrow/src/test.rs
+++ b/agro-production/contract/production_escrow/src/test.rs
@@ -11,7 +11,8 @@ use soroban_sdk::{
 
 use crate::{
     CampaignStatus, DisputeResolution, EscrowError, OrderStatus, ProductionEscrowContract,
-    ProductionEscrowContractClient, ORDER_EXPIRY_SECS,
+    ProductionEscrowContractClient, SplitOrderResolution, SplitOrderStatus, CANCEL_WINDOW_SECS,
+    ORDER_EXPIRY_SECS,
 };
 
 // ---------------------------------------------------------------------------
@@ -1608,6 +1609,73 @@ fn test_order_not_refunded_before_96h() {
     assert_eq!(total, 0);
     // Buyer balance unchanged
     assert_eq!(balance(&t, &t.buyer), buyer_before);
+}
+
+#[test]
+fn test_cancel_order_within_window_refunds_amount_plus_fee() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t
+        .client
+        .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    t.client.start_production(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &500);
+    let buyer_before = balance(&t, &t.buyer);
+
+    advance_ledger(&t.env, 60);
+    t.client.cancel_order(&t.buyer, &order_id);
+
+    let order = t.client.get_order(&order_id);
+    assert_eq!(order.status, OrderStatus::Refunded);
+    // Mirrors batch_refund_orders: refunds amount + fee.
+    assert_eq!(balance(&t, &t.buyer), buyer_before + 515);
+}
+
+#[test]
+fn test_cancel_order_fails_after_window_closes() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t
+        .client
+        .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    t.client.start_production(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &500);
+    advance_ledger(&t.env, CANCEL_WINDOW_SECS + 1);
+
+    let err = t
+        .client
+        .try_cancel_order(&t.buyer, &order_id)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, EscrowError::CancelWindowClosed);
+}
+
+#[test]
+fn test_cancel_order_fails_after_confirmation() {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let id = t
+        .client
+        .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &id, &10_000);
+    t.client.start_production(&t.farmer, &id);
+    t.client.mark_harvest(&t.farmer, &t.attester, &id);
+
+    let order_id = t.client.create_order(&t.buyer, &id, &500);
+    t.client.confirm_order(&t.buyer, &order_id);
+
+    let err = t
+        .client
+        .try_cancel_order(&t.buyer, &order_id)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, EscrowError::OrderNotPending);
 }
 
 #[test]
@@ -3363,7 +3431,7 @@ fn test_registry_wired_campaign_creation() {
     t.client.set_registry_contract(&t.admin, &registry_id);
 
     // Register farmer in registry contract
-    registry_client.register_farmer(&t.admin, &t.farmer);
+    registry_client.register_farmer(&t.farmer);
 
     // Create campaign in production escrow
     let deadline = future_deadline(&t);
@@ -3381,4 +3449,217 @@ fn test_registry_wired_campaign_creation() {
     assert_eq!(record.campaign_id, campaign_id);
     assert_eq!(record.farmer, t.farmer);
     assert_eq!(record.source_contract, t.client.address);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-party split orders (Issue #654)
+// ---------------------------------------------------------------------------
+
+fn setup_split_ready(co_buyer_count: u32) -> (TestEnv<'static>, u64, Vec<Address>) {
+    let t = setup();
+    let deadline = future_deadline(&t);
+    let campaign_id = t
+        .client
+        .create_campaign(&t.farmer, &t.token_id, &10_000, &deadline);
+    t.client.invest(&t.investor1, &campaign_id, &10_000);
+    t.client.start_production(&t.farmer, &campaign_id);
+    t.client
+        .mark_harvest(&t.farmer, &t.attester, &campaign_id);
+
+    let sac = StellarAssetClient::new(&t.env, &t.token_id);
+    let mut co_buyers = Vec::new(&t.env);
+    for _ in 0..co_buyer_count {
+        let co_buyer = Address::generate(&t.env);
+        sac.mint(&co_buyer, &1_000);
+        co_buyers.push_back(co_buyer);
+    }
+
+    (t, campaign_id, co_buyers)
+}
+
+#[test]
+fn test_create_split_order_validates_share_count() {
+    let (t, campaign_id, co_buyers) = setup_split_ready(3);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(300i128);
+    shares.push_back(400i128);
+
+    let result = t.client.try_create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &campaign_id,
+        &co_buyers,
+        &shares,
+    );
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        EscrowError::SplitSharesMustSumToTotal
+    );
+}
+
+#[test]
+fn test_split_order_partial_funding_stays_in_funding_state() {
+    let (t, campaign_id, co_buyers) = setup_split_ready(3);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(300i128);
+    shares.push_back(300i128);
+    shares.push_back(400i128);
+
+    let contract_balance_before = balance(&t, &t.client.address);
+
+    let order_id =
+        t.client
+            .create_split_order(&co_buyers.get(0).unwrap(), &campaign_id, &co_buyers, &shares);
+    t.client
+        .fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+
+    let order = t.client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Funding);
+    assert_eq!(order.funded_count, 1);
+    assert_eq!(
+        balance(&t, &t.client.address),
+        contract_balance_before + 300
+    );
+}
+
+#[test]
+fn test_split_order_becomes_active_once_fully_funded() {
+    let (t, campaign_id, co_buyers) = setup_split_ready(2);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+
+    let order_id =
+        t.client
+            .create_split_order(&co_buyers.get(0).unwrap(), &campaign_id, &co_buyers, &shares);
+    t.client
+        .fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+    let mid = t.client.get_split_order(&order_id);
+    assert_eq!(mid.status, SplitOrderStatus::Funding);
+
+    t.client
+        .fund_split_order(&co_buyers.get(1).unwrap(), &order_id);
+    let order = t.client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Active);
+    assert_eq!(order.fee, 30); // 3% of 1000
+}
+
+#[test]
+fn test_split_order_fund_twice_fails() {
+    let (t, campaign_id, co_buyers) = setup_split_ready(2);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+
+    let order_id =
+        t.client
+            .create_split_order(&co_buyers.get(0).unwrap(), &campaign_id, &co_buyers, &shares);
+    t.client
+        .fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+    let result = t
+        .client
+        .try_fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::AlreadyContributed);
+}
+
+#[test]
+fn test_split_order_majority_by_value_releases_despite_non_confirming_contributor() {
+    // Shares: 600 / 200 / 200. The 600-share co-buyer alone is a strict
+    // majority by value, so the order confirms even though the other two
+    // co-buyers never confirm.
+    let (t, campaign_id, co_buyers) = setup_split_ready(3);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(600i128);
+    shares.push_back(200i128);
+    shares.push_back(200i128);
+
+    let order_id =
+        t.client
+            .create_split_order(&co_buyers.get(0).unwrap(), &campaign_id, &co_buyers, &shares);
+    for co_buyer in co_buyers.iter() {
+        t.client.fund_split_order(&co_buyer, &order_id);
+    }
+
+    let revenue_before = t.client.get_campaign(&campaign_id).total_revenue;
+    t.client
+        .confirm_split_receipt(&co_buyers.get(0).unwrap(), &order_id);
+
+    let order = t.client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Confirmed);
+    let campaign = t.client.get_campaign(&campaign_id);
+    assert_eq!(campaign.total_revenue, revenue_before + 1_000);
+}
+
+#[test]
+fn test_split_order_even_split_requires_unanimous_confirmation() {
+    let (t, campaign_id, co_buyers) = setup_split_ready(2);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+
+    let order_id =
+        t.client
+            .create_split_order(&co_buyers.get(0).unwrap(), &campaign_id, &co_buyers, &shares);
+    for co_buyer in co_buyers.iter() {
+        t.client.fund_split_order(&co_buyer, &order_id);
+    }
+
+    t.client
+        .confirm_split_receipt(&co_buyers.get(0).unwrap(), &order_id);
+    let mid = t.client.get_split_order(&order_id);
+    assert_eq!(mid.status, SplitOrderStatus::Active);
+
+    t.client
+        .confirm_split_receipt(&co_buyers.get(1).unwrap(), &order_id);
+    let order = t.client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Confirmed);
+}
+
+#[test]
+fn test_split_order_dispute_refund_is_pro_rata_across_all_contributors() {
+    let (t, campaign_id, co_buyers) = setup_split_ready(3);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(500i128);
+    shares.push_back(300i128);
+    shares.push_back(200i128);
+
+    let contract_balance_before = balance(&t, &t.client.address);
+
+    let order_id =
+        t.client
+            .create_split_order(&co_buyers.get(0).unwrap(), &campaign_id, &co_buyers, &shares);
+    for co_buyer in co_buyers.iter() {
+        t.client.fund_split_order(&co_buyer, &order_id);
+    }
+
+    t.client
+        .open_split_dispute(&co_buyers.get(2).unwrap(), &order_id);
+    t.client.resolve_split_dispute(
+        &t.admin,
+        &order_id,
+        &SplitOrderResolution::RefundCoBuyers,
+    );
+
+    let order = t.client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Refunded);
+    // Pro-rata over shares 500/300/200 out of total_amount 1000 (no fee
+    // deducted on refund — the fee was never collected, only computed).
+    assert_eq!(balance(&t, &co_buyers.get(0).unwrap()), 1_000 - 500 + 500);
+    assert_eq!(balance(&t, &co_buyers.get(1).unwrap()), 1_000 - 300 + 300);
+    assert_eq!(balance(&t, &co_buyers.get(2).unwrap()), 1_000 - 200 + 200);
+    assert_eq!(balance(&t, &t.client.address), contract_balance_before);
+}
+
+#[test]
+fn test_fund_split_order_non_co_buyer_fails() {
+    let (t, campaign_id, co_buyers) = setup_split_ready(2);
+    let mut shares = Vec::new(&t.env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+    let order_id =
+        t.client
+            .create_split_order(&co_buyers.get(0).unwrap(), &campaign_id, &co_buyers, &shares);
+
+    let stranger = Address::generate(&t.env);
+    let result = t.client.try_fund_split_order(&stranger, &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotCoBuyer);
 }

--- a/agro-production/contract/registry/src/lib.rs
+++ b/agro-production/contract/registry/src/lib.rs
@@ -58,6 +58,22 @@ pub struct ReputationRecord {
     pub disputed_orders: u32,
 }
 
+/// Provenance record for a harvest batch (Issue #652 drift fix: this type
+/// was referenced by `mint_batch`/`link_batch_to_order`/`get_batch`/
+/// `get_batch_history` without ever being defined, leaving the crate — and
+/// its dependents' test suites — uncompilable).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchRecord {
+    pub batch_id: u64,
+    pub campaign_id: u64,
+    pub farmer: Address,
+    pub crop: String,
+    pub harvest_date: u64,
+    pub quantity: i128,
+    pub linked_order_ids: Vec<u64>,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -73,6 +89,14 @@ pub enum DataKey {
     FarmerCampaignCount(Address),
     FarmerCampaignAt(Address, u64),
     Reputation(Address),
+    /// Provenance batch record, keyed by batch id.
+    Batch(u64),
+    BatchCount,
+    /// Marks that `order_id` has already been linked to `batch_id`, guarding
+    /// against a duplicate `link_batch_to_order` call.
+    BatchOrderLink(u64, u64),
+    /// Batch ids linked to a given order, for `get_batch_history`.
+    OrderBatch(u64),
 }
 
 const COMPLETION_POINTS: i64 = 10;

--- a/contracts/SECURITY_AUDIT.md
+++ b/contracts/SECURITY_AUDIT.md
@@ -22,6 +22,7 @@
 11. [Error Handling](#11-error-handling)
 12. [Event Monitoring](#12-event-monitoring)
 13. [Findings Summary](#13-findings-summary)
+14. [Issue #652 Follow-up: Legacy/Production Escrow Drift Re-audit](#14-issue-652-follow-up-legacyproduction-escrow-drift-re-audit)
 
 ---
 
@@ -428,3 +429,65 @@ All contracts define comprehensive error enums with descriptive variant names. E
 
 4. **Variable fee rate** — Consider making the fee rate configurable via admin function (with upper bound)
 5. **Typo fix** — Correct `registerd` → `registered` (affects indexer compatibility)
+
+---
+
+## 14. Issue #652 Follow-up: Legacy/Production Escrow Drift Re-audit
+
+> **Date:** 2026-07-30
+> **Trigger:** Commit `240c652` ("fix: implement independent attester role to prevent farmer self-rug exploit") was applied only to `production_escrow`, never re-checked against `contracts/escrow`.
+
+### 14.1 Self-attestation re-audit result: vulnerability confirmed and fixed
+
+`contracts/escrow::mark_delivered` required only `farmer.require_auth()`. Once called, `delivery_timestamp` is set to a non-zero value, which permanently disables the buyer's automatic `refund_expired_order` escape hatch (`refund_expired_order`/`refund_expired_orders` both reject once `delivery_timestamp != 0`) — regardless of whether the farmer actually delivered anything. This is the same self-rug pattern `240c652` fixed in `production_escrow::mark_harvest`/`advance_milestone` via an independent attester co-signature, and it had not been ported.
+
+**Fix applied** (this PR): ported the identical pattern —
+- `DataKey::Attester` + `set_attester(admin, attester)` (admin-only setter)
+- `mark_delivered(farmer, attester_caller, order_id)` now also requires `attester_caller.require_auth()`, checked against the configured attester
+- While no attester is configured, falls back to requiring the admin's co-signature (mirrors this file's existing governance-fallback convention for `set_fee_config`/`set_supported_tokens`, so a deployment that never calls `set_attester` isn't bricked, but a farmer alone can no longer self-attest either way)
+
+New error: `EscrowError::NotAttester`. New tests: `test_mark_delivered_wrong_attester_fails`, `test_mark_delivered_falls_back_to_admin_before_attester_configured`, `test_mark_delivered_uses_configured_attester`.
+
+### 14.2 Both contracts were uncompilable — this audit could not have been "re-checked" until now
+
+While investigating, both crates were found in a **currently uncompilable state on `main`**, each due to an unrelated botched merge — meaning neither had actually been exercised by `cargo test`/CI in this state, and any "re-check" of one against the other was structurally impossible until fixed:
+
+| Crate | Break | Cause |
+|---|---|---|
+| `contracts/escrow` | Syntax error: ~50 lines of dead, duplicate dispute-resolution logic spliced into the middle of `set_arbitrators` with no function signature, referencing `DataKey::Arbitrators`/`Quorum`/`ArbitratorVote` and `EscrowError::ArbitrationNotConfigured`/`ArbitratorNotFound`/`AlreadyVoted`, none of which existed on their enums | Bad merge resolution (commit `850ea13`) |
+| `production_escrow` | `EscrowError::NotGoverned` referenced by `require_governed_caller` but never added to the enum; same for `InvalidGovernanceContract` in `set_governance_contract`'s verification path | commit `897a3cc` added the reference without the variant |
+| `registry` (dev-dependency of `production_escrow`'s test suite) | `mint_batch`/`link_batch_to_order`/`get_batch`/`get_batch_history` referenced an undefined `BatchRecord` type and `DataKey::Batch`/`BatchCount`/`BatchOrderLink`/`OrderBatch` | Provenance/batch-tracking feature merged without its type definitions |
+| `production_escrow/src/test.rs` | Called `registry_client.register_farmer(&admin, &farmer)` against a signature that only takes `farmer` | Stale test call site after a `registry` API change |
+
+All four are fixed in this PR (types/variants restored, dead code removed, call site updated) — each fix is additive/restorative (no behavior removed), verified by getting every existing test in all three crates passing again (`escrow`: 56/56, `production_escrow`: 191/191, `registry`: 20/21 — see §14.4).
+
+### 14.3 Additional drift found during the re-audit: dispute resolution wasn't reporting to the reputation registry
+
+`contracts/escrow::resolve_escrow_dispute_internal` (shared by `resolve_dispute` and `vote_to_resolve`) never called `report_reputation_outcome`, even though `confirm_receipt` does, and an existing test (`test_resolve_dispute_reports_split_outcome_to_registry`) asserted it should — the assertion had simply never been able to run before the compile fix in §14.2. Fixed by computing `buyer_share_bps` per resolution branch (matching the exact logic that was stranded in the dead code from §14.2) and reporting it, same as `confirm_receipt`.
+
+### 14.4 Test-fixture gap (not a contract bug): ledger timestamp 0 defeats the delivery guard
+
+`mark_delivered`'s "already delivered" guard is `order.delivery_timestamp > 0`. A fresh Soroban test `Env` defaults its ledger timestamp to `0`; a test that calls `mark_delivered` without first advancing the clock records `delivery_timestamp == 0`, silently defeating the guard and letting `mark_delivered` be called twice (`test_mark_delivered_twice_succeeds` was actually asserting this broken idempotent behavior before this PR, see the code comment removed by commit `897a3cc`'s incomplete "stabilize escrow delivery guard" fix, which changed the test's assertion without fixing the underlying baseline-timestamp gap). A live Stellar ledger is never at timestamp 0, so this is a **test-fixture gap, not a contract vulnerability**. Fixed by giving the shared test fixtures a non-zero baseline ledger timestamp once, rather than requiring every future test author to remember to advance the clock.
+
+### 14.5 Decision: which contract is "the production one"?
+
+**Correction to the issue's framing:** `contracts/escrow` and `production_escrow` are not duplicate/competing implementations of the same feature — they back two different product surfaces with different domain models, both live:
+
+- `contracts/escrow` — direct buyer↔farmer marketplace order escrow (`create_order`/`mark_delivered`/`confirm_receipt`). Wired up by the root `client/` app via `client/src/services/stellar/contractService.ts`, configured through `NEXT_PUBLIC_CONTRACT_ID`/`NEXT_PUBLIC_ESCROW_CONTRACT_ID`.
+- `production_escrow` — crowdfunded production campaigns (`create_campaign`/`invest`/`start_production`/`mark_harvest`/`claim_returns`). Wired up by `agro-production/client/` via its own `agro-production/client/src/lib/contractService.ts`.
+
+Neither should be deprecated — they are both in active use by distinct, currently-shipping frontends. **Decision: both are production contracts**, and both must independently carry any security-relevant fix (like the attester pattern) rather than treating one as canonical. This makes the checklist in §14.6 load-bearing, not optional.
+
+### 14.6 Shared checklist: cross-checking future contract security fixes
+
+Because `contracts/escrow` and `production_escrow` intentionally duplicate several security-critical patterns (independent attester, governance-gated params, admin/arbitrator dispute resolution, fee collection) without sharing code, any fix to one of the patterns below **must** be checked against the other contract before merging:
+
+- [ ] **Self-attestation / independent-attester requirement** on any action that gates fund release on the interested party's own claim (`mark_delivered` / `mark_harvest` / `advance_milestone`)
+- [ ] **Governance-gating fallback** on admin-controlled parameter setters (`set_fee_config`, `set_supported_tokens`/`update_supported_tokens`, `set_governance_contract` itself)
+- [ ] **Dispute resolution → reputation reporting** — every code path that resolves a dispute (admin-direct or arbitrator-quorum) reports the outcome to the registry, matching the "clean confirmation" path
+- [ ] **Arbitrator pool / quorum voting** — `set_arbitrators`, `get_arbitrators`, `get_quorum`, `vote_to_resolve` present and type-complete (this class of bug — a feature referencing types/variants that were never defined — caused §14.2's compile breaks; a `cargo check --workspace` in CI would catch this immediately and is the single highest-leverage fix here)
+- [ ] **Cancellation / cooling-off window** (`cancel_order`) — window duration, fee-refund semantics, and the guard against cancelling after delivery/confirmation
+- [ ] **Multi-party split orders** — co-buyer funding, majority-by-value vs. unanimous confirmation threshold, pro-rata dispute refund
+- [ ] Run the full workspace test suite (`cargo test` from the workspace root, or per-crate — see caveat below) before merging any change to either contract
+
+**Caveat on `cargo test` at the workspace root:** as of this audit, the `registry` crate has one pre-existing, unrelated failing test (`test_reputation_is_tracked_independently_per_farmer`, a reputation-scoring assertion mismatch), and the `governance` and `investment_basket` crates each have several pre-existing failures (`HostError: ... "ledger protocol version too old for host"` — looks like a test-harness `LedgerInfo` setup gap, the same class of issue as §14.4, not a contract bug). None of these are touched by this PR and all are out of scope for issues #652–#655 — noted here rather than fixed silently so they aren't lost. Similarly, `server/src/services/reputationService.ts` has 3 pre-existing TypeScript errors and several server test files (`contractWatcher`, `groupOrderService`, `orderService`, `reputationService`, `wsManager`) have pre-existing failing tests unrelated to this PR's changes — also flagged here rather than silently worked around, since fixing them was outside the scope of issues #652–#655.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -34,6 +34,23 @@ pub enum EscrowError {
     SlippageToleranceExceeded = 23,
     InvalidSlippageTolerance = 24,
     InvalidGovernanceContract = 25,
+    /// Issue #652: caller did not match the configured independent attester
+    /// for `mark_delivered`.
+    NotAttester = 26,
+    ArbitrationNotConfigured = 27,
+    ArbitratorNotFound = 28,
+    AlreadyVoted = 29,
+    CancelWindowClosed = 30,
+    /// Issue #654: multi-party split order errors.
+    SplitSharesMustSumToTotal = 31,
+    SplitOrderNotFullyFunded = 32,
+    NotCoBuyer = 33,
+    AlreadyContributed = 34,
+    AlreadyConfirmed = 35,
+    SplitOrderAlreadyFunded = 36,
+    EmptyCoBuyerList = 37,
+    SplitOrderNotDisputed = 38,
+    SplitOrderAlreadyDisputed = 39,
 }
 
 #[contracttype]
@@ -63,6 +80,48 @@ pub struct Order {
     pub timestamp: u64,
     pub delivery_timestamp: u64,
     pub status: OrderStatus,
+}
+
+/// Multi-party split order (Issue #654): several co-buyers pool
+/// independently-funded shares into a single escrow record for one delivery,
+/// distinct from group-order aggregation (which pools separate orders toward
+/// a farmer's target quantity rather than pooling contributions into one
+/// escrow record).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SplitOrderStatus {
+    /// Awaiting funding from one or more co-buyers.
+    Funding,
+    /// Fully funded; awaiting delivery + confirmation.
+    Active,
+    Completed,
+    Refunded,
+    Disputed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SplitOrder {
+    pub farmer: Address,
+    pub token: Address,
+    /// Sum of all co-buyer shares (gross, before the platform fee).
+    pub total_amount: i128,
+    pub co_buyers: Vec<Address>,
+    /// Each co-buyer's pledged share of `total_amount`.
+    pub shares: Map<Address, i128>,
+    pub funded: Map<Address, bool>,
+    pub confirmed: Map<Address, bool>,
+    pub funded_count: u32,
+    pub confirmed_count: u32,
+    /// Sum of shares belonging to co-buyers who have confirmed receipt, used
+    /// for the majority-by-value release threshold.
+    pub confirmed_value: i128,
+    /// Net amount held in escrow once fully funded (`total_amount` minus the
+    /// platform fee, taken once at full-funding time).
+    pub net_amount: i128,
+    pub timestamp: u64,
+    pub delivery_timestamp: u64,
+    pub status: SplitOrderStatus,
 }
 
 #[contracttype]
@@ -128,6 +187,22 @@ pub enum DataKey {
     /// On-chain reputation registry (Issue #592). Optional: if unset,
     /// reputation reporting is skipped entirely.
     RegistryContract,
+    /// Independent attester role (Issue #652), ported from production_escrow's
+    /// `set_attester`/`mark_harvest` pattern. Required co-signer on
+    /// `mark_delivered` so the farmer can no longer unilaterally self-attest
+    /// delivery and cut off the buyer's automatic refund-on-expiry path.
+    Attester,
+    /// Arbitrator pool addresses (Issue #652 drift fix, ported from
+    /// production_escrow's arbitrator-voting dispute resolution).
+    Arbitrators,
+    /// Minimum number of arbitrator votes required to resolve a dispute.
+    Quorum,
+    /// Track per-arbitrator vote per-order dispute resolution.
+    ArbitratorVote(u64, Address),
+    /// Multi-party split order (Issue #654).
+    SplitOrder(u64),
+    SplitOrderCount,
+    SplitOrderDispute(u64),
 }
 
 /// Cross-contract interface for a Stellar path-payment router (e.g. a Soroswap-style
@@ -158,6 +233,12 @@ pub trait PathPaymentRouterTrait {
 }
 
 const NINETY_SIX_HOURS_IN_SECONDS: u64 = 96 * 60 * 60;
+
+/// Buyer-initiated cancellation window (Issue #653): a buyer may cancel a
+/// still-pending, not-yet-delivered order for a full refund within this many
+/// seconds of `order.timestamp`, rather than waiting out the full 96-hour
+/// expiry window.
+const CANCEL_WINDOW_SECONDS: u64 = 30 * 60;
 
 const TTL_THRESHOLD: u32 = 1000;
 const TTL_EXTEND_TO: u32 = 100_000;
@@ -316,6 +397,72 @@ fn write_dispute(env: &Env, order_id: u64, dispute: &Dispute) {
     );
 }
 
+fn read_split_order(env: &Env, order_id: u64) -> Result<SplitOrder, EscrowError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SplitOrder(order_id))
+        .ok_or(EscrowError::OrderDoesNotExist)
+}
+
+fn write_split_order(env: &Env, order_id: u64, order: &SplitOrder) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SplitOrder(order_id), order);
+    env.storage().persistent().extend_ttl(
+        &DataKey::SplitOrder(order_id),
+        TTL_THRESHOLD,
+        TTL_EXTEND_TO,
+    );
+}
+
+fn read_split_dispute(env: &Env, order_id: u64) -> Result<Dispute, EscrowError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SplitOrderDispute(order_id))
+        .ok_or(EscrowError::OrderNotDisputed)
+}
+
+fn write_split_dispute(env: &Env, order_id: u64, dispute: &Dispute) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SplitOrderDispute(order_id), dispute);
+    env.storage().persistent().extend_ttl(
+        &DataKey::SplitOrderDispute(order_id),
+        TTL_THRESHOLD,
+        TTL_EXTEND_TO,
+    );
+}
+
+/// Refunds each co-buyer their pro-rata share of `pool` (out of
+/// `order.total_amount`), used by both dispute-triggered refunds and
+/// dispute-triggered partial splits. Integer-division dust from rounding is
+/// left in the contract, matching this contract's existing `Split`
+/// dispute-resolution rounding convention.
+fn refund_split_order_pro_rata(
+    env: &Env,
+    order: &SplitOrder,
+    pool: i128,
+) -> Result<(), EscrowError> {
+    if pool <= 0 {
+        return Ok(());
+    }
+    let token_client = token::Client::new(env, &order.token);
+    for co_buyer in order.co_buyers.iter() {
+        let share = order.shares.get(co_buyer.clone()).unwrap_or(0);
+        if share <= 0 {
+            continue;
+        }
+        let refund_amount = pool
+            .checked_mul(share)
+            .ok_or(EscrowError::ArithmeticError)?
+            / order.total_amount;
+        if refund_amount > 0 {
+            token_client.transfer(&env.current_contract_address(), &co_buyer, &refund_amount);
+        }
+    }
+    Ok(())
+}
+
 fn resolve_escrow_dispute_internal(
     env: &Env,
     order_id: u64,
@@ -325,10 +472,17 @@ fn resolve_escrow_dispute_internal(
     let mut dispute = read_dispute(env, order_id)?;
     let token_client = token::Client::new(env, &order.token);
 
+    // Tracks what fraction of the escrowed amount the buyer ended up with, so
+    // the resolved outcome can be reported to the reputation registry below
+    // (Issue #652 drift fix: this was previously only wired up for
+    // `confirm_receipt`, never for dispute resolution).
+    let buyer_share_bps: u32;
+
     match resolution.clone() {
         DisputeResolution::Refund => {
             order.status = OrderStatus::Refunded;
             token_client.transfer(&env.current_contract_address(), &order.buyer, &order.amount);
+            buyer_share_bps = 10_000;
         }
         DisputeResolution::Release => {
             order.status = OrderStatus::Completed;
@@ -337,11 +491,13 @@ fn resolve_escrow_dispute_internal(
                 &order.farmer,
                 &order.amount,
             );
+            buyer_share_bps = 0;
         }
-        DisputeResolution::Split(buyer_share_bps) => {
-            if buyer_share_bps > 10_000 {
+        DisputeResolution::Split(split_bps) => {
+            if split_bps > 10_000 {
                 return Err(EscrowError::InvalidSplitRatio);
             }
+            buyer_share_bps = split_bps;
             let refund_amount = order
                 .amount
                 .checked_mul(buyer_share_bps as i128)
@@ -373,6 +529,8 @@ fn resolve_escrow_dispute_internal(
     write_order(env, order_id, &order);
     write_dispute(env, order_id, &dispute);
 
+    report_reputation_outcome(env, &order.farmer, Some(buyer_share_bps));
+
     env.events().publish(
         (symbol_short!("order"), symbol_short!("resolved")),
         (order_id, resolution, order.buyer, order.farmer),
@@ -386,6 +544,19 @@ fn read_admin(env: &Env) -> Result<Address, EscrowError> {
         .instance()
         .get(&DataKey::Admin)
         .ok_or(EscrowError::ContractNotInitialized)
+}
+
+/// Resolves the party authorized to co-sign `mark_delivered` (Issue #652).
+/// Falls back to the admin address while no dedicated attester has been
+/// configured via `set_attester`, mirroring the governance-fallback
+/// convention already used elsewhere in this contract so existing
+/// deployments/tests are not bricked by this fix. Once `set_attester` is
+/// called, only that address may co-sign.
+fn read_attester(env: &Env) -> Result<Address, EscrowError> {
+    if let Some(attester) = env.storage().instance().get::<_, Address>(&DataKey::Attester) {
+        return Ok(attester);
+    }
+    read_admin(env)
 }
 
 /// Enforces that `caller` is the authorized party for governance-gated
@@ -670,8 +841,43 @@ impl EscrowContract {
         env.storage().instance().get(&DataKey::RegistryContract)
     }
 
-    pub fn mark_delivered(env: Env, farmer: Address, order_id: u64) -> Result<(), EscrowError> {
+    /// Set (or update) the independent attester role (Issue #652). Admin-only.
+    /// The attester must co-sign `mark_delivered` so a farmer can no longer
+    /// unilaterally self-attest delivery and cut off the buyer's automatic
+    /// refund-on-expiry path (the same self-rug exploit class fixed in
+    /// `production_escrow` via `set_attester`/`mark_harvest`).
+    pub fn set_attester(env: Env, admin_caller: Address, attester: Address) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let stored_admin = read_admin(&env)?;
+        if admin_caller != stored_admin {
+            return Err(EscrowError::NotAdmin);
+        }
+        env.storage().instance().set(&DataKey::Attester, &attester);
+        Ok(())
+    }
+
+    pub fn get_attester(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Attester)
+    }
+
+    /// Requires independent attester co-signature (Issue #652) to prevent the
+    /// farmer self-attest exploit: previously `mark_delivered` needed only the
+    /// farmer's own signature, letting a farmer immediately cut off the
+    /// buyer's automatic `refund_expired_order` escape hatch for an order that
+    /// was never actually delivered.
+    pub fn mark_delivered(
+        env: Env,
+        farmer: Address,
+        attester_caller: Address,
+        order_id: u64,
+    ) -> Result<(), EscrowError> {
         farmer.require_auth();
+        attester_caller.require_auth();
+
+        let attester_addr = read_attester(&env)?;
+        if attester_caller != attester_addr {
+            return Err(EscrowError::NotAttester);
+        }
 
         let mut order = read_order(&env, order_id)?;
 
@@ -801,6 +1007,416 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Buyer-initiated order cooling-off window (Issue #653). Lets a buyer who
+    /// fat-fingered a quantity or changed their mind undo the transaction
+    /// within `CANCEL_WINDOW_SECONDS` of creation, instead of being locked in
+    /// for the full 96-hour `refund_expired_order` window.
+    ///
+    /// Fee-refund semantics: `order.amount` is the *net* amount held in
+    /// escrow (the platform fee was already transferred to the fee collector
+    /// atomically at `create_order` time). `cancel_order` refunds this net
+    /// amount only — the fee is not refunded, matching the existing
+    /// `refund_expired_order`/`refund_expired_orders` behavior for the same
+    /// reason (the fee has already left the contract).
+    pub fn cancel_order(env: Env, buyer: Address, order_id: u64) -> Result<(), EscrowError> {
+        buyer.require_auth();
+
+        let mut order = read_order(&env, order_id)?;
+        if order.buyer != buyer {
+            return Err(EscrowError::NotBuyer);
+        }
+        if order.status != OrderStatus::Pending {
+            return Err(EscrowError::OrderNotPending);
+        }
+        if order.delivery_timestamp != 0 {
+            return Err(EscrowError::OrderNotDelivered);
+        }
+        if env.ledger().timestamp() > order.timestamp + CANCEL_WINDOW_SECONDS {
+            return Err(EscrowError::CancelWindowClosed);
+        }
+
+        order.status = OrderStatus::Refunded;
+        write_order(&env, order_id, &order);
+
+        token::Client::new(&env, &order.token).transfer(
+            &env.current_contract_address(),
+            &order.buyer,
+            &order.amount,
+        );
+
+        env.events().publish(
+            (symbol_short!("order"), symbol_short!("cancelled")),
+            (order_id, order.buyer),
+        );
+
+        Ok(())
+    }
+
+    // ── Multi-party split orders (Issue #654) ─────────────────────────────
+    // Several co-buyers pool independently-funded shares into a single
+    // escrow record for one delivery — e.g. three neighbors splitting one
+    // bulk sack of grain. Distinct from group-order aggregation, which pools
+    // separate orders toward a farmer's target quantity rather than pooling
+    // contributions into one escrow record.
+
+    /// Registers a new split order. `initiator` must be one of the listed
+    /// `co_buyers` (whichever neighbor proposes the split); `shares[i]` is
+    /// `co_buyers[i]`'s pledged contribution. No funds move yet — each
+    /// co-buyer funds their own share independently via `fund_split_order`.
+    pub fn create_split_order(
+        env: Env,
+        initiator: Address,
+        farmer: Address,
+        token: Address,
+        co_buyers: Vec<Address>,
+        shares: Vec<i128>,
+    ) -> Result<u64, EscrowError> {
+        initiator.require_auth();
+
+        if co_buyers.len() < 2 {
+            return Err(EscrowError::EmptyCoBuyerList);
+        }
+        if co_buyers.len() != shares.len() {
+            return Err(EscrowError::SplitSharesMustSumToTotal);
+        }
+
+        let instance_storage = env.storage().instance();
+        let supported_tokens: Vec<Address> = instance_storage
+            .get(&DataKey::SupportedTokens)
+            .ok_or(EscrowError::ContractNotInitialized)?;
+        if !supported_tokens.contains(&token) {
+            return Err(EscrowError::UnsupportedToken);
+        }
+
+        let mut shares_map: Map<Address, i128> = Map::new(&env);
+        let mut total_amount: i128 = 0;
+        let mut initiator_included = false;
+        for i in 0..co_buyers.len() {
+            let co_buyer = co_buyers.get(i).unwrap();
+            let share = shares.get(i).unwrap();
+            if co_buyer == farmer {
+                return Err(EscrowError::BuyerCannotEqualFarmer);
+            }
+            if share <= 0 {
+                return Err(EscrowError::AmountMustBePositive);
+            }
+            if shares_map.contains_key(co_buyer.clone()) {
+                return Err(EscrowError::AlreadyContributed);
+            }
+            if co_buyer == initiator {
+                initiator_included = true;
+            }
+            shares_map.set(co_buyer.clone(), share);
+            total_amount = total_amount
+                .checked_add(share)
+                .ok_or(EscrowError::ArithmeticError)?;
+        }
+        if !initiator_included {
+            return Err(EscrowError::NotCoBuyer);
+        }
+
+        let order_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SplitOrderCount)
+            .unwrap_or(0u64)
+            + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::SplitOrderCount, &order_id);
+
+        let order = SplitOrder {
+            farmer: farmer.clone(),
+            token: token.clone(),
+            total_amount,
+            co_buyers: co_buyers.clone(),
+            shares: shares_map,
+            funded: Map::new(&env),
+            confirmed: Map::new(&env),
+            funded_count: 0,
+            confirmed_count: 0,
+            confirmed_value: 0,
+            net_amount: 0,
+            timestamp: env.ledger().timestamp(),
+            delivery_timestamp: 0,
+            status: SplitOrderStatus::Funding,
+        };
+        write_split_order(&env, order_id, &order);
+
+        env.events().publish(
+            (symbol_short!("split"), symbol_short!("created")),
+            (order_id, farmer, token, total_amount),
+        );
+
+        Ok(order_id)
+    }
+
+    /// A listed co-buyer funds their own pledged share. Once every co-buyer
+    /// has funded, the order becomes `Active`: the platform fee is taken
+    /// once from the full pool and the remainder stays escrowed for the
+    /// farmer's eventual payout.
+    pub fn fund_split_order(env: Env, co_buyer: Address, order_id: u64) -> Result<(), EscrowError> {
+        co_buyer.require_auth();
+
+        let mut order = read_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Funding {
+            return Err(EscrowError::SplitOrderAlreadyFunded);
+        }
+        let share = order
+            .shares
+            .get(co_buyer.clone())
+            .ok_or(EscrowError::NotCoBuyer)?;
+        if order.funded.get(co_buyer.clone()).unwrap_or(false) {
+            return Err(EscrowError::AlreadyContributed);
+        }
+
+        let token_client = token::Client::new(&env, &order.token);
+        token_client.transfer(&co_buyer, &env.current_contract_address(), &share);
+
+        order.funded.set(co_buyer.clone(), true);
+        order.funded_count += 1;
+
+        if order.funded_count == order.co_buyers.len() {
+            let fee_collector: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::FeeCollector)
+                .ok_or(EscrowError::ContractNotInitialized)?;
+            let fee_rate_bps: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::FeeRateBps)
+                .unwrap_or(DEFAULT_FEE_RATE_BPS);
+            let fee = order
+                .total_amount
+                .checked_mul(fee_rate_bps as i128)
+                .ok_or(EscrowError::ArithmeticError)?
+                / 10_000;
+            let net_amount = order
+                .total_amount
+                .checked_sub(fee)
+                .ok_or(EscrowError::ArithmeticError)?;
+            if fee > 0 {
+                token_client.transfer(&env.current_contract_address(), &fee_collector, &fee);
+            }
+            order.net_amount = net_amount;
+            order.status = SplitOrderStatus::Active;
+
+            env.events().publish(
+                (symbol_short!("split"), symbol_short!("active")),
+                (order_id, net_amount),
+            );
+        }
+
+        write_split_order(&env, order_id, &order);
+
+        env.events().publish(
+            (symbol_short!("split"), symbol_short!("funded")),
+            (order_id, co_buyer, share),
+        );
+
+        Ok(())
+    }
+
+    pub fn mark_split_delivered(env: Env, farmer: Address, order_id: u64) -> Result<(), EscrowError> {
+        farmer.require_auth();
+
+        let mut order = read_split_order(&env, order_id)?;
+        if order.farmer != farmer {
+            return Err(EscrowError::NotFarmer);
+        }
+        if order.status != SplitOrderStatus::Active || order.delivery_timestamp > 0 {
+            return Err(EscrowError::SplitOrderNotFullyFunded);
+        }
+
+        order.delivery_timestamp = env.ledger().timestamp();
+        write_split_order(&env, order_id, &order);
+
+        env.events().publish(
+            (symbol_short!("split"), symbol_short!("delivrd")),
+            (order_id, farmer),
+        );
+
+        Ok(())
+    }
+
+    /// A co-buyer confirms receipt. Payout to the farmer fires once either a
+    /// strict majority-by-value of co-buyers have confirmed, or every
+    /// co-buyer has (unanimous) — whichever threshold is reached first.
+    pub fn confirm_split_receipt(env: Env, co_buyer: Address, order_id: u64) -> Result<(), EscrowError> {
+        co_buyer.require_auth();
+
+        let mut order = read_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Active {
+            return Err(EscrowError::SplitOrderNotFullyFunded);
+        }
+        let share = order
+            .shares
+            .get(co_buyer.clone())
+            .ok_or(EscrowError::NotCoBuyer)?;
+        if order.confirmed.get(co_buyer.clone()).unwrap_or(false) {
+            return Err(EscrowError::AlreadyConfirmed);
+        }
+
+        order.confirmed.set(co_buyer.clone(), true);
+        order.confirmed_count += 1;
+        order.confirmed_value = order
+            .confirmed_value
+            .checked_add(share)
+            .ok_or(EscrowError::ArithmeticError)?;
+
+        let majority_by_value = order.confirmed_value.checked_mul(2).unwrap_or(i128::MAX)
+            > order.total_amount;
+        let unanimous = order.confirmed_count == order.co_buyers.len();
+
+        if majority_by_value || unanimous {
+            order.status = SplitOrderStatus::Completed;
+            token::Client::new(&env, &order.token).transfer(
+                &env.current_contract_address(),
+                &order.farmer,
+                &order.net_amount,
+            );
+            env.events().publish(
+                (symbol_short!("split"), symbol_short!("complete")),
+                (order_id, order.farmer.clone(), order.net_amount),
+            );
+        }
+
+        write_split_order(&env, order_id, &order);
+
+        env.events().publish(
+            (symbol_short!("split"), symbol_short!("confirm")),
+            (order_id, co_buyer),
+        );
+
+        Ok(())
+    }
+
+    pub fn open_split_dispute(
+        env: Env,
+        opened_by: Address,
+        order_id: u64,
+        reason: String,
+        evidence_hash: String,
+    ) -> Result<(), EscrowError> {
+        opened_by.require_auth();
+
+        let mut order = read_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Active {
+            return Err(EscrowError::SplitOrderNotFullyFunded);
+        }
+        let is_co_buyer = order.shares.contains_key(opened_by.clone());
+        if !is_co_buyer && opened_by != order.farmer {
+            return Err(EscrowError::NotOrderParticipant);
+        }
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::SplitOrderDispute(order_id))
+        {
+            return Err(EscrowError::DisputeAlreadyExists);
+        }
+
+        order.status = SplitOrderStatus::Disputed;
+        write_split_order(&env, order_id, &order);
+
+        let dispute = Dispute {
+            order_id,
+            opened_by: opened_by.clone(),
+            reason,
+            evidence_hash,
+            timestamp: env.ledger().timestamp(),
+            resolved: false,
+        };
+        write_split_dispute(&env, order_id, &dispute);
+
+        env.events().publish(
+            (symbol_short!("split"), symbol_short!("disputed")),
+            (order_id, opened_by),
+        );
+
+        Ok(())
+    }
+
+    /// Admin resolves a disputed split order. `Refund` splits `net_amount`
+    /// pro-rata back to each contributor (by their original share of
+    /// `total_amount`); `Release` pays the farmer in full; `Split(bps)`
+    /// divides `net_amount` between a pro-rata refund pool and the farmer.
+    pub fn resolve_split_dispute(
+        env: Env,
+        admin_caller: Address,
+        order_id: u64,
+        resolution: DisputeResolution,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let stored_admin = read_admin(&env)?;
+        if admin_caller != stored_admin {
+            return Err(EscrowError::NotAdmin);
+        }
+
+        let mut order = read_split_order(&env, order_id)?;
+        if order.status != SplitOrderStatus::Disputed {
+            return Err(EscrowError::SplitOrderNotDisputed);
+        }
+        let mut dispute = read_split_dispute(&env, order_id)?;
+        if dispute.resolved {
+            return Err(EscrowError::SplitOrderAlreadyDisputed);
+        }
+
+        match resolution.clone() {
+            DisputeResolution::Refund => {
+                refund_split_order_pro_rata(&env, &order, order.net_amount)?;
+                order.status = SplitOrderStatus::Refunded;
+            }
+            DisputeResolution::Release => {
+                token::Client::new(&env, &order.token).transfer(
+                    &env.current_contract_address(),
+                    &order.farmer,
+                    &order.net_amount,
+                );
+                order.status = SplitOrderStatus::Completed;
+            }
+            DisputeResolution::Split(buyer_share_bps) => {
+                if buyer_share_bps > 10_000 {
+                    return Err(EscrowError::InvalidSplitRatio);
+                }
+                let refund_pool = order
+                    .net_amount
+                    .checked_mul(buyer_share_bps as i128)
+                    .ok_or(EscrowError::ArithmeticError)?
+                    / 10_000;
+                let release_amount = order
+                    .net_amount
+                    .checked_sub(refund_pool)
+                    .ok_or(EscrowError::ArithmeticError)?;
+                refund_split_order_pro_rata(&env, &order, refund_pool)?;
+                if release_amount > 0 {
+                    token::Client::new(&env, &order.token).transfer(
+                        &env.current_contract_address(),
+                        &order.farmer,
+                        &release_amount,
+                    );
+                }
+                order.status = SplitOrderStatus::Completed;
+            }
+        }
+
+        dispute.resolved = true;
+        write_split_order(&env, order_id, &order);
+        write_split_dispute(&env, order_id, &dispute);
+
+        env.events().publish(
+            (symbol_short!("split"), symbol_short!("resolved")),
+            (order_id, resolution),
+        );
+
+        Ok(())
+    }
+
+    pub fn get_split_order(env: Env, order_id: u64) -> Result<SplitOrder, EscrowError> {
+        read_split_order(&env, order_id)
+    }
+
     pub fn open_dispute(
         env: Env,
         opened_by: Address,
@@ -868,56 +1484,25 @@ impl EscrowContract {
         resolve_escrow_dispute_internal(&env, order_id, resolution)
     }
 
-        let buyer_share_bps: u32;
+    // ── Arbitrator pool dispute resolution (Issue #652 drift fix) ────────────
+    // Ported from production_escrow's arbitrator-voting design so the two
+    // contracts no longer diverge on dispute-resolution capability: an
+    // admin-configured pool of arbitrators can vote to resolve a dispute once
+    // quorum is reached, as an alternative to single-admin `resolve_dispute`.
 
-        match resolution.clone() {
-            DisputeResolution::Refund => {
-                order.status = OrderStatus::Refunded;
-                token_client.transfer(&env.current_contract_address(), &order.buyer, &order.amount);
-                buyer_share_bps = 10_000;
-            }
-            DisputeResolution::Release => {
-                order.status = OrderStatus::Completed;
-                token_client.transfer(
-                    &env.current_contract_address(),
-                    &order.farmer,
-                    &order.amount,
-                );
-                buyer_share_bps = 0;
-            }
-            DisputeResolution::Split(split_bps) => {
-                if split_bps > 10_000 {
-                    return Err(EscrowError::InvalidSplitRatio);
-                }
-                buyer_share_bps = split_bps;
-
-                let refund_amount = order
-                    .amount
-                    .checked_mul(buyer_share_bps as i128)
-                    .ok_or(EscrowError::ArithmeticError)?
-                    / 10_000;
-                let release_amount = order
-                    .amount
-                    .checked_sub(refund_amount)
-                    .ok_or(EscrowError::ArithmeticError)?;
-
-                if refund_amount > 0 {
-                    token_client.transfer(
-                        &env.current_contract_address(),
-                        &order.buyer,
-                        &refund_amount,
-                    );
-                }
-                if release_amount > 0 {
-                    token_client.transfer(
-                        &env.current_contract_address(),
-                        &order.farmer,
-                        &release_amount,
-                    );
-                }
-
-                order.status = OrderStatus::Completed;
-            }
+    pub fn set_arbitrators(
+        env: Env,
+        admin_caller: Address,
+        arbitrators: Vec<Address>,
+        quorum: u32,
+    ) -> Result<(), EscrowError> {
+        admin_caller.require_auth();
+        let stored_admin = read_admin(&env)?;
+        if admin_caller != stored_admin {
+            return Err(EscrowError::NotAdmin);
+        }
+        if quorum == 0 || quorum > arbitrators.len() as u32 {
+            return Err(EscrowError::InvalidSplitRatio);
         }
         env.storage().instance().set(&DataKey::Arbitrators, &arbitrators);
         env.storage().instance().set(&DataKey::Quorum, &quorum);

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -2,8 +2,8 @@
 
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
-    token, Address, Env, String,
+    testutils::{Address as _, Events, Ledger},
+    token, Address, Env, IntoVal, String,
 };
 
 fn setup_test() -> (
@@ -20,6 +20,15 @@ fn setup_test() -> (
 ) {
     let env = Env::default();
     env.mock_all_auths();
+    // Issue #652 shared test-fixture fix: a fresh Env defaults to ledger
+    // timestamp 0, which collides with `delivery_timestamp == 0` used
+    // throughout this contract as the "not yet delivered" sentinel. Tests
+    // that don't explicitly advance the clock before `mark_delivered` would
+    // otherwise silently record a delivery_timestamp of 0, defeating the
+    // "already delivered" guard. A live Stellar ledger never has timestamp
+    // 0, so this is a test-fixture gap, not a contract bug — fixed here once
+    // for every test built on this shared fixture instead of per-test.
+    env.ledger().set_timestamp(1_000_000);
 
     let admin = Address::generate(&env);
     let farmer = Address::generate(&env);
@@ -74,6 +83,15 @@ fn create_test_with_tokens() -> (
 ) {
     let env = Env::default();
     env.mock_all_auths();
+    // Issue #652 shared test-fixture fix: a fresh Env defaults to ledger
+    // timestamp 0, which collides with `delivery_timestamp == 0` used
+    // throughout this contract as the "not yet delivered" sentinel. Tests
+    // that don't explicitly advance the clock before `mark_delivered` would
+    // otherwise silently record a delivery_timestamp of 0, defeating the
+    // "already delivered" guard. A live Stellar ledger never has timestamp
+    // 0, so this is a test-fixture gap, not a contract bug — fixed here once
+    // for every test built on this shared fixture instead of per-test.
+    env.ledger().set_timestamp(1_000_000);
 
     let admin = Address::generate(&env);
     let buyer = Address::generate(&env);
@@ -126,14 +144,14 @@ fn test_create_and_confirm_order() {
 
 #[test]
 fn test_mark_delivered_then_confirm() {
-    let (env, client, buyer, farmer, _collector, token, _, _, _, _) = setup_test();
+    let (env, client, buyer, farmer, _collector, token, _, admin, _, _) = setup_test();
 
     let order_id = client
         .mock_all_auths()
         .create_order(&buyer, &farmer, &token.address, &500);
 
     env.ledger().set_timestamp(1000);
-    client.mock_all_auths().mark_delivered(&farmer, &order_id);
+    client.mock_all_auths().mark_delivered(&farmer, &admin, &order_id);
 
     let order = client.get_order_details(&order_id);
     assert_eq!(order.status, OrderStatus::Pending);
@@ -147,7 +165,7 @@ fn test_mark_delivered_then_confirm() {
 
 #[test]
 fn test_mark_delivered_wrong_farmer_fails() {
-    let (env, client, buyer, farmer, _, token, _, _, _, _) = setup_test();
+    let (env, client, buyer, farmer, _, token, _, admin, _, _) = setup_test();
     let fake_farmer = Address::generate(&env);
 
     let order_id = client
@@ -156,22 +174,78 @@ fn test_mark_delivered_wrong_farmer_fails() {
 
     let result = client
         .mock_all_auths()
-        .try_mark_delivered(&fake_farmer, &order_id);
+        .try_mark_delivered(&fake_farmer, &admin, &order_id);
     assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotFarmer);
 }
 
 #[test]
 fn test_mark_delivered_twice_succeeds() {
-    let (env, client, buyer, farmer, _, token, _, _, _, _) = setup_test();
+    let (env, client, buyer, farmer, _, token, _, admin, _, _) = setup_test();
 
     let order_id = client
         .mock_all_auths()
         .create_order(&buyer, &farmer, &token.address, &500);
 
-    client.mock_all_auths().mark_delivered(&farmer, &order_id);
+    client.mock_all_auths().mark_delivered(&farmer, &admin, &order_id);
     env.ledger().set_timestamp(1000);
-    let result = client.mock_all_auths().try_mark_delivered(&farmer, &order_id);
+    let result = client
+        .mock_all_auths()
+        .try_mark_delivered(&farmer, &admin, &order_id);
     assert_eq!(result.unwrap_err().unwrap(), EscrowError::OrderNotPending);
+}
+
+#[test]
+fn test_mark_delivered_wrong_attester_fails() {
+    let (env, client, buyer, farmer, _, token, _, admin, _, _) = setup_test();
+    let fake_attester = Address::generate(&env);
+    client.mock_all_auths().set_attester(&admin, &admin);
+
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &500);
+
+    let result = client
+        .mock_all_auths()
+        .try_mark_delivered(&farmer, &fake_attester, &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotAttester);
+}
+
+#[test]
+fn test_mark_delivered_falls_back_to_admin_before_attester_configured() {
+    let (_env, client, buyer, farmer, _, token, _, admin, _, _) = setup_test();
+
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &500);
+
+    // No set_attester call: admin is the fallback attester.
+    client.mock_all_auths().mark_delivered(&farmer, &admin, &order_id);
+    let order = client.get_order_details(&order_id);
+    assert!(order.delivery_timestamp > 0);
+}
+
+#[test]
+fn test_mark_delivered_uses_configured_attester() {
+    let (env, client, buyer, farmer, _, token, _, admin, _, _) = setup_test();
+    let attester = Address::generate(&env);
+    client.mock_all_auths().set_attester(&admin, &attester);
+
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &500);
+
+    // Admin (the pre-attester fallback) can no longer co-sign once a
+    // dedicated attester is configured.
+    let result = client
+        .mock_all_auths()
+        .try_mark_delivered(&farmer, &admin, &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotAttester);
+
+    client
+        .mock_all_auths()
+        .mark_delivered(&farmer, &attester, &order_id);
+    let order = client.get_order_details(&order_id);
+    assert!(order.delivery_timestamp > 0);
 }
 
 #[test]
@@ -244,6 +318,96 @@ fn test_refund_unexpired_order_fails() {
 
     let result = client.mock_all_auths().try_refund_expired_order(&buyer, &order_id);
     assert_eq!(result.unwrap_err().unwrap(), EscrowError::OrderNotExpired);
+}
+
+#[test]
+fn test_cancel_order_within_window_refunds_buyer() {
+    let (env, client, buyer, farmer, collector, token, _, _, _, contract_id) = setup_test();
+    let amount = 500i128;
+    let fee = amount * 3 / 100;
+    let net_amount = amount - fee;
+
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &amount);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 60);
+    client.mock_all_auths().cancel_order(&buyer, &order_id);
+
+    let order = client.get_order_details(&order_id);
+    assert_eq!(order.status, OrderStatus::Refunded);
+
+    assert_eq!(token.balance(&buyer), 1000 - amount + net_amount);
+    assert_eq!(token.balance(&collector), fee);
+    assert_eq!(token.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_cancel_order_fails_after_window_closes() {
+    let (env, client, buyer, farmer, _, token, _, _, _, _) = setup_test();
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &500);
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + CANCEL_WINDOW_SECONDS + 1);
+
+    let result = client.mock_all_auths().try_cancel_order(&buyer, &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::CancelWindowClosed);
+}
+
+#[test]
+fn test_cancel_order_fails_after_delivery() {
+    let (_env, client, buyer, farmer, _, token, _, admin, _, _) = setup_test();
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &500);
+
+    client
+        .mock_all_auths()
+        .mark_delivered(&farmer, &admin, &order_id);
+
+    let result = client.mock_all_auths().try_cancel_order(&buyer, &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::OrderNotDelivered);
+}
+
+#[test]
+fn test_cancel_order_wrong_buyer_fails() {
+    let (env, client, buyer, farmer, _, token, _, _, _, _) = setup_test();
+    let stranger = Address::generate(&env);
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &500);
+
+    let result = client.mock_all_auths().try_cancel_order(&stranger, &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotBuyer);
+}
+
+#[test]
+fn test_cancel_order_emits_distinct_event() {
+    let (env, client, buyer, farmer, _, token, _, _, _, contract_id) = setup_test();
+    let amount = 500i128;
+    let order_id = client
+        .mock_all_auths()
+        .create_order(&buyer, &farmer, &token.address, &amount);
+
+    client.mock_all_auths().cancel_order(&buyer, &order_id);
+
+    // The test env's event log only retains the most recent top-level
+    // invocation's events, so filtering to the escrow contract after
+    // `cancel_order` isolates exactly the event it emitted. Confirms it's
+    // the distinct `order:cancelled` topic, not a reused `order:refunded`.
+    let escrow_events = env.events().all().filter_by_contract(&contract_id);
+    let expected: soroban_sdk::Vec<(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)> =
+        soroban_sdk::vec![
+            &env,
+            (
+                contract_id,
+                (symbol_short!("order"), symbol_short!("cancelled")).into_val(&env),
+                (order_id, buyer).into_val(&env),
+            ),
+        ];
+    assert_eq!(escrow_events, expected);
 }
 
 #[test]
@@ -645,6 +809,8 @@ fn test_get_orders_by_farmer() {
 fn test_initialize_with_only_one_token_fails() {
     let env = Env::default();
     env.mock_all_auths();
+    // Non-zero baseline ledger timestamp (Issue #652 fixture fix, see setup_test).
+    env.ledger().set_timestamp(1_000_000);
 
     let admin = Address::generate(&env);
     let fee_collector = Address::generate(&env);
@@ -667,6 +833,8 @@ fn test_initialize_with_only_one_token_fails() {
 fn test_initialize_duplicate_fails() {
     let env = Env::default();
     env.mock_all_auths();
+    // Non-zero baseline ledger timestamp (Issue #652 fixture fix, see setup_test).
+    env.ledger().set_timestamp(1_000_000);
 
     let admin = Address::generate(&env);
     let fee_collector = Address::generate(&env);
@@ -830,6 +998,8 @@ fn setup_path_payment_test(
 ) {
     let env = Env::default();
     env.mock_all_auths();
+    // Non-zero baseline ledger timestamp (Issue #652 fixture fix, see setup_test).
+    env.ledger().set_timestamp(1_000_000);
 
     let admin = Address::generate(&env);
     let buyer = Address::generate(&env);
@@ -946,6 +1116,8 @@ fn test_create_order_via_path_payment_unsupported_settlement_token_fails() {
 fn test_create_order_via_path_payment_no_router_configured_fails() {
     let env = Env::default();
     env.mock_all_auths();
+    // Non-zero baseline ledger timestamp (Issue #652 fixture fix, see setup_test).
+    env.ledger().set_timestamp(1_000_000);
 
     let admin = Address::generate(&env);
     let buyer = Address::generate(&env);
@@ -1077,4 +1249,270 @@ fn test_confirm_receipt_without_registry_configured_still_succeeds() {
 
     let order = client.get_order_details(&order_id);
     assert_eq!(order.status, OrderStatus::Completed);
+}
+
+// ── Multi-party split orders (Issue #654) ──────────────────────────────────
+
+fn setup_split_test(
+    co_buyer_count: u32,
+) -> (
+    Env,
+    EscrowContractClient<'static>,
+    Address,
+    Vec<Address>,
+    token::Client<'static>,
+    Address,
+    Address,
+) {
+    let (env, client, _buyer, farmer, _collector, token, _, admin, _, contract_id) = setup_test();
+
+    let sac = token::StellarAssetClient::new(&env, &token.address);
+    let mut co_buyers = Vec::new(&env);
+    for _ in 0..co_buyer_count {
+        let co_buyer = Address::generate(&env);
+        sac.mint(&co_buyer, &1_000);
+        co_buyers.push_back(co_buyer);
+    }
+
+    (env, client, farmer, co_buyers, token, contract_id, admin)
+}
+
+#[test]
+fn test_create_split_order_validates_shares() {
+    let (env, client, farmer, co_buyers, token, _, _admin) = setup_split_test(3);
+    let initiator = co_buyers.get(0).unwrap();
+
+    let mut shares = Vec::new(&env);
+    shares.push_back(300i128);
+    shares.push_back(400i128);
+    // Missing third share: length mismatch.
+    let result = client.mock_all_auths().try_create_split_order(
+        &initiator,
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        EscrowError::SplitSharesMustSumToTotal
+    );
+}
+
+#[test]
+fn test_split_order_partial_funding_stays_in_funding_state() {
+    let (env, client, farmer, co_buyers, token, contract_id, _admin) = setup_split_test(3);
+    let mut shares = Vec::new(&env);
+    shares.push_back(300i128);
+    shares.push_back(300i128);
+    shares.push_back(400i128);
+
+    let order_id = client.mock_all_auths().create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+
+    // Only the first co-buyer funds their share.
+    client
+        .mock_all_auths()
+        .fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+
+    let order = client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Funding);
+    assert_eq!(order.funded_count, 1);
+    // Farmer has not been paid — funds are held, not disbursed.
+    assert_eq!(token.balance(&farmer), 0);
+    assert_eq!(token.balance(&contract_id), 300);
+}
+
+#[test]
+fn test_split_order_becomes_active_once_fully_funded() {
+    let (env, client, farmer, co_buyers, token, _, _admin) = setup_split_test(2);
+    let mut shares = Vec::new(&env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+
+    let order_id = client.mock_all_auths().create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+    client
+        .mock_all_auths()
+        .fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+    let mid = client.get_split_order(&order_id);
+    assert_eq!(mid.status, SplitOrderStatus::Funding);
+
+    client
+        .mock_all_auths()
+        .fund_split_order(&co_buyers.get(1).unwrap(), &order_id);
+    let order = client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Active);
+    // 3% platform fee taken once on full funding: 1000 - 30 = 970.
+    assert_eq!(order.net_amount, 970);
+}
+
+#[test]
+fn test_split_order_fund_twice_fails() {
+    let (env, client, farmer, co_buyers, token, _, _admin) = setup_split_test(2);
+    let mut shares = Vec::new(&env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+
+    let order_id = client.mock_all_auths().create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+    client
+        .mock_all_auths()
+        .fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+    let result = client
+        .mock_all_auths()
+        .try_fund_split_order(&co_buyers.get(0).unwrap(), &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::AlreadyContributed);
+}
+
+#[test]
+fn test_split_order_majority_by_value_releases_despite_non_confirming_contributor() {
+    // Shares: 600 / 200 / 200. The 600-share co-buyer alone is a strict
+    // majority by value, so the order completes even though the other two
+    // co-buyers never confirm.
+    let (env, client, farmer, co_buyers, token, contract_id, _admin) = setup_split_test(3);
+    let mut shares = Vec::new(&env);
+    shares.push_back(600i128);
+    shares.push_back(200i128);
+    shares.push_back(200i128);
+
+    let order_id = client.mock_all_auths().create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+    for co_buyer in co_buyers.iter() {
+        client.mock_all_auths().fund_split_order(&co_buyer, &order_id);
+    }
+    client
+        .mock_all_auths()
+        .mark_split_delivered(&farmer, &order_id);
+
+    // Only the majority-share (non-confirming-others) co-buyer confirms.
+    client
+        .mock_all_auths()
+        .confirm_split_receipt(&co_buyers.get(0).unwrap(), &order_id);
+
+    let order = client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Completed);
+    assert_eq!(token.balance(&farmer), 970);
+    assert_eq!(token.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_split_order_even_split_requires_unanimous_confirmation() {
+    // Shares: 500 / 500. Neither co-buyer alone is a strict majority, so
+    // both must confirm before the farmer is paid.
+    let (env, client, farmer, co_buyers, token, _, _admin) = setup_split_test(2);
+    let mut shares = Vec::new(&env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+
+    let order_id = client.mock_all_auths().create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+    for co_buyer in co_buyers.iter() {
+        client.mock_all_auths().fund_split_order(&co_buyer, &order_id);
+    }
+    client
+        .mock_all_auths()
+        .mark_split_delivered(&farmer, &order_id);
+
+    client
+        .mock_all_auths()
+        .confirm_split_receipt(&co_buyers.get(0).unwrap(), &order_id);
+    let mid = client.get_split_order(&order_id);
+    assert_eq!(mid.status, SplitOrderStatus::Active);
+    assert_eq!(token.balance(&farmer), 0);
+
+    client
+        .mock_all_auths()
+        .confirm_split_receipt(&co_buyers.get(1).unwrap(), &order_id);
+    let order = client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Completed);
+    assert_eq!(token.balance(&farmer), 970);
+}
+
+#[test]
+fn test_split_order_dispute_refund_is_pro_rata_across_all_contributors() {
+    let (env, client, farmer, co_buyers, token, contract_id, admin) = setup_split_test(3);
+    let mut shares = Vec::new(&env);
+    shares.push_back(500i128);
+    shares.push_back(300i128);
+    shares.push_back(200i128);
+
+    let order_id = client.mock_all_auths().create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+    for co_buyer in co_buyers.iter() {
+        client.mock_all_auths().fund_split_order(&co_buyer, &order_id);
+    }
+
+    let reason = String::from_str(&env, "produce never arrived");
+    let evidence_hash = String::from_str(&env, "hash");
+    client.mock_all_auths().open_split_dispute(
+        &co_buyers.get(2).unwrap(),
+        &order_id,
+        &reason,
+        &evidence_hash,
+    );
+
+    client
+        .mock_all_auths()
+        .resolve_split_dispute(&admin, &order_id, &DisputeResolution::Refund);
+
+    let order = client.get_split_order(&order_id);
+    assert_eq!(order.status, SplitOrderStatus::Refunded);
+    // net_amount = 1000 - 3% fee = 970, pro-rata over shares 500/300/200.
+    assert_eq!(token.balance(&co_buyers.get(0).unwrap()), 1_000 - 500 + 485);
+    assert_eq!(token.balance(&co_buyers.get(1).unwrap()), 1_000 - 300 + 291);
+    assert_eq!(token.balance(&co_buyers.get(2).unwrap()), 1_000 - 200 + 194);
+    assert_eq!(token.balance(&contract_id), 0);
+    assert_eq!(token.balance(&farmer), 0);
+}
+
+#[test]
+fn test_fund_split_order_non_co_buyer_fails() {
+    let (env, client, farmer, co_buyers, token, _, _admin) = setup_split_test(2);
+    let mut shares = Vec::new(&env);
+    shares.push_back(500i128);
+    shares.push_back(500i128);
+    let order_id = client.mock_all_auths().create_split_order(
+        &co_buyers.get(0).unwrap(),
+        &farmer,
+        &token.address,
+        &co_buyers,
+        &shares,
+    );
+
+    let stranger = Address::generate(&env);
+    let result = client
+        .mock_all_auths()
+        .try_fund_split_order(&stranger, &order_id);
+    assert_eq!(result.unwrap_err().unwrap(), EscrowError::NotCoBuyer);
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -119,11 +119,12 @@ model Product {
   createdAt     DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt     DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  farmer       Profile        @relation(fields: [farmerWallet], references: [wallet_address], onDelete: Cascade)
+  farmer       Profile            @relation(fields: [farmerWallet], references: [wallet_address], onDelete: Cascade)
   cartItems    CartItem[]
   orders       Order[]
   priceHistory PriceHistory[]
   groupOrders  GroupOrder[]
+  priceTiers   ProductPriceTier[]
 
   @@index([farmerWallet, isAvailable])
   @@map("products")

--- a/server/src/routes/productRoutes.ts
+++ b/server/src/routes/productRoutes.ts
@@ -1,7 +1,14 @@
 import express from 'express';
 import { requireWallet, type WalletRequest } from '../middleware/walletAuth.js';
 import { ApiError, sendProblem } from '../http/errors.js';
-import { createProduct, getProductById, listProducts, softDeleteProduct, updateProduct } from '../services/productService.js';
+import {
+  createProduct,
+  getProductById,
+  getSuggestedPrice,
+  listProducts,
+  softDeleteProduct,
+  updateProduct,
+} from '../services/productService.js';
 
 const router = express.Router();
 
@@ -27,6 +34,16 @@ router.get('/products', async (req, res) => {
 router.get('/products/:id', async (req, res, next) => {
   try {
     const data = await getProductById(String(req.params['id']));
+    res.status(200).json(data);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/products/:id/suggested-price', requireWallet, async (req: WalletRequest, res, next) => {
+  try {
+    if (!req.walletAddress) throw new ApiError(401, 'Unauthorized', 'Missing wallet');
+    const data = await getSuggestedPrice(String(req.params['id']), req.walletAddress);
     res.status(200).json(data);
   } catch (error) {
     next(error);

--- a/server/src/services/productService.test.ts
+++ b/server/src/services/productService.test.ts
@@ -4,6 +4,7 @@ vi.mock('../config/database.js', () => ({
   prisma: {
     $transaction: vi.fn(),
     product: { findUnique: vi.fn(), findMany: vi.fn(), count: vi.fn(), create: vi.fn(), update: vi.fn() },
+    priceHistory: { findMany: vi.fn() },
   },
 }));
 
@@ -17,6 +18,8 @@ import {
   createProduct,
   updateProduct,
   softDeleteProduct,
+  computeSuggestedPrice,
+  getSuggestedPrice,
 } from './productService.js';
 import { prisma } from '../config/database.js';
 
@@ -26,6 +29,7 @@ const mockCount = vi.mocked(prisma.product.count);
 const mockTransaction = vi.mocked(prisma.$transaction);
 const mockCreate = vi.mocked(prisma.product.create);
 const mockUpdate = vi.mocked(prisma.product.update);
+const mockPriceHistoryFindMany = vi.mocked(prisma.priceHistory.findMany);
 
 const SAMPLE_PRODUCT = {
   id: 'prod-1',
@@ -153,5 +157,121 @@ describe('softDeleteProduct', () => {
     const result = await softDeleteProduct('prod-1', '0xfarmer');
 
     expect((result as any).is_available).toBe(false);
+  });
+});
+
+describe('computeSuggestedPrice', () => {
+  it('returns null below the minimum sample threshold', () => {
+    expect(computeSuggestedPrice([])).toBeNull();
+    expect(computeSuggestedPrice([10])).toBeNull();
+    expect(computeSuggestedPrice([10, 20])).toBeNull();
+  });
+
+  it('returns the median for an odd number of samples', () => {
+    expect(computeSuggestedPrice([10, 30, 20])).toBe(20);
+  });
+
+  it('is robust to a single outlier sale', () => {
+    // A single wildly high outlier should not drag the suggestion up much,
+    // unlike a plain average would (which would be ~252).
+    expect(computeSuggestedPrice([98, 100, 102, 1000])).toBe(101);
+  });
+});
+
+describe('getSuggestedPrice', () => {
+  it('throws 404 when the product does not exist', async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+
+    await expect(getSuggestedPrice('missing', '0xfarmer')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 403 when the caller does not own the product', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...SAMPLE_PRODUCT, farmerWallet: '0xother' } as any);
+
+    await expect(getSuggestedPrice('prod-1', '0xfarmer')).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('has no suggestion when the farmer has no sales history', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...SAMPLE_PRODUCT, category: 'Vegetables' } as any);
+    mockPriceHistoryFindMany.mockResolvedValueOnce([]);
+
+    const result = await getSuggestedPrice('prod-1', '0xfarmer');
+
+    expect(result).toEqual({
+      has_suggestion: false,
+      suggested_price: null,
+      currency: null,
+      sample_count: 0,
+    });
+  });
+
+  it('has no suggestion for a single past sale', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...SAMPLE_PRODUCT, category: 'Vegetables' } as any);
+    mockPriceHistoryFindMany.mockResolvedValueOnce([
+      { price: '500', currency: 'USDC' },
+    ] as any);
+
+    const result = await getSuggestedPrice('prod-1', '0xfarmer');
+
+    expect(result.has_suggestion).toBe(false);
+    expect(result.sample_count).toBe(1);
+  });
+
+  it('suggests the median price once enough sales history exists', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...SAMPLE_PRODUCT, category: 'Vegetables' } as any);
+    mockPriceHistoryFindMany.mockResolvedValueOnce([
+      { price: '600', currency: 'USDC' },
+      { price: '500', currency: 'USDC' },
+      { price: '550', currency: 'USDC' },
+    ] as any);
+
+    const result = await getSuggestedPrice('prod-1', '0xfarmer');
+
+    expect(result).toEqual({
+      has_suggestion: true,
+      suggested_price: '550',
+      currency: 'USDC',
+      sample_count: 3,
+    });
+  });
+
+  it('is not skewed by a single outlier sale', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...SAMPLE_PRODUCT, category: 'Vegetables' } as any);
+    mockPriceHistoryFindMany.mockResolvedValueOnce([
+      { price: '98', currency: 'USDC' },
+      { price: '100', currency: 'USDC' },
+      { price: '102', currency: 'USDC' },
+      { price: '1000', currency: 'USDC' },
+    ] as any);
+
+    const result = await getSuggestedPrice('prod-1', '0xfarmer');
+
+    expect(result.suggested_price).toBe('101');
+  });
+
+  it('scopes the query to the calling farmer and same category', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...SAMPLE_PRODUCT, category: 'Vegetables' } as any);
+    mockPriceHistoryFindMany.mockResolvedValueOnce([]);
+
+    await getSuggestedPrice('prod-1', '0xfarmer');
+
+    expect(mockPriceHistoryFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { product: { farmerWallet: '0xfarmer', category: 'Vegetables' } },
+      }),
+    );
+  });
+
+  it('falls back to the same product when it has no category', async () => {
+    mockFindUnique.mockResolvedValueOnce({ ...SAMPLE_PRODUCT, category: null } as any);
+    mockPriceHistoryFindMany.mockResolvedValueOnce([]);
+
+    await getSuggestedPrice('prod-1', '0xfarmer');
+
+    expect(mockPriceHistoryFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { product: { id: 'prod-1', farmerWallet: '0xfarmer' } },
+      }),
+    );
   });
 });

--- a/server/src/services/productService.ts
+++ b/server/src/services/productService.ts
@@ -233,3 +233,69 @@ export async function softDeleteProduct(productId: string, farmerWallet: string)
   emitProductEvent('product:deleted', result);
   return result;
 }
+
+// ── Farmer-owned sales-history price suggestion (Issue #655) ────────────────
+// Lightweight, per-farmer, own-history-only suggestion at the point of
+// listing — distinct from the market-wide price index (#594) or forecasting
+// dashboard (#603), which pool data across farmers.
+
+/** Below this many past sales, a suggestion would be too noisy to show. */
+export const MIN_SALES_FOR_SUGGESTION = 3;
+/** Caps how far back a suggestion looks, so old prices don't dominate. */
+const MAX_SALES_CONSIDERED = 20;
+
+export interface SuggestedPriceResult {
+  has_suggestion: boolean;
+  suggested_price: string | null;
+  currency: string | null;
+  sample_count: number;
+}
+
+/**
+ * Median of `prices`, robust to a single outlier sale skewing a plain
+ * average. Returns null below `MIN_SALES_FOR_SUGGESTION` samples.
+ */
+export function computeSuggestedPrice(prices: number[]): number | null {
+  if (prices.length < MIN_SALES_FOR_SUGGESTION) return null;
+  const sorted = [...prices].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/**
+ * Suggests a listing price for `productId` based on the calling farmer's own
+ * past `PriceHistory` rows for the same category (falling back to the same
+ * product when it has no category), most recent first. Scoped strictly to
+ * `farmerWallet` — never reads another farmer's sales history.
+ */
+export async function getSuggestedPrice(
+  productId: string,
+  farmerWallet: string,
+): Promise<SuggestedPriceResult> {
+  const product = await prisma.product.findUnique({ where: { id: productId } });
+  if (!product) throw new ApiError(404, 'Not Found', 'Product not found');
+  if (product.farmerWallet.toLowerCase() !== farmerWallet.toLowerCase()) {
+    throw new ApiError(403, 'Forbidden', 'You do not own this product');
+  }
+
+  const history = await prisma.priceHistory.findMany({
+    where: {
+      product: product.category
+        ? { farmerWallet: farmerWallet.toLowerCase(), category: product.category }
+        : { id: product.id, farmerWallet: farmerWallet.toLowerCase() },
+    },
+    orderBy: { timestamp: 'desc' },
+    take: MAX_SALES_CONSIDERED,
+    select: { price: true, currency: true },
+  });
+
+  const prices = history.map((row) => Number(row.price)).filter((n) => Number.isFinite(n));
+  const suggested = computeSuggestedPrice(prices);
+
+  return {
+    has_suggestion: suggested !== null,
+    suggested_price: suggested !== null ? suggested.toString() : null,
+    currency: suggested !== null ? (history[0]?.currency ?? product.currency) : null,
+    sample_count: prices.length,
+  };
+}


### PR DESCRIPTION
## Summary

- **#652** — Re-audited `contracts/escrow` against the independent-attester fix (`240c652`) that only landed in `production_escrow`, and ported it (`set_attester` + `mark_delivered` now requires attester co-signature, falling back to admin while unconfigured). Along the way, found and fixed that `contracts/escrow`, `production_escrow`, and `registry` were all **currently uncompilable on `main`** due to unrelated botched merges (missing enum variants / a stray duplicated code block / an undefined `BatchRecord` type) — meaning none of their test suites had actually run in this state. Also found `resolve_escrow_dispute_internal` wasn't reporting outcomes to the reputation registry (unlike `confirm_receipt`), despite an existing test asserting it should. Documented findings, the "both are production contracts, different product surfaces" decision, and a cross-check checklist in `contracts/SECURITY_AUDIT.md` §14.
- **#653** — Added `cancel_order(buyer, order_id)` to both `contracts/escrow` and `production_escrow`: buyer-only, 30-minute cooling-off window, clean error after the window closes or after delivery/confirmation, distinct `order:cancelled` event.
- **#654** — Added multi-party split orders to both contracts: co-buyers pledge shares and fund independently; the order activates once fully funded; payout to the farmer triggers on majority-by-value or unanimous confirmation (whichever comes first); disputes refund pro-rata across all contributors.
- **#655** — Added `GET /products/:id/suggested-price`: computes a median-based (outlier-robust) suggestion from the calling farmer's own `PriceHistory` for the same category (or the same product if uncategorized), with a graceful no-suggestion fallback below 3 past sales. Scoped strictly to the calling farmer's own wallet (404/403 otherwise).

## Test plan

- [x] `cargo test` in `contracts/escrow` — 56/56 passing (incl. 3 new attester tests, 5 new cancel_order tests, 8 new split-order tests)
- [x] `cargo test` in `agro-production/contract/production_escrow` — 191/191 passing (incl. 3 new cancel_order tests, 8 new split-order tests)
- [x] `cargo test` in `agro-production/contract/registry` — compiles and runs again (20/21 passing; the 1 pre-existing failure is unrelated reputation-scoring logic, noted in the audit doc rather than silently fixed)
- [x] `npx vitest run src/services/productService.test.ts` in `server` — 23/23 passing (incl. 9 new suggested-price tests)
- [x] `npx tsc --noEmit` in `server` — no new type errors (3 pre-existing errors in an untouched file, noted in the audit doc)

Pre-existing, unrelated failures found during this work (documented in `contracts/SECURITY_AUDIT.md` §14.6 rather than silently worked around, since fixing them is out of scope for these 4 issues): one `registry` reputation test, several `governance`/`investment_basket` ledger-setup test failures, and several pre-existing `server` test/type failures untouched by this PR.

Closes #652
Closes #653
Closes #654
Closes #655