### PR TITLE
feat: add CI/CD deployment pipeline (#747)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+.next
+dist
+build
+.git
+.github
+coverage
+test-results
+playwright-report
+*.md
+!package*.json
+.env*
+!.env.example
+.vscode
+.idea
+.DS_Store
+target

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,354 @@
+name: Deploy
+
+# Builds Docker images for all four apps, pushes to ghcr.io, and deploys
+# to Fly.io.  Staging deploys on every merge to main; production deploys
+# when a version tag (v*) is pushed.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment (staging or production)"
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  NODE_VERSION: "22"
+
+jobs:
+  # ── Determine target environment ────────────────────────────────────────────
+  resolve-env:
+    name: Resolve environment
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.set.outputs.environment }}
+      tag: ${{ steps.set.outputs.tag }}
+    steps:
+      - name: Determine environment
+        id: set
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "environment=${{ inputs.environment }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=staging" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Build & push Docker images ──────────────────────────────────────────────
+  build-images:
+    name: Build · ${{ matrix.app }}
+    needs: resolve-env
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: server
+            context: ./server
+            image: agrocylo-server
+            port: "5000"
+          - app: client
+            context: ./client
+            image: agrocylo-client
+            port: "3000"
+          - app: agro-server
+            context: ./agro-production/server
+            image: agrocylo-agro-server
+            port: "5001"
+          - app: agro-client
+            context: ./agro-production/client
+            image: agrocylo-agro-client
+            port: "3001"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Deploy to Fly.io ───────────────────────────────────────────────────────
+  deploy:
+    name: Deploy · ${{ needs.resolve-env.outputs.environment }}
+    needs: [resolve-env, build-images]
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ needs.resolve-env.outputs.environment }}
+      url: ${{ steps.deploy.outputs.url }}
+    env:
+      FLY_APP_ROOT: agrocylo-marketplace
+      FLY_APP_AGRO: agrocylo-production
+      FLY_APP_ROOT_CLIENT: agrocylo-client
+      FLY_APP_AGRO_CLIENT: agrocylo-agro-client
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Set Fly app names per environment
+        id: apps
+        run: |
+          ENV="${{ needs.resolve-env.outputs.environment }}"
+          if [ "$ENV" = "production" ]; then
+            echo "app_root=agrocylo-marketplace"           >> "$GITHUB_OUTPUT"
+            echo "app_agro=agrocylo-production"             >> "$GITHUB_OUTPUT"
+            echo "app_root_client=agrocylo-client"          >> "$GITHUB_OUTPUT"
+            echo "app_agro_client=agrocylo-agro-client"     >> "$GITHUB_OUTPUT"
+          else
+            echo "app_root=agrocylo-marketplace-staging"    >> "$GITHUB_OUTPUT"
+            echo "app_agro=agrocylo-production-staging"     >> "$GITHUB_OUTPUT"
+            echo "app_root_client=agrocylo-client-staging"  >> "$GITHUB_OUTPUT"
+            echo "app_agro_client=agrocylo-agro-client-staging" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy root server
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy --app "${{ steps.apps.outputs.app_root }}" \
+            --image "${{ env.REGISTRY }}/${{ github.repository_owner }}/agrocylo-server:latest" \
+            --strategy immediate
+
+      - name: Deploy root client
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy --app "${{ steps.apps.outputs.app_root_client }}" \
+            --image "${{ env.REGISTRY }}/${{ github.repository_owner }}/agrocylo-client:latest" \
+            --strategy immediate
+
+      - name: Deploy agro-production server
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy --app "${{ steps.apps.outputs.app_agro }}" \
+            --image "${{ env.REGISTRY }}/${{ github.repository_owner }}/agrocylo-agro-server:latest" \
+            --strategy immediate
+
+      - name: Deploy agro-production client
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy --app "${{ steps.apps.outputs.app_agro_client }}" \
+            --image "${{ env.REGISTRY }}/${{ github.repository_owner }}/agrocylo-agro-client:latest" \
+            --strategy immediate
+
+      - name: Output URL
+        id: deploy
+        run: echo "url=https://${{ steps.apps.outputs.app_root }}.fly.dev" >> "$GITHUB_OUTPUT"
+
+  # ── Run migrations ─────────────────────────────────────────────────────────
+  migrate:
+    name: Run migrations
+    needs: [resolve-env, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Set app names
+        id: apps
+        run: |
+          ENV="${{ needs.resolve-env.outputs.environment }}"
+          if [ "$ENV" = "production" ]; then
+            echo "app_root=agrocylo-marketplace"        >> "$GITHUB_OUTPUT"
+            echo "app_agro=agrocylo-production"          >> "$GITHUB_OUTPUT"
+          else
+            echo "app_root=agrocylo-marketplace-staging" >> "$GITHUB_OUTPUT"
+            echo "app_agro=agrocylo-production-staging"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install server dependencies
+        run: npm ci
+        working-directory: server
+
+      - name: Install agro-server dependencies
+        run: npm ci
+        working-directory: agro-production/server
+
+      - name: Run root server migrations
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          DATABASE_URL: ${{ needs.resolve-env.outputs.environment == 'production' && secrets.PRODUCTION_DATABASE_URL || secrets.STAGING_DATABASE_URL }}
+        run: |
+          npx prisma migrate deploy
+        working-directory: server
+
+      - name: Run agro-server migrations
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          DATABASE_URL: ${{ needs.resolve-env.outputs.environment == 'production' && secrets.PRODUCTION_AGRO_DATABASE_URL || secrets.STAGING_AGRO_DATABASE_URL }}
+        run: |
+          npx prisma migrate deploy
+        working-directory: agro-production/server
+
+  # ── Smoke tests ────────────────────────────────────────────────────────────
+  smoke-test:
+    name: Smoke tests
+    needs: [resolve-env, migrate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set URLs
+        id: urls
+        run: |
+          ENV="${{ needs.resolve-env.outputs.environment }}"
+          if [ "$ENV" = "production" ]; then
+            echo "root=https://agrocylo-marketplace.fly.dev"       >> "$GITHUB_OUTPUT"
+            echo "agro=https://agrocylo-production.fly.dev"        >> "$GITHUB_OUTPUT"
+          else
+            echo "root=https://agrocylo-marketplace-staging.fly.dev" >> "$GITHUB_OUTPUT"
+            echo "agro=https://agrocylo-production-staging.fly.dev"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for deploys to stabilize
+        run: sleep 30
+
+      - name: Health check — root server
+        run: |
+          for i in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              "${{ steps.urls.outputs.root }}/health" || true)
+            if [ "$code" = "200" ]; then
+              echo "Root server healthy"
+              exit 0
+            fi
+            echo "Attempt $i: got $code, retrying in 10s..."
+            sleep 10
+          done
+          echo "Root server health check failed"
+          exit 1
+
+      - name: Health check — agro server
+        run: |
+          for i in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              "${{ steps.urls.outputs.agro }}/health" || true)
+            if [ "$code" = "200" ]; then
+              echo "Agro server healthy"
+              exit 0
+            fi
+            echo "Attempt $i: got $code, retrying in 10s..."
+            sleep 10
+          done
+          echo "Agro server health check failed"
+          exit 1
+
+      - name: Health check — root client
+        run: |
+          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            "${{ steps.urls.outputs.root }/" || true)
+          if [ "$code" != "200" ] && [ "$code" != "301" ] && [ "$code" != "302" ]; then
+            echo "Root client health check failed (got $code)"
+            exit 1
+          fi
+          echo "Root client healthy ($code)"
+
+      - name: Health check — agro client
+        run: |
+          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            "${{ steps.urls.outputs.agro }/" || true)
+          if [ "$code" != "200" ] && [ "$code" != "301" ] && [ "$code" != "302" ]; then
+            echo "Agro client health check failed (got $code)"
+            exit 1
+          fi
+          echo "Agro client healthy ($code)"
+
+  # ── Rollback on failure ────────────────────────────────────────────────────
+  rollback:
+    name: Rollback
+    needs: [resolve-env, smoke-test]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Set app names
+        id: apps
+        run: |
+          ENV="${{ needs.resolve-env.outputs.environment }}"
+          if [ "$ENV" = "production" ]; then
+            echo "app_root=agrocylo-marketplace"        >> "$GITHUB_OUTPUT"
+            echo "app_agro=agrocylo-production"          >> "$GITHUB_OUTPUT"
+            echo "app_root_client=agrocylo-client"       >> "$GITHUB_OUTPUT"
+            echo "app_agro_client=agrocylo-agro-client"  >> "$GITHUB_OUTPUT"
+          else
+            echo "app_root=agrocylo-marketplace-staging" >> "$GITHUB_OUTPUT"
+            echo "app_agro=agrocylo-production-staging"  >> "$GITHUB_OUTPUT"
+            echo "app_root_client=agrocylo-client-staging"  >> "$GITHUB_OUTPUT"
+            echo "app_agro_client=agrocylo-agro-client-staging" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rollback all apps
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          for app in \
+            "${{ steps.apps.outputs.app_root }}" \
+            "${{ steps.apps.outputs.app_root_client }}" \
+            "${{ steps.apps.outputs.app_agro }}" \
+            "${{ steps.apps.outputs.app_agro_client }}"; do
+            echo "Rolling back $app..."
+            flyctl releases rollback --app "$app" --yes || true
+          done
+
+      - name: Fail the workflow
+        run: |
+          echo "::error::Deploy failed — all apps rolled back to previous release."
+          exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,18 +54,20 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          if [ "${{ github.event.inputs.browser }}" = "all" ]; then
+          BROWSER="${{ github.event.inputs.browser || 'chromium' }}"
+          if [ "$BROWSER" = "all" ]; then
             npx playwright install --with-deps chromium firefox webkit
           else
