### PR TITLE
Drip

### DIFF
--- a/client/src/components/analytics/ConsentBanner.test.tsx
+++ b/client/src/components/analytics/ConsentBanner.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ConsentBanner from "./ConsentBanner";
+
+const mockSetConsent = vi.fn();
+let mockConsent: "granted" | "denied" | "unknown" = "unknown";
+
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({
+    consent: mockConsent,
+    setConsent: mockSetConsent,
+  }),
+}));
+
+describe("ConsentBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConsent = "unknown";
+  });
+
+  it("renders on first visit, when no consent choice has been made yet", () => {
+    render(<ConsentBanner />);
+    expect(screen.getByTestId("analytics-consent-banner")).toBeInTheDocument();
+  });
+
+  it("does not render on a subsequent visit once consent was granted", () => {
+    mockConsent = "granted";
+    render(<ConsentBanner />);
+    expect(
+      screen.queryByTestId("analytics-consent-banner"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render on a subsequent visit once consent was denied", () => {
+    mockConsent = "denied";
+    render(<ConsentBanner />);
+    expect(
+      screen.queryByTestId("analytics-consent-banner"),
+    ).not.toBeInTheDocument();
+  });
+
+  it('grants consent when "Accept" is clicked', () => {
+    render(<ConsentBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+    expect(mockSetConsent).toHaveBeenCalledWith("granted");
+  });
+
+  it('denies consent when "Decline" is clicked', () => {
+    render(<ConsentBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /decline/i }));
+    expect(mockSetConsent).toHaveBeenCalledWith("denied");
+  });
+});

