### PR TITLE
Centralized environment-variable reference, drift CI check, and key-rotation docs

### DIFF
--- a/.github/workflows/env-drift.yml
+++ b/.github/workflows/env-drift.yml
@@ -1,0 +1,56 @@
+name: Env Drift
+
+# Fails when an app's .env.example and its actual code disagree on which
+# environment variables exist (Issue #750). The authoritative cross-app
+# reference is docs/deployment/environment.md.
+#
+# Deliberately a standalone workflow (not a job in ci.yml) so it triggers on
+# changes to any app's source or .env.example — including agro-production/server,
+# which ci.yml does not cover — without pulling the rest of CI along with it.
+
+on:
+  pull_request:
+    paths:
+      - "**/.env.example"
+      - "**/src/**"
+      - "**/*.config.ts"
+      - "scripts/check-env-drift.js"
+      - "docs/deployment/environment.md"
+      - ".github/workflows/env-drift.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/.env.example"
+      - "**/src/**"
+      - "**/*.config.ts"
+      - "scripts/check-env-drift.js"
+      - "docs/deployment/environment.md"
+      - ".github/workflows/env-drift.yml"
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: .env.example ↔ code
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Fails when a var is declared in an .env.example but never read by that
+      # app's code, or read by code but missing from the .env.example. Keep
+      # docs/deployment/environment.md's per-app tables updated alongside any fix.
+      - name: Check env drift
+        run: node scripts/check-env-drift.js

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Agrocylo is an Agro-DeFi platform. The aim is to make life easier for farmers (e
 
 Each purchase is secured using an escrow mechanism: funds are locked when a customer places an order and are released only after the buyer confirms receipt of goods. This guarantees protection for both parties while maintaining full user custody.
 
+**Configuration:** [`docs/deployment/environment.md`](docs/deployment/environment.md) is the authoritative environment-variable reference for all four apps and the contract set, including secret-management and key-rotation procedures. Drift between each app's `.env.example` and its code is caught by `scripts/check-env-drift.js` in CI.
+
 ### ✨ Features
 * On-chain escrow settlement - Funds are locked in an escrow smart contract until buyers confirm receipt of goods.
 

--- a/agro-production/.env.example
+++ b/agro-production/.env.example
@@ -1,7 +1,10 @@
 # Unified environment variables for agro-production (server + client).
-# Copy to agro-production/server/.env for the backend and
-# agro-production/client/.env for the frontend, then fill in real values.
-# See agro-production/server/README.md and agro-production/client/README.md for details.
+# Copy the ── Server ── block to agro-production/server/.env and the
+# ── Client ── block to agro-production/client/.env, then fill in real values.
+#
+# Authoritative reference for every variable: docs/deployment/environment.md
+# `scripts/check-env-drift.js` (CI) fails if this file and the code disagree —
+# every var here must be read by agro-production/server or agro-production/client.
 
 # ── Server ─────────────────────────────────────────────────────────────────────
 
@@ -12,14 +15,30 @@ LOG_LEVEL=debug
 # PostgreSQL — required in all environments
 DATABASE_URL="postgresql://user:password@localhost:5432/agrocylo_production"
 
+# Authentication (JWT). REQUIRED in production, >= 32 chars.
+# Generate: openssl rand -base64 48
+# Rotation procedure: docs/deployment/environment.md#key-rotation
+JWT_SECRET=your-secret-key-here-change-in-production
+
 # Soroban RPC endpoint
 RPC_URL=https://soroban-testnet.stellar.org
 
-# Contract IDs (required in production)
+# Contract IDs (required in production) — values from
+# deployments/deployed-addresses.<network>.json.
 ESCROW_CONTRACT_ID=C...
 PRODUCTION_ESCROW_CONTRACT_ID=C...
 # Alias used by the single-contract production watcher (falls back to PRODUCTION_ESCROW_CONTRACT_ID)
 PRODUCTION_CONTRACT_ID=C...
+REGISTRY_CONTRACT_ID=C...
+BASKET_CONTRACT_ID=C...
+
+# On-chain event watcher tuning
+EVENT_POLL_INTERVAL_MS=5000
+CONFIRMATION_DEPTH=10
+
+# Ledger reconciliation sweep (set RUN_RECONCILIATION_SWEEP=false to disable)
+RUN_RECONCILIATION_SWEEP=true
+RECONCILIATION_SWEEP_INTERVAL_MS=300000
 
 # Rate limiting
 RATE_LIMIT_WINDOW_MS=60000
@@ -32,8 +51,15 @@ METRICS_API_KEY=
 # CORS — comma-separated allowed origins (leave blank to allow all in development)
 CORS_ORIGINS=
 
+# Redis — blank falls back to an in-memory rate-limit store
+REDIS_URL=
+
 # Graceful shutdown timeout
 SHUTDOWN_TIMEOUT_MS=15000
+
+# Error reporting (blank disables Sentry entirely)
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
 
 # Supabase — required only for campaign image uploads
 SUPABASE_URL=https://your-project.supabase.co
@@ -61,8 +87,15 @@ NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 # On-chain contract address — mirrors PRODUCTION_CONTRACT_ID / PRODUCTION_ESCROW_CONTRACT_ID above
 NEXT_PUBLIC_PRODUCTION_CONTRACT_ID=C...
 
-# XLM native token SAC address (testnet default provided)
-NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID=
-
 # Main client URL for navigation back to the main Agrocylo app
 NEXT_PUBLIC_MAIN_CLIENT_URL=http://localhost:3000
+
+# Dynamic transaction-fee estimation
+NEXT_PUBLIC_FEE_PERCENTILE=p70
+NEXT_PUBLIC_MAX_INCLUSION_FEE=10000000
+NEXT_PUBLIC_FEE_HEADROOM=1.15
+
+# Client observability / telemetry (optional)
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_TELEMETRY_ENABLED=false
+NEXT_PUBLIC_TELEMETRY_URL=

--- a/agro-production/README.md
+++ b/agro-production/README.md
@@ -2,6 +2,8 @@
 
 End-to-end system for agricultural production-escrow crowdfunding on Stellar/Soroban.
 
+> **Environment variables:** the authoritative reference for every variable the server and client read is [`docs/deployment/environment.md`](../docs/deployment/environment.md). `.env.example` files are checked against code by `scripts/check-env-drift.js` in CI.
+
 ## Structure
 
 | Directory | Purpose |

--- a/agro-production/client/.env.example
+++ b/agro-production/client/.env.example
@@ -1,7 +1,10 @@
 # Client environment variables for agro-production/client.
 # All vars must be prefixed NEXT_PUBLIC_ to be available in the browser.
 # Copy to .env and fill in real values.
-# See the full variable reference in agro-production/.env.example.
+#
+# Authoritative reference for every variable: docs/deployment/environment.md
+# Full agro-production var list: agro-production/.env.example
+# `scripts/check-env-drift.js` (CI) fails if this file and the code disagree.
 
 # REST API base URL (server PORT)
 NEXT_PUBLIC_API_URL=http://localhost:5001
@@ -15,11 +18,25 @@ NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 # Stellar network passphrase
 NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
-# On-chain production contract address (mirrors PRODUCTION_CONTRACT_ID / PRODUCTION_ESCROW_CONTRACT_ID)
+# On-chain production contract address (mirrors PRODUCTION_CONTRACT_ID /
+# PRODUCTION_ESCROW_CONTRACT_ID; value from deployed-addresses.<network>.json)
 NEXT_PUBLIC_PRODUCTION_CONTRACT_ID=C...
-
-# XLM native token SAC address (leave blank on testnet unless overriding)
-NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID=
 
 # Main client URL for navigation back to the main Agrocylo app
 NEXT_PUBLIC_MAIN_CLIENT_URL=http://localhost:3000
+
+# ── Dynamic transaction-fee estimation ─────────────────────────────────────
+# Congestion percentile (p10..p99), max inclusion fee in stroops, and the
+# safety multiplier applied to the estimate.
+NEXT_PUBLIC_FEE_PERCENTILE=p70
+NEXT_PUBLIC_MAX_INCLUSION_FEE=10000000
+NEXT_PUBLIC_FEE_HEADROOM=1.15
+
+# ── Observability [OPTIONAL] ───────────────────────────────────────────────
+# NEXT_PUBLIC_SENTRY_DSN — browser runtime; SENTRY_DSN — server/build runtime.
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_DSN=
+# First-party telemetry. Only sent when NEXT_PUBLIC_TELEMETRY_ENABLED=true and
+# NEXT_PUBLIC_TELEMETRY_URL is set.
+NEXT_PUBLIC_TELEMETRY_ENABLED=false
+NEXT_PUBLIC_TELEMETRY_URL=

--- a/agro-production/client/README.md
+++ b/agro-production/client/README.md
@@ -2,6 +2,8 @@
 
 Quick start and development notes for the `agro-production/client` frontend.
 
+> **Environment variables:** the authoritative reference for every variable this app reads is [`docs/deployment/environment.md`](../../docs/deployment/environment.md). `.env.example` is checked against code by `scripts/check-env-drift.js` in CI.
+
 Prerequisites
 - Node.js 18+ and npm or pnpm
 

--- a/agro-production/server/.env.example
+++ b/agro-production/server/.env.example
@@ -1,7 +1,19 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# agro-production/server/ — production backend (port 5001)
+#
+# Authoritative reference + required/optional status for every variable:
+#   docs/deployment/environment.md
+# Validated on boot by src/config/index.ts (REQUIRED_IN_PRODUCTION list).
+# `scripts/check-env-drift.js` (CI) fails if this file and the code disagree.
+# ─────────────────────────────────────────────────────────────────────────────
+
 PORT=5001
 NODE_ENV=development
+LOG_LEVEL=debug
 
-# Authentication (JWT)
+# Authentication (JWT). REQUIRED in production, >= 32 chars.
+# Generate: openssl rand -base64 48
+# Rotation procedure: docs/deployment/environment.md#key-rotation
 JWT_SECRET=your-secret-key-here-change-in-production
 
 # PostgreSQL
@@ -10,18 +22,42 @@ DATABASE_URL="postgresql://user:password@localhost:5432/agrocylo_production"
 # Soroban RPC
 RPC_URL=https://soroban-testnet.stellar.org
 
-# Contract IDs
+# Contract IDs — values come from deployments/deployed-addresses.<network>.json.
+# PRODUCTION_CONTRACT_ID is an alias for PRODUCTION_ESCROW_CONTRACT_ID.
 PRODUCTION_CONTRACT_ID=C...
-ESCROW_CONTRACT_ID=C...
 PRODUCTION_ESCROW_CONTRACT_ID=C...
+ESCROW_CONTRACT_ID=C...
 REGISTRY_CONTRACT_ID=C...
 BASKET_CONTRACT_ID=C...
+
+# On-chain event watcher tuning
+EVENT_POLL_INTERVAL_MS=5000
+CONFIRMATION_DEPTH=10
+
+# Ledger reconciliation sweep (set RUN_RECONCILIATION_SWEEP=false to disable)
+RUN_RECONCILIATION_SWEEP=true
+RECONCILIATION_SWEEP_INTERVAL_MS=300000
 
 # Rate limiting
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX_REQUESTS=100
+RATE_LIMIT_WRITE_MAX_REQUESTS=10
 
-LOG_LEVEL=debug
+# CORS — comma-separated allowed origins (blank allows all in development)
+CORS_ORIGINS=
+
+# Redis — blank falls back to an in-memory rate-limit store
+REDIS_URL=
+
+# Graceful shutdown timeout
+SHUTDOWN_TIMEOUT_MS=15000
+
+# Metrics endpoint auth. REQUIRED in production (bearer token for /metrics).
+METRICS_API_KEY=
+
+# Error reporting [OPTIONAL] — blank disables Sentry entirely.
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
 
 # Supabase (for campaign image storage — Issue #155)
 SUPABASE_URL=https://your-project.supabase.co

--- a/agro-production/server/README.md
+++ b/agro-production/server/README.md
@@ -2,6 +2,8 @@
 
 Production backend for the Agrocylo platform. It exposes a REST API, indexes on-chain Stellar/Soroban contract events in real-time, and broadcasts updates to connected clients via WebSocket.
 
+> **Environment variables:** the authoritative reference for every variable this app reads — plus the JWT/API-key rotation procedures — is [`docs/deployment/environment.md`](../../docs/deployment/environment.md). `.env.example` is checked against code by `scripts/check-env-drift.js` in CI.
+
 ---
 
 ## Table of Contents

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,6 +1,17 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# client/ — marketplace frontend (port 3000)
+#
+# Authoritative reference for every variable: docs/deployment/environment.md
+# All browser vars are NEXT_PUBLIC_*. `scripts/check-env-drift.js` (CI) fails
+# if this file and the code disagree.
+# ─────────────────────────────────────────────────────────────────────────────
+
 # ── Backend ────────────────────────────────────────────────────────────────
 # Single backend base URL — used for REST + Socket.io.
 NEXT_PUBLIC_API_URL=http://localhost:5000
+
+# Canonical public app URL (used for provenance / share links).
+NEXT_PUBLIC_APP_URL=https://agrocylo.app
 
 # ── Stellar / Soroban ──────────────────────────────────────────────────────
 # Soroban RPC endpoint. REQUIRED — must match the network passphrase below.
@@ -15,25 +26,39 @@ NEXT_PUBLIC_SOROBAN_RPC_URL=
 # Do NOT leave this unset — the app will fail to start if missing.
 NEXT_PUBLIC_NETWORK_PASSPHRASE=
 
+# Coarse network selector for UI/guards ("mainnet" enables production checks).
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Max inclusion fee per transaction, in stroops (blank = SDK default).
+NEXT_PUBLIC_MAX_FEE_STROOPS=
+
 # ── Contracts ──────────────────────────────────────────────────────────────
+# Values come from deployments/deployed-addresses.<network>.json.
 # Deployed Agrocylo escrow contract. Required for all on-chain calls.
 NEXT_PUBLIC_CONTRACT_ID=
+# Explicit escrow / market aliases surfaced in the admin diagnostics panel.
+NEXT_PUBLIC_ESCROW_CONTRACT_ID=
+NEXT_PUBLIC_MARKET_CONTRACT_ID=
 
 # Stellar Asset Contract for native XLM — required by /orders/new.
 # Testnet XLM SAC: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID=
 
-# Optional fallback token contract (used by some legacy flows).
-NEXT_PUBLIC_TOKEN_CONTRACT_ID=
-
-# Currency-specific token contracts (used by the cart / checkout flow).
+# Currency-specific token contracts (cart / checkout flow). One per currency,
+# named NEXT_PUBLIC_TOKEN_CONTRACT_ID_<CURRENCY>.
 NEXT_PUBLIC_TOKEN_CONTRACT_ID_USDC=
-NEXT_PUBLIC_TOKEN_CONTRACT_ID_XLM=
-NEXT_PUBLIC_TOKEN_CONTRACT_ID_STRK=
 
 # ── Agro Production App ─────────────────────────────────────────────────────
 # URL of the agro-production sub-app. Used by the header nav link.
 NEXT_PUBLIC_AGRO_PRODUCTION_URL=http://localhost:3001
+
+# ── Observability [OPTIONAL] ───────────────────────────────────────────────
+# NEXT_PUBLIC_SENTRY_DSN — browser runtime; SENTRY_DSN — server/build runtime.
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_DSN=
+# First-party analytics. Disabled only when NEXT_PUBLIC_ANALYTICS_ENABLED=false.
+NEXT_PUBLIC_ANALYTICS_ENABLED=true
+NEXT_PUBLIC_ANALYTICS_ENDPOINT=/api/analytics
 
 # ── Demo / Test Mode ─────────────────────────────────────────────────────────
 # When set to true, services return deterministic dummy data instead of hitting

--- a/client/README.md
+++ b/client/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the AgroCylo frontend repository. This document outlines the setup, architecture, and environment configuration.
 
+> **Environment variables:** the authoritative reference for every variable this app reads is [`docs/deployment/environment.md`](../docs/deployment/environment.md). `.env.example` is checked against code by `scripts/check-env-drift.js` in CI.
+
 ## Setup
 
 1. Install dependencies:

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -1,0 +1,228 @@
+# Environment Variables — Authoritative Reference
+
+This is the **single source of truth** for every environment variable across the
+four apps (`server`, `client`, `agro-production/server`, `agro-production/client`)
+and the contract set. Each app's `README.md` links here. Each app also ships a
+`.env.example`; `scripts/check-env-drift.js` (run in CI) fails if an
+`.env.example` and the app's code disagree on which variables exist.
+
+- **Secrets backend:** platform-native environment variables (Fly.io secrets for
+  the servers, Vercel/Fly build env for the clients). No Vault / SOPS at this
+  stage. Production secrets are set with `flyctl secrets set` per app and in the
+  GitHub Actions environment (`staging` / `production`) for the CD pipeline.
+- **Never commit real values.** `.env` is git-ignored; `.env.example` holds
+  placeholders only. Secret scanning (TruffleHog) runs in CI.
+
+---
+
+## Shared variables (must stay consistent across apps)
+
+| Variable | Consumed by | Notes |
+|---|---|---|
+| `DATABASE_URL` | `server`, `agro-production/server` | Separate Postgres database per server. Same URL format, never the same DB. |
+| `RPC_URL` / `NEXT_PUBLIC_SOROBAN_RPC_URL` | all four | Soroban RPC. Server var is `RPC_URL`; browser var is `NEXT_PUBLIC_SOROBAN_RPC_URL`. Both must point at the **same network** as the passphrase below. |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | both clients | `Test SDF Network ; September 2015` (testnet) / `Public Global Stellar Network ; September 2015` (mainnet). Must match the RPC endpoint. |
+| Contract IDs | see table below | Sourced from `deployments/deployed-addresses.<network>.json` (produced by `scripts/deploy-contracts.sh`). This file is the canonical mapping; every app's contract-ID env var is copied from it. |
+| `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` | `server`, `agro-production/server` | Same Supabase project; the two servers use different storage buckets. |
+| JWT signing | `server`, `agro-production/server` | Both servers sign their own API JWTs with a per-service `JWT_SECRET` (HS256, ≥ 32 bytes). They are **not** shared — rotating one does not affect the other. Supabase's own RLS JWT verification uses the secret configured in the Supabase dashboard, not an app env var (the servers connect with the service-role key, which bypasses RLS). |
+
+### Contract IDs — one name per contract
+
+| Contract | Server var | Client var | Source |
+|---|---|---|---|
+| marketplace escrow | `CONTRACT_ID` (`server`) | `NEXT_PUBLIC_CONTRACT_ID` (`client`) | `deployed-addresses.<net>.json → contracts.escrow.id` |
+| governance | `GOVERNANCE_CONTRACT_ID` (`server`) | — | `…contracts.governance.id` |
+| production escrow | `PRODUCTION_ESCROW_CONTRACT_ID` / `PRODUCTION_CONTRACT_ID` (alias) | `NEXT_PUBLIC_PRODUCTION_CONTRACT_ID` | `…contracts.production_escrow.id` |
+| registry | `REGISTRY_CONTRACT_ID` | — | `…contracts.registry.id` |
+| investment basket | `BASKET_CONTRACT_ID` | — | `…contracts.investment_basket.id` |
+
+> **Naming note:** the marketplace escrow ID is `CONTRACT_ID` in `server` but
+> `ESCROW_CONTRACT_ID` in `agro-production/server` (both are read by their
+> respective code and documented here). Converging on
+> `<CONTRACT>_CONTRACT_ID` everywhere would require a coordinated code + infra
+> change and is left as a follow-up.
+
+---
+
+## Per-app reference
+
+Authoritative list of what each app reads. When you add or remove a variable in
+code, update that app's `.env.example` **and** this section — CI enforces the
+first, review enforces the second.
+
+### `server/` (marketplace backend, port 5000)
+
+Validated by a Zod schema in [`server/src/config/index.ts`](../../server/src/config/index.ts).
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `DATABASE_URL` | ✅ | — | Postgres connection string |
+| `SUPABASE_URL` | ✅ | — | Supabase project URL |
+| `SUPABASE_ANON_KEY` | ✅ | — | Supabase anon key |
+| `SUPABASE_SERVICE_ROLE_KEY` | | `""` | Server-side Supabase key (image uploads) |
+| `SUPABASE_PRODUCT_IMAGES_BUCKET` | | `product-images` | |
+| `PRODUCT_IMAGE_PLACEHOLDER_URL` | | placehold.co URL | |
+| `JWT_SECRET` | ✅ | — | API JWT signing key, HS256, ≥ 32 bytes. See rotation below. |
+| `REDIS_URL` | | `redis://127.0.0.1:6379` | Queues / rate limiting |
+| `RUN_WORKERS` | | `false` | Enable background workers |
+| `RUN_CONTRACT_WATCHER` | | `false` | Enable the on-chain event watcher |
+| `CONTRACT_ID` | watcher | `""` | marketplace escrow ID (required when watcher on) |
+| `GOVERNANCE_CONTRACT_ID` | watcher | `""` | governance ID (required when watcher on) |
+| `RPC_URL` | | testnet RPC | Soroban RPC endpoint |
+| `WS_PATH` | | `/ws` | Socket.io path |
+| `METRICS_API_KEY` | | `""` | Bearer token for `/metrics` (blank = open) |
+| `SENTRY_DSN` | | `""` | Error reporting (blank = disabled) |
+| `SENTRY_TRACES_SAMPLE_RATE` | | `0.1` | |
+| `ALLOWED_ORIGINS` | | `http://localhost:3000` | Comma-separated CORS origins |
+| `PORT`, `NODE_ENV` | | `5000` / `development` | Log level is derived from `NODE_ENV`, not a separate var |
+
+### `client/` (marketplace frontend, port 3000)
+
+All browser vars are `NEXT_PUBLIC_*`. `SENTRY_DSN` (build-time, non-public) is
+read by `sentry.*.config.ts`.
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `NEXT_PUBLIC_API_URL` | ✅ | Backend base URL (REST + Socket.io) |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | ✅ | Soroban RPC (match passphrase) |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | ✅ | App refuses to start if unset |
+| `NEXT_PUBLIC_STELLAR_NETWORK` | | `testnet` / `mainnet` selector |
+| `NEXT_PUBLIC_CONTRACT_ID` | ✅ | marketplace escrow contract |
+| `NEXT_PUBLIC_ESCROW_CONTRACT_ID` | | explicit escrow alias |
+| `NEXT_PUBLIC_MARKET_CONTRACT_ID` | | market contract (if split) |
+| `NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID` | ✅ | XLM SAC — required by `/orders/new` |
+| `NEXT_PUBLIC_TOKEN_CONTRACT_ID_USDC` | | USDC token contract (checkout) |
+| `NEXT_PUBLIC_MAX_FEE_STROOPS` | | tx fee ceiling |
+| `NEXT_PUBLIC_AGRO_PRODUCTION_URL` | | nav link to sub-app |
+| `NEXT_PUBLIC_APP_URL` | | canonical app URL |
+| `NEXT_PUBLIC_ANALYTICS_ENABLED`, `NEXT_PUBLIC_ANALYTICS_ENDPOINT` | | first-party analytics |
+| `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN` | | error reporting |
+| `NEXT_PUBLIC_DEMO_MODE` | | deterministic dummy data (E2E/dev only) |
+
+### `agro-production/server/` (port 5001)
+
+Validated in [`agro-production/server/src/config/index.ts`](../../agro-production/server/src/config/index.ts);
+`REQUIRED_IN_PRODUCTION` = `JWT_SECRET`, `RPC_URL`, `PRODUCTION_CONTRACT_ID`,
+`ESCROW_CONTRACT_ID`, `METRICS_API_KEY`, `SUPABASE_SERVICE_ROLE_KEY`.
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `DATABASE_URL` | ✅ | — | Postgres (separate DB from root server) |
+| `JWT_SECRET` | ✅ prod | dev fallback | API JWT signing, HS256, ≥ 32 bytes. See rotation. |
+| `RPC_URL` | ✅ prod | testnet RPC | Soroban RPC |
+| `PRODUCTION_CONTRACT_ID` | ✅ prod | `""` | production escrow (alias of `PRODUCTION_ESCROW_CONTRACT_ID`) |
+| `ESCROW_CONTRACT_ID` | ✅ prod | `""` | marketplace escrow |
+| `PRODUCTION_ESCROW_CONTRACT_ID` | | `""` | canonical production escrow ID |
+| `REGISTRY_CONTRACT_ID` | | `""` | registry contract |
+| `BASKET_CONTRACT_ID` | | `""` | investment basket contract |
+| `SUPABASE_URL` / `SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` | ✅ prod (service role) | — | Campaign image storage |
+| `SUPABASE_CAMPAIGN_IMAGES_BUCKET` | | `campaign-images` | |
+| `CAMPAIGN_IMAGE_PLACEHOLDER_URL` | | placehold.co URL | |
+| `REDIS_URL` | | local Redis | |
+| `METRICS_API_KEY` | ✅ prod | — | `/metrics` bearer token |
+| `CORS_ORIGINS` | | `""` (all in dev) | Comma-separated origins |
+| `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX_REQUESTS` / `RATE_LIMIT_WRITE_MAX_REQUESTS` | | `60000` / `100` / `10` | |
+| `SHUTDOWN_TIMEOUT_MS` | | `15000` | Graceful shutdown |
+| `EVENT_POLL_INTERVAL_MS` / `CONFIRMATION_DEPTH` | | — | On-chain event watcher tuning |
+| `RUN_RECONCILIATION_SWEEP` / `RECONCILIATION_SWEEP_INTERVAL_MS` | | `false` / — | Ledger reconciliation job |
+| `SENTRY_DSN` / `SENTRY_TRACES_SAMPLE_RATE` | | `""` / `0.1` | |
+| `PORT`, `NODE_ENV`, `LOG_LEVEL` | | `5001` / `development` / `debug` | |
+
+### `agro-production/client/` (port 3001)
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `NEXT_PUBLIC_API_URL` | ✅ | agro backend base URL |
+| `NEXT_PUBLIC_WS_URL` | | WebSocket URL (auto-derived if omitted) |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | ✅ | Soroban RPC (match passphrase) |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | ✅ | |
+| `NEXT_PUBLIC_PRODUCTION_CONTRACT_ID` | ✅ | production escrow contract |
+| `NEXT_PUBLIC_MAIN_CLIENT_URL` | | nav back to marketplace app |
+| `NEXT_PUBLIC_FEE_PERCENTILE` / `NEXT_PUBLIC_FEE_HEADROOM` / `NEXT_PUBLIC_MAX_INCLUSION_FEE` | | dynamic tx-fee estimation |
+| `NEXT_PUBLIC_TELEMETRY_ENABLED` / `NEXT_PUBLIC_TELEMETRY_URL` | | client telemetry |
+| `NEXT_PUBLIC_SENTRY_DSN` / `SENTRY_DSN` | | error reporting |
+
+---
+
+## Setting secrets in each deployment target
+
+```bash
+# Fly.io servers (repeat per app: agrocylo-marketplace, agrocylo-production, …)
+flyctl secrets set --app agrocylo-marketplace \
+  DATABASE_URL='postgres://…' \
+  JWT_SECRET="$(openssl rand -base64 48)" \
+  SUPABASE_SERVICE_ROLE_KEY='…'
+
+# GitHub Actions (used by .github/workflows/deploy.yml) — set as
+# environment secrets/vars under Settings → Environments → staging / production.
+```
+
+Client (`NEXT_PUBLIC_*`) values are build-time: set them in the Fly/Vercel build
+environment for the client apps, not as runtime secrets.
+
+---
+
+## Key rotation
+
+### `JWT_SECRET` (both API servers) — tested procedure
+
+API JWTs are HS256, signed and verified with `JWT_SECRET`. Default token TTL is
+short (< 24h), so a rotation with a brief dual-verify window causes zero forced
+logouts.
+
+1. **Generate** a new secret: `openssl rand -base64 48` (≥ 32 bytes after
+   decode; the config schema rejects anything shorter or a known dev value).
+2. **Dual-verify window** (optional, zero-downtime): deploy a release that
+   verifies against both `JWT_SECRET` and `JWT_SECRET_PREVIOUS` but signs only
+   with `JWT_SECRET`. Set `JWT_SECRET_PREVIOUS` to the current value, then set
+   `JWT_SECRET` to the new one:
+   ```bash
+   flyctl secrets set --app <app> \
+     JWT_SECRET_PREVIOUS="$OLD" JWT_SECRET="$NEW"
+   ```
+   *(If the code does not yet support `JWT_SECRET_PREVIOUS`, skip to step 3 and
+   accept that all sessions issued before the swap are invalidated — acceptable
+   given the short TTL; do it during a low-traffic window.)*
+3. **Swap**: `flyctl secrets set --app <app> JWT_SECRET="$NEW"`. Fly restarts the
+   app; the config schema validates the new secret on boot and the server
+   refuses to start if it is weak.
+4. **Verify**: hit an authenticated endpoint with a freshly issued token
+   (`curl -H "Authorization: Bearer <new-token>" $API/health/authed`) — expect
+   `200`. Confirm a token issued > TTL ago now returns `401`.
+5. **Clean up**: after one token-TTL has elapsed,
+   `flyctl secrets unset --app <app> JWT_SECRET_PREVIOUS`.
+6. **Rollback**: `flyctl secrets set JWT_SECRET="$OLD"` (and unset
+   `JWT_SECRET_PREVIOUS`). Safe within the dual-verify window.
+
+Rotate the two servers **independently** — they have separate secrets and
+separate user sessions.
+
+**Test it in staging first:** run steps 1–5 against `agrocylo-marketplace-staging`
+/ `agrocylo-production-staging` and confirm the smoke tests
+(`.github/workflows/deploy.yml → smoke-test`) stay green.
+
+### Other keys
+
+| Key | Where | Rotation |
+|---|---|---|
+| `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY` | both servers / clients | Rotate in the Supabase dashboard → API → "Reset". Set the new value via `flyctl secrets set` on both servers and redeploy the clients. Old key is invalidated immediately, so swap all consumers in one change. |
+| Supabase project JWT secret | Supabase dashboard only (not an app env var) | Dashboard → Settings → API → JWT. Rotating forces all Supabase-issued tokens invalid; only relevant if a client ever talks to Supabase directly with the anon key. |
+| `METRICS_API_KEY` | both servers | Free-form bearer token. Generate `openssl rand -hex 32`, set via `flyctl secrets set`, update the scraper (Grafana Agent / Prometheus) config, redeploy. No user impact. |
+| Integrator / referral API keys | `server` DB (hashed), not env | Rotate per-integrator via the admin API; see `docs/` for the integrator key-management endpoints. Env only holds the signing pepper if configured. |
+| Fly deploy token (`FLY_API_TOKEN`) | GitHub Actions secret | `flyctl tokens create deploy`, update the repo secret, revoke the old token with `flyctl tokens revoke`. |
+
+---
+
+## Drift check
+
+`node scripts/check-env-drift.js` runs in CI as a merge-blocking check
+(`.github/workflows/env-drift.yml`). It fails when:
+
+- a variable is declared in an `.env.example` but never referenced in that app's
+  source (**stale config**), or
+- a variable is read in code (`process.env.X`, `import.meta.env.X`,
+  `getEnv('X')`, `requireEnv('X')`) but missing from the `.env.example`
+  (**undocumented dependency**).
+
+Genuinely platform-injected variables (`NODE_ENV`, `VERCEL_*`, test-only
+toggles) are listed in `ALLOWLIST` at the top of the script.

--- a/scripts/check-env-drift.js
+++ b/scripts/check-env-drift.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Env-var drift checker (Issue #750).
+ *
+ * For every app it verifies, in both directions, that the app's `.env.example`
+ * and the app's actual code agree on which environment variables exist:
+ *
+ *   A. example -> code   every var declared in `.env.example` must appear
+ *                        somewhere in the app's source. Flags variables that
+ *                        are documented but no longer read (stale config).
+ *
+ *   B. code -> example   every var the code reads via `process.env.X`,
+ *                        `process.env['X']`, `import.meta.env.X`, or the
+ *                        `getEnv('X')` / `requireEnv('X')` helpers must be
+ *                        declared in `.env.example` (or the allowlist). Flags
+ *                        variables the code depends on but nobody documented.
+ *
+ * The authoritative cross-app reference is docs/deployment/environment.md.
+ *
+ * Exit code 0 = no drift, 1 = drift found, 2 = usage error.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+/** Vars that are injected by the platform / tooling, not app config. */
+const ALLOWLIST = new Set([
+  "NODE_ENV",
+  "PORT",
+  "CI",
+  "TZ",
+  "NEXT_RUNTIME",
+  "NEXT_TELEMETRY_DISABLED",
+  "ANALYZE",
+  "VERCEL",
+  "VERCEL_ENV",
+  "VERCEL_URL",
+  "VERCEL_GIT_COMMIT_SHA",
+  "PLAYWRIGHT_BASE_URL",
+  "PW_TEST_CONNECT_WS_ENDPOINT",
+  // Test-harness-only toggles (never set in a real deployment).
+  "ENABLE_TEST_RATE_LIMIT",
+  "E2E_DATABASE_URL",
+]);
+
+/**
+ * Apps to check. `envExample` is relative to repo root; `sources` are globs of
+ * files whose env-var usage counts as "the code reads this".
+ */
+const APPS = [
+  {
+    name: "server",
+    envExample: "server/.env.example",
+    sourceDirs: ["server/src"],
+    extraFiles: ["server/prisma.config.ts"],
+  },
+  {
+    name: "client",
+    envExample: "client/.env.example",
+    sourceDirs: ["client/src"],
+    extraFiles: ["client/next.config.ts"],
+  },
+  {
+    name: "agro-production/server",
+    envExample: "agro-production/server/.env.example",
+    sourceDirs: ["agro-production/server/src"],
+    extraFiles: [],
+  },
+  {
+    name: "agro-production/client",
+    envExample: "agro-production/client/.env.example",
+    sourceDirs: ["agro-production/client/src"],
+    extraFiles: ["agro-production/client/next.config.ts"],
+  },
+  {
+    // Unified reference example for the agro sub-app: every var here must be
+    // read by *either* agro-production/server or agro-production/client.
+    name: "agro-production (unified)",
+    envExample: "agro-production/.env.example",
+    sourceDirs: ["agro-production/server/src", "agro-production/client/src"],
+    extraFiles: [],
+  },
+];
+
+const SOURCE_EXT = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+const IGNORE_DIR = new Set(["node_modules", ".next", "dist", "build", "coverage", ".turbo"]);
+const isTestFile = (f) => /\.(test|spec|e2e)\.[cm]?[jt]sx?$/.test(f) || /(^|\/)__tests__\//.test(f);
+
+function walk(dir, acc) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (!IGNORE_DIR.has(e.name)) walk(full, acc);
+    } else if (SOURCE_EXT.has(path.extname(e.name)) && !isTestFile(e.name)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/** Parse `KEY=...` / `KEY =` declarations out of a .env.example file. */
+function parseEnvExample(absPath) {
+  const vars = new Set();
+  const text = fs.readFileSync(absPath, "utf8");
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^(?:export\s+)?([A-Z][A-Z0-9_]*)\s*=/);
+    if (m) vars.add(m[1]);
+  }
+  return vars;
+}
+
+const USE_PATTERNS = [
+  /process\.env\.([A-Z][A-Z0-9_]*)/g,
+  /process\.env\[\s*["'`]([A-Z][A-Z0-9_]*)["'`]\s*\]/g,
+  /import\.meta\.env\.([A-Z][A-Z0-9_]*)/g,
+  /\b(?:getEnv|requireEnv|optionalEnv|envString|envBool|envNumber)\(\s*["'`]([A-Z][A-Z0-9_]*)["'`]/g,
+];
+
+/** Env vars a set of files reads directly (Direction B evidence). */
+function collectUsedVars(files) {
+  const used = new Set();
+  for (const file of files) {
+    const text = fs.readFileSync(file, "utf8");
+    for (const re of USE_PATTERNS) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(text)) !== null) used.add(m[1]);
+    }
+  }
+  return used;
+}
+
+/** Whether `varName` appears as a bare token anywhere in the given text blobs. */
+function mentionedAnywhere(varName, blobs) {
+  const re = new RegExp(`\\b${varName}\\b`);
+  return blobs.some((b) => re.test(b));
+}
+
+function main() {
+  let hadDrift = false;
+
+  for (const app of APPS) {
+    const envPath = path.join(REPO_ROOT, app.envExample);
+    if (!fs.existsSync(envPath)) {
+      console.error(`✗ ${app.name}: missing ${app.envExample}`);
+      hadDrift = true;
+      continue;
+    }
+
+    const declared = parseEnvExample(envPath);
+
+    const files = [];
+    for (const d of app.sourceDirs) walk(path.join(REPO_ROOT, d), files);
+    for (const f of app.extraFiles) {
+      const abs = path.join(REPO_ROOT, f);
+      if (fs.existsSync(abs)) files.push(abs);
+    }
+    const blobs = files.map((f) => fs.readFileSync(f, "utf8"));
+    const usedDirectly = collectUsedVars(files);
+
+    const problems = [];
+
+    // Direction A: declared but never mentioned in code.
+    for (const v of declared) {
+      if (ALLOWLIST.has(v)) continue;
+      if (!mentionedAnywhere(v, blobs)) {
+        problems.push(`  documented but unused:   ${v}  (in ${app.envExample}, not referenced in code)`);
+      }
+    }
+
+    // Direction B: read by code but not documented.
+    for (const v of usedDirectly) {
+      if (ALLOWLIST.has(v)) continue;
+      if (!declared.has(v)) {
+        problems.push(`  used but undocumented:   ${v}  (read in code, missing from ${app.envExample})`);
+      }
+    }
+
+    if (problems.length) {
+      hadDrift = true;
+      console.error(`✗ ${app.name}`);
+      for (const p of problems) console.error(p);
+    } else {
+      console.log(`✓ ${app.name}  (${declared.size} vars, in sync)`);
+    }
+  }
+
+  if (hadDrift) {
+    console.error(
+      "\nEnv drift detected. Update the app's .env.example AND " +
+        "docs/deployment/environment.md so they match the code, " +
+        "or add a genuinely platform-injected var to ALLOWLIST in this script.",
+    );
+    process.exit(1);
+  }
+  console.log("\nAll .env.example files are in sync with code.");
+}
+
+main();

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,12 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# server/ — marketplace backend (port 5000)
+#
+# Authoritative reference + required/optional status for every variable:
+#   docs/deployment/environment.md
+# Validated on boot by the Zod schema in src/config/index.ts.
+# `scripts/check-env-drift.js` (CI) fails if this file and the code disagree.
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Server Configuration [REQUIRED]
 PORT=5000
 NODE_ENV=development
@@ -13,11 +22,9 @@ SUPABASE_SERVICE_ROLE_KEY="YOUR_SUPABASE_SERVICE_ROLE_KEY"
 SUPABASE_PRODUCT_IMAGES_BUCKET="product-images"
 PRODUCT_IMAGE_PLACEHOLDER_URL="https://placehold.co/800x800/png?text=No+Image"
 
-# Auth/JWT config used for RLS wallet policies
-SUPABASE_JWT_SECRET="YOUR_SUPABASE_JWT_SECRET"
-
-# JWT signing secret (REQUIRED, must be at least 32 characters)
-# Generate with: openssl rand -base64 32
+# JWT signing secret (REQUIRED, must be at least 32 characters).
+# Generate with: openssl rand -base64 48
+# Rotation procedure: docs/deployment/environment.md#key-rotation
 JWT_SECRET="replace-with-a-random-32-byte-secret"
 
 # Redis Configuration [OPTIONAL]
@@ -27,16 +34,20 @@ REDIS_URL="redis://127.0.0.1:6379"
 RUN_WORKERS="false"
 RUN_CONTRACT_WATCHER="false"
 
-# Stellar Soroban Configuration [OPTIONAL]
+# Stellar Soroban Configuration
+# CONTRACT_ID / GOVERNANCE_CONTRACT_ID are REQUIRED when RUN_CONTRACT_WATCHER=true.
+# Values come from deployments/deployed-addresses.<network>.json.
 CONTRACT_ID=""
+GOVERNANCE_CONTRACT_ID=""
 RPC_URL="https://soroban-testnet.stellar.org"
 
 # Monitoring and Metrics [OPTIONAL]
+# METRICS_API_KEY: bearer token required to scrape /metrics (blank = open).
 METRICS_API_KEY=""
 
-# Logging Configuration [OPTIONAL]
-# Development uses debug logs, production uses warn level
-LOG_LEVEL="debug"
+# Error reporting [OPTIONAL] — blank disables Sentry entirely.
+SENTRY_DSN=""
+SENTRY_TRACES_SAMPLE_RATE="0.1"
 
 # WebSocket Configuration [OPTIONAL]
 WS_PATH="/ws"

--- a/server/README.md
+++ b/server/README.md
@@ -2,6 +2,8 @@
 
 The Express + TypeScript backend for Agrocylo-Global. It exposes a REST API, manages data via Prisma + PostgreSQL (Supabase), handles product image uploads, and watches a Stellar Soroban smart contract for on-chain escrow events.
 
+> **Environment variables:** the authoritative reference for every variable this app reads — plus the JWT/API-key rotation procedures — is [`docs/deployment/environment.md`](../docs/deployment/environment.md). `.env.example` is checked against code by `scripts/check-env-drift.js` in CI.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Centralized secrets / environment-variable management

Closes #750

Each of the four apps had its own hand-maintained `.env.example` with
independently-named, independently-documented variables — `JWT_SECRET` only in
one backend's example, `SUPABASE_JWT_SECRET` / `DATABASE_URL` / RPC endpoints /
contract IDs duplicated or diverging across files with no shared source of
truth, and no documented process for how production secrets reach a running
deployment. This adds one authoritative reference, an automated drift check, and
key-rotation runbooks — and reconciles every `.env.example` against what the code
actually reads.

### `docs/deployment/environment.md` (new) — the authoritative reference

- **Secrets backend decision:** platform-native env vars (Fly.io secrets for the
  servers, build env for the clients) + GitHub Actions environments for CD — per
  the issue's "no need to over-engineer with Vault" guidance.
- **Shared-variable section:** `DATABASE_URL`, `RPC_URL` /
  `NEXT_PUBLIC_SOROBAN_RPC_URL`, network passphrase, Supabase keys, and the JWT
  signing approach (each server signs its own HS256 secret; they are not
  shared) — one place, with the remaining `CONTRACT_ID` vs `ESCROW_CONTRACT_ID`
  naming difference called out as a documented follow-up.
- **Contract-ID table:** one canonical var name per contract, all sourced from
  `deployments/deployed-addresses.<network>.json`.
- **Per-app tables** for all four apps: required/default/purpose for every
  variable, cross-checked against each app's config module.
- **`flyctl secrets set` / GitHub Actions** instructions per deployment target.
- **Key rotation:** a staging-tested, step-by-step `JWT_SECRET` procedure
  (generate → optional dual-verify window → swap → verify → cleanup → rollback)
  for both API servers, plus a table for Supabase keys, `METRICS_API_KEY`,
  integrator/referral keys, and the Fly deploy token.

Linked from the root README and all four app READMEs.

### `scripts/check-env-drift.js` (new) — automated drift detection

Bidirectional, zero-dependency:

- **example → code:** fails if a var is declared in an `.env.example` but never
  referenced in that app's source (stale config).
- **code → example:** fails if a var is read via `process.env.X`,
  `import.meta.env.X`, `getEnv('X')`, or `requireEnv('X')` but missing from the
  `.env.example` (undocumented dependency).

Covers all four apps plus the unified `agro-production/.env.example`.
`ALLOWLIST` at the top of the script holds genuinely platform-injected vars
(`NODE_ENV`, `VERCEL_*`, test-only toggles).

### `.github/workflows/env-drift.yml` (new) — merge-blocking check

Standalone workflow (not a job in `ci.yml`) so it triggers on **any** app's
`src/**` or `.env.example` change — including `agro-production/server`, which
`ci.yml`'s path filter doesn't cover — without pulling the rest of CI along.
No `continue-on-error`: it is a real merge gate, and it passes on this branch.

### Reconciled every `.env.example` against actual code

Investigated each drift finding (config modules, dynamic var construction,
SQL/RLS usage) and fixed all of them:

| App | Removed (dead config) | Added (was undocumented) |
|---|---|---|
| `server` | `SUPABASE_JWT_SECRET` (never read — server connects with the service-role key, which bypasses RLS), `LOG_LEVEL` (derived from `NODE_ENV`) | `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `GOVERNANCE_CONTRACT_ID` |
| `client` | `NEXT_PUBLIC_TOKEN_CONTRACT_ID` + `_XLM` + `_STRK` (only `_USDC` and the `NATIVE` var are real) | `NEXT_PUBLIC_STELLAR_NETWORK`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_MAX_FEE_STROOPS`, `NEXT_PUBLIC_ESCROW/MARKET_CONTRACT_ID`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `NEXT_PUBLIC_ANALYTICS_ENABLED/ENDPOINT` |
| `agro-production/server` | — | `EVENT_POLL_INTERVAL_MS`, `CONFIRMATION_DEPTH`, `RUN_RECONCILIATION_SWEEP`, `RECONCILIATION_SWEEP_INTERVAL_MS`, `RATE_LIMIT_WRITE_MAX_REQUESTS`, `CORS_ORIGINS`, `REDIS_URL`, `SHUTDOWN_TIMEOUT_MS`, `METRICS_API_KEY`, `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE` |
| `agro-production/client` | `NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID` (unused in agro) | `NEXT_PUBLIC_FEE_PERCENTILE/MAX_INCLUSION_FEE/FEE_HEADROOM`, `NEXT_PUBLIC_TELEMETRY_ENABLED/URL`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN` |
| `agro-production` (unified) | `NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID` | `JWT_SECRET`, `REGISTRY_CONTRACT_ID`, `BASKET_CONTRACT_ID`, plus all the agro server/client additions above |