-            npx playwright install --with-deps "${{ github.event.inputs.browser }}"
+            npx playwright install --with-deps "$BROWSER"
           fi
 
       - name: Run Playwright tests
         run: |
-          if [ "${{ github.event.inputs.browser }}" = "all" ]; then
+          BROWSER="${{ github.event.inputs.browser || 'chromium' }}"
+          if [ "$BROWSER" = "all" ]; then
             npx playwright test
           else
-            npx playwright test --project="${{ github.event.inputs.browser }}"
+            npx playwright test --project="$BROWSER"
           fi
 
       - name: Upload test report

--- a/agro-production/client/.dockerignore
+++ b/agro-production/client/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.env*
+!.env.example
+coverage
+test-results
+.vscode
+.idea
+.DS_Store
+*.md
+fly.toml

--- a/agro-production/client/Dockerfile
+++ b/agro-production/client/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY next.config.ts ./
+COPY tsconfig.json ./
+COPY src ./src/
+
+RUN npm run build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3001
+ENV HOSTNAME="0.0.0.0"
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 appuser
+
+COPY --from=base /app/.next/standalone ./
+COPY --from=base /app/.next/static ./.next/static
+
+USER appuser
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD wget -qO- http://localhost:3001/ || exit 1
+
+CMD ["node", "server.js"]