--- a/client/src/components/analytics/ConsentBanner.tsx
+++ b/client/src/components/analytics/ConsentBanner.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useAnalytics } from "@/hooks/useAnalytics";
+
+/**
+ * First-load analytics consent banner.
+ *
+ * Distinct from `components/onboarding/LocationConsent.tsx`, which only
+ * covers geolocation sharing. This banner governs general analytics
+ * tracking (`src/lib/analytics.ts`) and is the only UI that can move
+ * `consentState` out of its default "unknown" state.
+ *
+ * Renders only while consent is "unknown" (i.e. no choice has been
+ * persisted yet). Once the user grants or denies, `setConsent` persists
+ * the choice via `setAnalyticsConsent`/`loadConsent` in the analytics lib
+ * and the banner disappears for good (until storage is cleared).
+ */
+export default function ConsentBanner() {
+  const { consent, setConsent } = useAnalytics();
+
+  if (consent !== "unknown") {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="analytics-consent-banner"
+      className="fixed inset-x-0 bottom-0 z-50 p-4"
+    >
+      <Card className="mx-auto max-w-2xl">
+        <CardContent className="flex flex-col items-center gap-4 py-4 sm:flex-row sm:justify-between">
+          <p className="text-sm text-muted-foreground">
+            We use analytics to understand how Agrocylo is used and improve
+            the platform. No analytics data is collected until you accept.
+          </p>
+          <div className="flex w-full shrink-0 gap-2 sm:w-auto">
+            <Button
+              variant="outline"
+              className="flex-1 sm:flex-none"
+              onClick={() => setConsent("denied")}
+            >
+              Decline
+            </Button>
+            <Button
+              className="flex-1 sm:flex-none"
+              onClick={() => setConsent("granted")}
+            >
+              Accept
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/components/providers/global-provider.tsx
+++ b/client/src/components/providers/global-provider.tsx
@@ -8,6 +8,7 @@ import type { FC, ReactNode } from "react";
 import NextJsToploader from "nextjs-toploader";
 
 import AnalyticsInit from "@/components/AnalyticsInit";
+import ConsentBanner from "@/components/analytics/ConsentBanner";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import QueryProvider from "@/components/QueryProvider";
@@ -27,6 +28,7 @@ interface GlobalProviderProps {
  *   ReactLenis                  smooth scroll, RAF driven by GSAP ticker
  *   QueryProvider               TanStack Query cache
  *   AnalyticsProvider           local event capture + dashboard state
+ *                               (+ ConsentBanner gating that capture)
  *   TransactionFeedbackProvider transaction-state machine
  *   WalletProviderWrapper       Freighter wallet + Profile + Cart + global Navbar
  *
@@ -61,6 +63,7 @@ const GlobalProvider: FC<GlobalProviderProps> = ({ children }) => {
                   color="var(--primary)"
                 />
                 {children}
+                <ConsentBanner />
                 <Toaster richColors />
               </WalletProviderWrapper>
             </TransactionFeedbackProvider>

--- a/client/src/lib/analytics.network.test.ts
+++ b/client/src/lib/analytics.network.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// jsdom does not implement navigator.sendBeacon, so the transport layer
+// falls back to fetch — which lets us assert on outbound requests directly.
+describe("analytics network gating (integration)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.localStorage.clear();
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true } as Response),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("makes no request to the analytics endpoint before consent is granted", async () => {
+    const { trackPageView, trackClick } = await import("./analytics");
+    trackPageView("/marketplace");
+    trackClick({ element: "button", label: "Buy" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("makes no request to the analytics endpoint while consent is denied", async () => {
+    const { setAnalyticsConsent, trackClick } = await import("./analytics");
+    setAnalyticsConsent("denied");
+    trackClick({ element: "button", label: "Buy" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("only sends a request to the analytics endpoint after consent is granted", async () => {
+    const { setAnalyticsConsent, trackClick } = await import("./analytics");
+    setAnalyticsConsent("granted");
+    trackClick({ element: "button", label: "Buy" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/analytics",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/client/src/lib/analytics.test.ts
+++ b/client/src/lib/analytics.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("analytics consent gating", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults consentState to "unknown" rather than "granted"', async () => {
+    const { getAnalyticsConsent } = await import("./analytics");
+    expect(getAnalyticsConsent()).toBe("unknown");
+  });
+
+  it('falls back to "unknown" (not "granted") for an unrecognized stored value', async () => {
+    window.localStorage.setItem("agrocylo.analytics.consent", "yes-please");
+    const { getAnalyticsConsent } = await import("./analytics");
+    expect(getAnalyticsConsent()).toBe("unknown");
+  });
+
+  it("is a no-op for trackEvent-style calls while consent is unknown", async () => {
+    const { trackPageView, trackClick, getAnalyticsEvents } = await import(
+      "./analytics"
+    );
+    trackPageView("/marketplace");
+    trackClick({ element: "button", label: "Buy" });
+    expect(getAnalyticsEvents()).toHaveLength(0);
+  });
+
+  it("is a no-op for trackEvent-style calls once consent is explicitly denied", async () => {
+    const { setAnalyticsConsent, trackClick, getAnalyticsEvents } =
+      await import("./analytics");
+    setAnalyticsConsent("denied");
+    trackClick({ element: "button", label: "Buy" });
+    const clickEvents = getAnalyticsEvents().filter(
+      (event) => event.name === "click",
+    );
+    expect(clickEvents).toHaveLength(0);
+  });
+
+  it("records events once consent is granted", async () => {
+    const { setAnalyticsConsent, trackClick, getAnalyticsEvents } =
+      await import("./analytics");
+    setAnalyticsConsent("granted");
+    trackClick({ element: "button", label: "Buy" });
+    const clickEvents = getAnalyticsEvents().filter(
+      (event) => event.name === "click",
+    );
+    expect(clickEvents).toHaveLength(1);
+  });
+});

--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -88,7 +88,7 @@ const analyticsEndpoint =
   process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT ?? "/api/analytics";
 
 let initialized = false;
-let consentState: AnalyticsConsentState = "granted";
+let consentState: AnalyticsConsentState = "unknown";
 let sessionId = "session";
 let anonymousId = "anonymous";
 let currentPath = "/";
@@ -110,12 +110,12 @@ function generateId() {
 }
 
 function loadConsent(): AnalyticsConsentState {
-  if (!isBrowser) return "granted";
+  if (!isBrowser) return "unknown";
   const stored = window.localStorage.getItem(STORAGE_KEYS.consent);
   if (stored === "granted" || stored === "denied" || stored === "unknown") {
     return stored;
   }
-  return "granted";
+  return "unknown";
 }
 
 function persistConsent(next: AnalyticsConsentState) {


### PR DESCRIPTION
fix(analytics): default consent to "unknown" and add consent banner

- analytics.ts: consentState now defaults to "unknown" instead of
  "granted"; loadConsent() falls back to "unknown" for SSR and any
  unrecognized stored value.
- Add ConsentBanner (components/analytics/), separate from the
  geolocation-scoped LocationConsent, shown only while consent is
  "unknown". Grant/deny persists via the existing setConsent/
  setAnalyticsConsent/loadConsent mechanism.
- Mount ConsentBanner in global-provider.tsx inside AnalyticsProvider.
- Add unit, network-integration, and component tests covering the
  acceptance criteria.

trackEvent-style calls and enqueueTransport already gated on
consentState === "granted"; fixing the default was the actual bug —
no analytics network call can fire before explicit opt-in now.

Closes #818 