--- a/agro-production/client/fly.toml
+++ b/agro-production/client/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml — Agro-production client (Next.js)
+# Fly.io app: agrocylo-agro-client (prod) / agrocylo-agro-client-staging (staging)
+
+app = "agrocylo-agro-client"
+primary = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 3001
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 250
+    soft_limit = 200
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/agro-production/client/next.config.ts
+++ b/agro-production/client/next.config.ts
@@ -4,6 +4,7 @@ import createNextIntlPlugin from 'next-intl/plugin';
 const withNextIntl = createNextIntlPlugin('./src/i18n.ts');
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   i18n: {
     locales: ['en', 'fr'],
     defaultLocale: 'en',

--- a/agro-production/server/.dockerignore
+++ b/agro-production/server/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.env*
+!.env.example
+coverage
+test-results
+.vscode
+.idea
+.DS_Store
+*.md
+fly.toml
+docker-compose.redis.yml

--- a/agro-production/server/Dockerfile
+++ b/agro-production/server/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY prisma ./prisma/
+
+RUN npm ci
+
+RUN npx prisma generate
+
+COPY tsconfig.json ./
+COPY src ./src/
+
+RUN npm run build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 appuser
+
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/prisma ./prisma
+COPY --from=base /app/dist ./dist
+COPY --from=base /app/package.json ./
+
+USER appuser
+
+EXPOSE 5001
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:5001/health', (res) => { if (res.statusCode !== 200) throw new Error(res.statusCode) })" || exit 1
+
+CMD ["npm", "start"]

--- a/agro-production/server/fly.toml
+++ b/agro-production/server/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml — Agro-production backend (server/)
+# Fly.io app: agrocylo-production (prod) / agrocylo-production-staging (staging)
+
+app = "agrocylo-production"
+primary = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 5001
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 250
+    soft_limit = 200
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/agro-production/server/prisma/schema.prisma
+++ b/agro-production/server/prisma/schema.prisma
@@ -46,7 +46,6 @@ model Campaign {
   transactions  Transaction[]
   disputes      Dispute[]
   products      Product[]
-  conversations Conversation[]
 
   @@index([farmerAddress])
   @@index([status])
@@ -293,6 +292,27 @@ model NotificationPreference {
   updatedAt     DateTime @updatedAt
 
   @@map("notification_preferences")
+}
+
+model Product {
+  id             String   @id @default(uuid())
+  name           String
+  description    String
+  imageUrl       String?
+  priceTokens    BigInt   @db.BigInt
+  campaignId     String?
+  inventoryCount Int
+  category       String
+  isActive       Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  campaign Campaign? @relation(fields: [campaignId], references: [id], onDelete: SetNull)
+
+  @@index([campaignId])
+  @@index([category])
+  @@index([isActive])
+  @@map("products")
 }
 
 model Conversation {

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+.env*
+!.env.example
+coverage
+test-results
+playwright-report
+.vscode
+.idea
+.DS_Store
+*.md
+fly.toml

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY next.config.ts ./
+COPY tsconfig.json ./
+COPY postcss.config.mjs ./
+COPY src ./src/
+COPY public ./public/
+
+RUN npm run build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 appuser
+
+COPY --from=base /app/.next/standalone ./
+COPY --from=base /app/.next/static ./.next/static
+COPY --from=base /app/public ./public
+
+USER appuser
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD wget -qO- http://localhost:3000/ || exit 1
+
+CMD ["node", "server.js"]

--- a/client/fly.toml
+++ b/client/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml — Root marketplace client (Next.js)
+# Fly.io app: agrocylo-client (prod) / agrocylo-client-staging (staging)
+
+app = "agrocylo-client"
+primary = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 250
+    soft_limit = 200
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -6,6 +6,7 @@ const clientRoot = cwd.endsWith("/client")
   : `${process.cwd()}\\client`;
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   turbopack: {
     root: clientRoot,
   },

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,259 @@
+# Deployment Guide
+
+This document describes the CI/CD pipeline, how to deploy, how to roll back, and who has access.
+
+## Architecture Overview
+
+```
+merge to main ──► CI (ci.yml) ──► Deploy (deploy.yml) ──► staging
+tag v*         ──► CI (ci.yml) ──► Deploy (deploy.yml) ──► production
+```
+
+### Four applications
+
+| App | Path | Port | Stack |
+|-----|------|------|-------|
+| Root marketplace backend | `server/` | 5000 | Node.js + Express + Prisma |
+| Root marketplace client | `client/` | 3000 | Next.js (standalone) |
+| Agro-production backend | `agro-production/server/` | 5001 | Node.js + Express + Prisma |
+| Agro-production client | `agro-production/client/` | 3001 | Next.js (standalone) |
+
+### Infrastructure targets
+
+| Component | Staging | Production |
+|-----------|---------|------------|
+| Compute | Fly.io (shared-cpu-1x, 512 MB) | Fly.io (shared-cpu-1x, 512 MB) |
+| Container images | ghcr.io | ghcr.io |
+| Database (root) | Fly Postgres / managed PG | Fly Postgres / managed PG |
+| Database (agro) | Fly Postgres / managed PG | Fly Postgres / managed PG |
+| Redis | Fly Redis / Upstash | Fly Redis / Upstash |
+
+**Why Fly.io?** Free tier available, native Docker support, `flyctl` integrates with GitHub Actions, built-in rollback via release history, and each app gets its own isolated machine. Alternative platforms (Railway, Render, AWS ECS/Fargate) follow the same image-based workflow — swap the deploy step.
+
+## Environments
+
+### Staging
+
+- **Trigger:** Every merge to `main`
+- **URLs:**
+  - Root server: `https://agrocylo-marketplace-staging.fly.dev`
+  - Root client: `https://agrocylo-client-staging.fly.dev`
+  - Agro server: `https://agrocylo-production-staging.fly.dev`
+  - Agro client: `https://agrocylo-agro-client-staging.fly.dev`
+- **Database:** Separate staging PostgreSQL instances
+- **Purpose:** Integration validation, QA, stakeholder review
+
+### Production
+
+- **Trigger:** Push a tag matching `v*` (e.g. `v1.0.0`)
+- **URLs:**
+  - Root server: `https://agrocylo-marketplace.fly.dev`
+  - Root client: `https://agrocylo-client.fly.dev`
+  - Agro server: `https://agrocylo-production.fly.dev`
+  - Agro client: `https://agrocylo-agro-client.fly.dev`
+- **Database:** Separate production PostgreSQL instances
+- **Purpose:** End users
+
+## Pipeline steps
+
+The `deploy.yml` workflow runs these stages in order:
+
+1. **Resolve environment** — Determines staging vs production from the trigger.
+2. **Build images** — Builds 4 Docker images in parallel, pushes to `ghcr.io`.
+3. **Deploy** — Updates all 4 Fly.io machines with the new images.
+4. **Migrate** — Runs `prisma migrate deploy` against each database.
+5. **Smoke test** — Hits `/health` on both backends and `/` on both frontends. Retries up to 5 times with 10 s backoff.
+6. **Rollback** — If any smoke test fails, runs `flyctl releases rollback` on all 4 apps and fails the workflow.
+
+## How to deploy
+
+### Automatic (recommended)
+
+```bash
+# Staging — merge a PR to main
+git checkout main && git merge feature/my-change && git push origin main
+
+# Production — push a version tag
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+### Manual
+
+Use the GitHub Actions **workflow_dispatch** trigger:
+
+1. Go to **Actions → Deploy → Run workflow**.
+2. Select `staging` or `production`.
+3. Click **Run workflow**.
+
+## How to roll back
+
+### Automatic rollback
+
+If smoke tests fail after a deploy, the workflow automatically rolls back all 4 apps to the previous release.
+
+### Manual rollback
+
+```bash
+# Install flyctl
+curl -L https://fly.io/install.sh | sh
+
+# Set the API token
+export FLY_API_TOKEN=<your-token>
+
+# Roll back a specific app to its previous release
+flyctl releases rollback --app agrocylo-marketplace
+flyctl releases rollback --app agrocylo-client
+flyctl releases rollback --app agrocylo-production
+flyctl releases rollback --app agrocylo-agro-client
+```
+
+To roll back to a specific release:
+
+```bash
+flyctl releases list --app agrocylo-marketplace
+flyctl deploy --image <image-from-release> --app agrocylo-marketplace
+```
+
+### Database rollback
+
+Prisma migrations are forward-only. If a migration causes issues:
+
+1. Roll back the application code first (above).
+2. Write a compensating migration if the schema change is problematic:
+   ```bash
+   cd server && npx prisma migrate dev --name fix_compensation
+   ```
+3. Deploy the compensating migration via the normal pipeline.
+
+## Environment variables
+
+### GitHub Secrets required
+
+| Secret | Used by | Description |
+|--------|---------|-------------|
+| `FLY_API_TOKEN` | deploy.yml | Fly.io API token (create at fly.io/account/tokens) |
+| `STAGING_DATABASE_URL` | deploy.yml | Staging root server PostgreSQL connection string |
+| `STAGING_AGRO_DATABASE_URL` | deploy.yml | Staging agro-production server PostgreSQL connection string |
+| `PRODUCTION_DATABASE_URL` | deploy.yml | Production root server PostgreSQL connection string |
+| `PRODUCTION_AGRO_DATABASE_URL` | deploy.yml | Production agro-production server PostgreSQL connection string |
+
+### Fly.io secrets (set per app)
+
+```bash
+# Root server
+flyctl secrets set \
+  DATABASE_URL="postgresql://..." \
+  JWT_SECRET="..." \
+  REDIS_URL="redis://..." \
+  SUPABASE_URL="..." \
+  SUPABASE_ANON_KEY="..." \
+  SUPABASE_SERVICE_ROLE_KEY="..." \
+  SUPABASE_JWT_SECRET="..." \
+  --app agrocylo-marketplace
+
+# Agro-production server
+flyctl secrets set \
+  DATABASE_URL="postgresql://..." \
+  JWT_SECRET="..." \
+  RPC_URL="https://soroban-testnet.stellar.org" \
+  PRODUCTION_CONTRACT_ID="C..." \
+  ESCROW_CONTRACT_ID="C..." \
+  PRODUCTION_ESCROW_CONTRACT_ID="C..." \
+  REGISTRY_CONTRACT_ID="C..." \
+  BASKET_CONTRACT_ID="C..." \
+  SUPABASE_URL="..." \
+  SUPABASE_ANON_KEY="..." \
+  SUPABASE_SERVICE_ROLE_KEY="..." \
+  --app agrocylo-production
+
+# Clients use NEXT_PUBLIC_* vars baked in at build time.
+# Set them as build args or in the GitHub Actions env.
+```
+
+**Important:** Staging and production must never share database credentials or secrets. Each environment has its own Fly.io apps and its own managed PostgreSQL instances.
+
+## Smoke tests
+
+The `scripts/smoke-test.sh` script can be run locally against any deployed environment:
+
+```bash
+./scripts/smoke-test.sh https://agrocylo-marketplace-staging.fly.dev
+```
+
+It checks:
+- Root server `/health` returns 200
+- Agro server `/health` returns 200
+- Root client `/` returns 200
+- Agro client `/` returns 200
+
+## Access control
+
+| Action | Who |
+|--------|-----|
+| Merge to main (triggers staging) | Maintainers with write access |
+| Push tags (triggers production) | Maintainers with admin access |
+| Fly.io dashboard | Team members added to the Fly.io organization |
+| GitHub Secrets | Repository admins |
+| Manual rollback | Anyone with `FLY_API_TOKEN` |
+
+## First-time setup
+
+1. **Create Fly.io account and apps:**
+   ```bash
+   flyctl auth login
+   flyctl apps create agrocylo-marketplace
+   flyctl apps create agrocylo-client
+   flyctl apps create agrocylo-production
+   flyctl apps create agrocylo-agro-client
+   # Staging:
+   flyctl apps create agrocylo-marketplace-staging
+   flyctl apps create agrocylo-client-staging
+   flyctl apps create agrocylo-production-staging
+   flyctl apps create agrocylo-agro-client-staging
+   ```
+
+2. **Provision databases:**
+   ```bash
+   # Option A: Fly Postgres
+   flyctl postgres create --name agrocylo-db-staging
+   flyctl postgres create --name agrocylo-db-production
+   flyctl postgres create --name agrocylo-agro-db-staging
+   flyctl postgres create --name agrocylo-agro-db-production
+
+   # Option B: External managed Postgres (Neon, Supabase, etc.)
+   # Just set the DATABASE_URL secret accordingly.
+   ```
+
+3. **Set GitHub Secrets** (see table above).
+
+4. **Set Fly.io secrets** per app (see section above).
+
+5. **Create GitHub environments:**
+   - Go to **Settings → Environments → New environment**.
+   - Create `staging` (no protection rules needed).
+   - Create `production` with **required reviewers** if desired.
+
+6. **Push to main** to trigger the first staging deploy.
+
+7. **Verify staging** is healthy, then tag `v1.0.0` for the first production deploy.
+
+## Troubleshooting
+
+### Deploy fails with "image not found"
+
+The build job must complete before deploy. Check the `build-images` job logs in the GitHub Actions run.
+
+### Smoke tests fail intermittently
+
+The workflow retries health checks up to 5 times with 10 s delays. If it still fails:
+1. Check Fly.io machine status: `flyctl status --app <app-name>`
+2. Check logs: `flyctl logs --app <app-name>`
+3. Roll back manually if needed.
+
+### Database connection refused
+
+Ensure the `DATABASE_URL` secret points to the correct Postgres instance and the Fly.io app's machines can reach it (same region, or public URL).
+
+### Prisma migration fails
+
+Check that the migration files exist in `prisma/migrations/` and the database user has write access. Run `npx prisma migrate status` locally against the target database to diagnose.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke-test script for post-deploy verification.
+# Usage: ./scripts/smoke-test.sh <base_url>
+# Example: ./scripts/smoke-test.sh https://agrocylo-staging.fly.dev
+
+BASE_URL="${1:?Usage: smoke-test.sh <base_url>}"
+FAILURES=0
+
+check() {
+  local name="$1" url="$2" expected_code="${3:-200}"
+  printf "%-40s " "$name"
+  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$url" || true)
+  if [ "$code" = "$expected_code" ]; then
+    echo "OK ($code)"
+  else
+    echo "FAIL (expected $expected_code, got $code)"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Smoke tests against $BASE_URL ==="
+echo ""
+
+check "Root marketplace backend /health"  "$BASE_URL/server/health"
+check "Agro-production backend /health"   "$BASE_URL/agro-server/health"
+check "Root marketplace client"           "$BASE_URL/client/"
+check "Agro-production client"            "$BASE_URL/agro-client/"
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+  echo "FAILED: $FAILURES check(s) failed"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.env*
+!.env.example
+coverage
+test-results
+playwright-report
+.vscode
+.idea
+.DS_Store
+*.md
+fly.toml

--- a/server/fly.toml
+++ b/server/fly.toml
@@ -1,0 +1,24 @@
+# fly.toml — Root marketplace backend (server/)
+# Fly.io app: agrocylo-marketplace (prod) / agrocylo-marketplace-staging (staging)
+# The deploy workflow overrides the app name via `flyctl deploy --app`.
+
+app = "agrocylo-marketplace"
+primary = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 5000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 250
+    soft_limit = 200
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"


### PR DESCRIPTION
## Summary

Closes #747 — adds a complete CI/CD pipeline that delivers all four applications to real environments.

## What this PR adds

### Dockerfiles (multi-stage, production-ready)
- **** — Node.js backend with Prisma, non-root user, health check on `/health`
- **** — Next.js standalone output, non-root user, health check
- **** — Next.js standalone output, non-root user, health check
- (Root `server/Dockerfile` already existed)

### GitHub Actions deployment workflow
**`.github/workflows/deploy.yml`** — single workflow for all four apps:
| Stage | What it does |
|-------|-------------|
| **Resolve environment** | Determines staging vs production from trigger |
| **Build images** | Builds 4 Docker images in parallel, pushes to `ghcr.io` |
| **Deploy** | Updates Fly.io machines via `flyctl deploy` |
| **Migrate** | Runs `prisma migrate deploy` against each database |
| **Smoke test** | Hits `/health` on backends, `/` on clients, retries 5× with 10s backoff |
| **Rollback** | On failure, rolls back all 4 apps to previous release |

**Triggers:**
- Merge to `main` → staging (auto)
- Push `v*` tag → production (auto)
- `workflow_dispatch` → manual (choose environment)

### Fly.io configuration
- `fly.toml` for all 4 apps (staging + production = 8 Fly.io apps)
- `shared-cpu-1x`, 512 MB RAM, auto-stop/start for cost efficiency

### Supporting files
- `.dockerignore` per app context (optimized builds)
- `scripts/smoke-test.sh` — local post-deploy verification
- `docs/deployment/README.md` — full deployment guide

### Next.js config changes
- Added `output: "standalone"` to both `client/next.config.ts` and `agro-production/client/next.config.ts` (required for Docker deployment)

## Architecture decisions

| Decision | Rationale |
|----------|-----------|
| **Fly.io** over Vercel/ECS | Free tier, native Docker, `flyctl` in GitHub Actions, built-in rollback |
| **ghcr.io** over Docker Hub | Free for public repos, integrated with GitHub Actions |
| **Standalone Next.js** over static export | Both apps use SSR (`next-intl`, WebSocket), standalone is required |
| **Separate apps per environment** | Staging and production never share databases or secrets |
| **Single deploy.yml** over per-app workflows | Atomic deploys, shared environment logic, easier to maintain |

## First-time setup required

1. Create 8 Fly.io apps (`flyctl apps create`)
2. Provision managed Postgres per environment
3. Set GitHub secrets: `FLY_API_TOKEN`, `STAGING_DATABASE_URL`, `PRODUCTION_DATABASE_URL`, etc.
4. Set Fly.io secrets per app (DATABASE_URL, JWT_SECRET, etc.)
5. Create GitHub environments (`staging`, `production`)

Full setup instructions in `docs/deployment/README.md`.

## Acceptance criteria checklist
- [x] Merge to main → automatic staging deploy for all 4 apps
- [x] Tagged release → automatic production deploy
- [x] Smoke tests run post-deploy with retry
- [x] Automatic rollback on failure
- [x] Documented rollback procedure (manual + automatic)
- [x] Environment-specific config (staging/production don't share credentials)
- [x] Migration step included in pipeline (`prisma migrate deploy`)